### PR TITLE
[move_bewteen_collections] Changes to enable 'move to collection' feature

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -18,10 +18,14 @@ class CollectionsController < ApplicationController
   include BlacklightAdvancedSearch::ParseBasicQ
   include BlacklightAdvancedSearch::Controller
   include Sufia::Noid # for normalize_identifier method
+  include Hydra::Collections::SelectsCollections
+  
   prepend_before_filter :normalize_identifier, :except => [:index, :create, :new]
   before_filter :filter_docs_with_read_access!, :except => [:show]
   before_filter :has_access?, :except => [:show]
   before_filter :initialize_fields_for_edit, only:[:edit, :new]
+  before_filter :find_collections, only: [:edit]
+  
   layout "sufia-one-column"
 
   def after_destroy (id)

--- a/app/views/collections/_destination_collection_list.html.erb
+++ b/app/views/collections/_destination_collection_list.html.erb
@@ -1,0 +1,16 @@
+<div>
+  <div class="collection-list-container">
+    <div class="vertical-offset">
+      <div class="collection-list-box">
+        <a href="#" onclick="modal_collection_list('close', event)"><div id="modalClose">&#10006;</div></a>       
+        <% if user_collections.blank? %>
+          <em> You do not have access to any existing collections. You may create a new collection.</em><br><br><br><br>
+          <%= button_for_create_collection %>
+        <% else %>
+          <%= render partial: "form_for_select_destination_collection", locals: {user_collections: @user_collections} %>
+        <% end %> <!-- else -->
+      </div><!-- collection-list-box -->
+    </div><!-- vertical-offest -->
+  </div><!-- collection-list-container -->
+</div>
+

--- a/app/views/collections/_sort_and_per_page.html.erb
+++ b/app/views/collections/_sort_and_per_page.html.erb
@@ -15,13 +15,17 @@ limitations under the License.
 %>
 <div class="batch-info">
   <div>
-    <%= render partial: 'collections/form_for_select_collection', locals: {user_collections: @user_collections}  %>
+    <%= render partial: 'collections/destination_collection_list', locals: {user_collections: @user_collections}  %>
   </div>
 
   <div class="batch-toggle">
      <% session[:batch_edit_state] = "on" %>
      <!--a href="#" class="btn btn-primary submits-batches-add" onclick="modal_collection_list('open', event)">Add to Another Collection</a-->
     <%= button_for_remove_selected_from_collection @collection %>
+    <div>
+       <%= submit_tag "Move to Another Collection", :class => 'btn btn-primary submits-batches submits-batches-add', :onclick=>"return modal_collection_list('open', event)" %>
+    </div>
+    
    </div>
    <div class="sort-toggle">
      <%-# kind of hacky way to get this to work on catalog and folder controllers.  May be able to simple do {:action=>"index"} but I'm not sure -%>


### PR DESCRIPTION
You might not actually want to merge this into scholarsphere, since the feature is actually aimed more for archivesphere, but either way, this shows what changes you need to make in order to enable the feature in scholarsphere/archivesphere.  Note: this relies on changes in hydra-collections reflected here: https://github.com/projecthydra/hydra-collections/pull/13/commits
