### PR TITLE
Capistrano3

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -20,6 +20,9 @@ require 'capistrano/rails' #rails (includes bundler, rails/assets and rails/migr
 require 'whenever/capistrano' #whenever 
 require 'capistrano/passenger' #passenger
 require 'capistrano-resque'  #resque
+require 'capistrano/git' #git
+require './lib/capistrano/submodule_strategy' #custom submodule strategy
+require 'capistrano/rbenv_install' #rbenv install plugin
 
 # Loads custom tasks from `lib/capistrano/tasks' if you have any defined.
 # tasks included: passenger, checksum

--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ group :development do
   gem 'capistrano-rbenv', '~> 2.0', require: false
   gem 'capistrano-passenger'
   gem 'capistrano-resque', '~> 0.2.1', require: false
+  gem 'capistrano-rbenv-install'
   gem 'passenger'
   gem 'unicorn-rails'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,6 +129,9 @@ GEM
     capistrano-rbenv (2.0.2)
       capistrano (~> 3.1)
       sshkit (~> 1.3)
+    capistrano-rbenv-install (1.0.0)
+      capistrano (>= 3.0)
+      capistrano-rbenv (>= 2.0)
     capistrano-resque (0.2.1)
       capistrano
       resque
@@ -648,6 +651,7 @@ DEPENDENCIES
   capistrano-passenger
   capistrano-rails (~> 1.1)
   capistrano-rbenv (~> 2.0)
+  capistrano-rbenv-install
   capistrano-resque (~> 0.2.1)
   capybara (~> 2.0)
   capybara-screenshot

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -37,6 +37,7 @@ set :whenever_identifier, -> {"#{fetch(:application)}_#{fetch(:stage)}"}
 
 # git for source control
 set :scm, :git
+set :git_strategy, Capistrano::Git::SubmoduleStrategy
 
 # Default value for :format is :pretty
 set :format, :pretty
@@ -142,14 +143,5 @@ namespace :deploy do
   end
  end
  after :symlink_shared, :remove_resque
-
- # Restart the application
- desc 'Restart application'
- task :restart do
-  on roles(:app), in: :sequence, wait: 5 do
-      execute :touch, release_path.join('tmp/restart.txt')
-  end
- end
- #after :publishing, :restart 
  after :restart, "passenger:warmup" 
 end

--- a/lib/capistrano/submodule_strategy.rb
+++ b/lib/capistrano/submodule_strategy.rb
@@ -1,0 +1,21 @@
+class Capistrano::Git < Capistrano::SCM
+  module SubmoduleStrategy
+    include DefaultStrategy
+
+    def test
+      test! " [ -d #{repo_path}/.git ] "
+    end
+ 
+    def clone
+      git :clone, '-b', fetch(:branch), '--recursive', repo_url, repo_path
+    end
+ 
+    def release
+      context.execute :rm, '-rf', release_path
+      git :clone, '--branch', fetch(:branch),
+        '--recursive',
+        '--no-hardlinks',
+        repo_path, release_path
+    end
+  end
+end


### PR DESCRIPTION
Branch adds the ability for final release to maintain itself as a git repository versus utilizing git archive to deploy the final release.

Also added 'rbenv_install' capistrano plugin which includes the ability to install rbenv, bundle, and ruby.
