### PR TITLE
Adds rake tasks to audit the Fedora 3 to Fedora 4 migration

### DIFF
--- a/app/models/migrate_audit.rb
+++ b/app/models/migrate_audit.rb
@@ -1,0 +1,35 @@
+class MigrateAudit < ActiveRecord::Base
+
+  # This method populates the migrate_audit table with data 
+  # from the Fedora 3 repo.
+  def self.f3_audit!(auditor)
+    raise ArgumentError, "Auditor must respond to audit method" unless auditor.respond_to? :audit
+    clear_audit_data!
+    auditor.audit do |f3_obj|
+      create(f3_pid: f3_obj.pid, f3_model: f3_obj.has_model, f3_title: f3_obj.title)
+    end
+  end
+
+  # This method makes sure each record in the migrate_audit table is
+  # in the Fedora 4 repo and it has the same model as its Fedora 3
+  # counterpart.
+  def self.f4_audit(auditor)
+    raise ArgumentError, "Auditor must respond to audit method" unless auditor.respond_to? :audit
+    reset_audit_status
+    auditor.audit(all) do |result|
+      MigrateAudit.update(result.id, f4_id: result.f4_id, status: result.status)
+    end
+  end
+
+  private 
+
+  def self.clear_audit_data!
+    # destroy all existing audit records
+    all.each { |obj| obj.destroy! }
+  end
+
+  def self.reset_audit_status
+    MigrateAudit.update_all(f4_id: nil, status: nil)
+  end
+
+end

--- a/app/models/migrate_audit_fedora3.rb
+++ b/app/models/migrate_audit_fedora3.rb
@@ -1,0 +1,131 @@
+class MigrateAuditFedora3
+
+  Fedora3Object = Struct.new("Fedora3Object", :pid, :has_model, :title)
+
+  # The code in this class makes direct HTTP calls to Fedora 3 to 
+  # fetch data and does not depend on Rubydora or ActiveFedora.
+  def initialize(fedora_url, fedora_user, fedora_password, namespace)
+    @fedora_url = fedora_url
+    @fedora_user = fedora_user
+    @fedora_password = fedora_password
+    @namespace = namespace
+  end
+
+  def audit
+    raise "Must receive a block parameter" unless block_given?
+    pids.each do |pid|
+      f3_obj = get_info pid
+      yield f3_obj
+    end 
+  end
+
+  # Gets the list of all PIDs in the Fedora 3 repository. 
+  # Fedora returns the list of PIDS in an XML that looks more or
+  # less like this:
+  #
+  # <result>
+  #   <listSession>
+  #     <token>xxx</token>
+  #     ...
+  #   </listSession>
+  #   <resultList>
+  #     <objectFields>
+  #       <pid>scholarsphere:123xyz</pid>
+  #     <objectFields>
+  #     more objectFields
+  #   </resultList>
+  # <result>
+  def pids
+    batch_size = 50
+    all_pids = []
+    session_token = nil
+    while true
+      session = (session_token == nil) ? "" : "sessionToken=#{session_token}"
+      query_string = "query=&resultFormat=xml&maxResults=#{batch_size}&pid=true&#{session}"
+      fedora_response = fedora_get("/objects", query_string)
+      xml = Nokogiri::XML(fedora_response)
+      extract_pids(xml) do |pid| 
+        all_pids.push pid 
+      end
+      session_token = extract_session_token(xml)
+      break if session_token.nil?
+    end
+    all_pids  
+  end
+
+  # Gets basic information (model and title) about a Fedora 3 object.
+  # Fedora returns an XML that looks more ot less like this with the 
+  # information about a given object:
+  # 
+  # <foxml:digitalObject>
+  #   ...
+  #   <foxml:datastream ID="DC" ...>
+  #     <foxml:datastreamVersion ...>
+  #       <foxml:xmlContent>
+  #         <oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" ...>
+  #           <dc:title>the_title_of_the_generic_file</dc:title>
+  #         </oai_dc:dc>
+  #       </foxml:xmlContent>
+  #     </foxml:datastreamVersion>
+  #   </foxml:datastream>
+  #   ...
+  #   <foxml:datastream ID="RELS-EXT" ...>
+  #     <foxml:datastreamVersion ...>
+  #       <foxml:xmlContent>
+  #         <rdf:RDF xmlns:ns1="info:fedora/fedora-system:def/model#" ...>
+  #           <rdf:Description rdf:about="info:fedora/scholarsphere:hh63sv96j">
+  #             <ns1:hasModel rdf:resource="info:fedora/afmodel:GenericFile"/>
+  #           </rdf:Description>
+  #         </rdf:RDF>
+  #       </foxml:xmlContent>
+  #     </foxml:datastreamVersion>
+  #   </foxml:datastream>
+  #   ...
+  def get_info(pid)
+    fedora_response = fedora_get("/objects/#{pid}/objectXML")
+    xml = Nokogiri::XML(fedora_response)
+    title = extract_title(xml)
+    has_model = extract_model(xml)
+    Fedora3Object.new(pid, has_model, title)
+  end  
+
+
+  private
+
+  def fedora_get(url_path, url_querystring = "")
+    uri = URI.parse(@fedora_url + url_path + "?" + url_querystring)
+    response = Net::HTTP.start(uri.hostname, uri.port) do |http|
+      request = Net::HTTP::Get.new(uri.path + "?" + url_querystring)
+      request.basic_auth(@fedora_user, @fedora_password)
+      http.request(request)
+    end
+    response.body
+  end
+
+  def extract_pids(xml)
+    docs = xml.xpath("//doc:pid", doc: "http://www.fedora.info/definitions/1/0/types/").children
+    docs.each do |doc|
+      yield doc.text if doc.to_s.start_with?(@namespace + ":")
+    end
+  end
+
+  # Get the session token. This is what allows us to fetch the next batch 
+  # of PIDs in the next execution of the query.
+  def extract_session_token(xml)
+    header = xml.xpath("//header:token", header: "http://www.fedora.info/definitions/1/0/types/").children
+    return header[0].text if header.length == 1
+  end
+
+  # Extract the title from the DC data stream
+  def extract_title(xml)
+    titles = xml.xpath("//dc:title", dc: "http://purl.org/dc/elements/1.1/").first
+    return titles.children[0].text if titles && titles.children.count > 0
+  end
+
+  # Extract the "has_model" (GenericFile, Batch, Collection) from the RELS-EXT data stream
+  def extract_model(xml)
+    models = xml.xpath("//ns1:hasModel", ns1: "info:fedora/fedora-system:def/model#" ).first
+    return models.attributes["resource"].value if models && models.attributes.key?("resource")
+  end
+
+end

--- a/app/models/migrate_audit_fedora4.rb
+++ b/app/models/migrate_audit_fedora4.rb
@@ -1,0 +1,92 @@
+class MigrateAuditFedora4
+
+  AuditResult = Struct.new("AuditResult", :id, :f3_pid, :f4_id, :status)
+
+  def initialize(fedora_url, fedora_user, fedora_password)
+    @fedora_url = fedora_url
+    @fedora_user = fedora_user
+    @fedora_password = fedora_password
+  end
+
+  def audit(f3_objects)
+    f3_objects.each do |f3_obj|
+      f4_url = @fedora_url + "/" + pid_to_uri(f3_obj.f3_pid)
+      result = AuditResult.new(f3_obj.id, f3_obj.f3_pid, f4_url, nil)
+      result.status = audit_one(f3_obj, f4_url)
+      yield result
+    end
+  end
+
+  private
+
+  def audit_one(f3_obj, f4_url)
+    f4_obj = fedora_get_metadata f4_url
+    return "Not found" if f4_obj.nil?
+    f4_model = model_from_resource f4_obj
+    f3_model = normalized_f3_model f3_obj.f3_model
+    return "Models mismatch. Expected: #{f3_model} but found: #{f4_model}" if f3_model != f4_model 
+    "OK"
+  end
+
+  # f3 models are stored like this: "info:fedora/afmodel:Batch"
+  # and we only care about the last part ("Batch" in this case)
+  def normalized_f3_model(f3_model)
+    f3_model.split(':').last
+  end
+
+  def pid_to_uri(pid)
+    id = pid.split(':').last
+    raise "Cannot detect ID from PID #{pid}" unless id.length >= 9
+    id[0..1] + "/" + id[2..3] + "/" + id[4..5] + "/" + id[6..7] + "/" + id
+  end
+
+  def model_from_resource(triples)
+    object = parse_triples triples 
+    object[:model]
+  end
+
+  # Response is an RDF graph in n-triple format and we expect it to have the 
+  # model of the object (e.g. GenericFile, Batch) as well a list of its children.
+  # 
+  # The model comes in the form:
+  #     <URI> <info:fedora/fedora-system:def/model#hasModel> "GenericFile"^^<http://www.w3.org/2001/XMLSchema#string> .
+  #
+  # Children come in the form:
+  #     <URI> <http://www.w3.org/ns/ldp#contains> <CHILD-URI-1> .
+  #     <URI> <http://www.w3.org/ns/ldp#contains> <CHILD-URI-2> .
+  #
+  def parse_triples response
+    model = nil
+    children = []
+    response.split("\n").each do |line|
+      tokens = line.split(" ")
+      predicate = tokens[1]
+      object = tokens[2]
+      if predicate == "<info:fedora/fedora-system:def/model#hasModel>"
+        # get the model of the object
+        has_model = tokens[2]
+        caret = object.index("^^")
+        if caret
+          model = has_model[0,caret].gsub('"', '')
+        end
+      elsif predicate == "<http://www.w3.org/ns/ldp#contains>"
+        # get the list of children of the object
+        child_url = tokens[2].gsub("<", "").gsub(">", "")
+        children.push child_url
+      end
+    end
+    {model: model, children: children}
+  end
+
+  def fedora_get_metadata(url)
+    headers = { "Accept" => "application/n-triples" }
+    uri = URI.parse(url  + "/fcr:metadata")
+    response = Net::HTTP.start(uri.hostname, uri.port) do |http|
+      request = Net::HTTP::Get.new(uri.path, headers)
+      request.basic_auth(@fedora_user, @fedora_password)
+      http.request(request)
+    end
+    return nil if response.code == "404"
+    response.body
+  end
+end

--- a/db/migrate/20150205141342_create_migrate_audits.rb
+++ b/db/migrate/20150205141342_create_migrate_audits.rb
@@ -1,0 +1,12 @@
+class CreateMigrateAudits < ActiveRecord::Migration
+  def change
+    create_table :migrate_audits do |t|
+      t.string :f3_pid
+      t.string :f3_model
+      t.string :f3_title
+      t.string :f4_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20150220191721_add_status_to_migrate_audits.rb
+++ b/db/migrate/20150220191721_add_status_to_migrate_audits.rb
@@ -1,0 +1,5 @@
+class AddStatusToMigrateAudits < ActiveRecord::Migration
+  def change
+    add_column :migrate_audits, :status, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,14 +11,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141205164302) do
+ActiveRecord::Schema.define(version: 20150220191721) do
 
   create_table "bookmarks", force: true do |t|
     t.integer  "user_id",     null: false
     t.string   "document_id"
     t.string   "title"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.string   "user_type"
   end
 
@@ -29,11 +29,11 @@ ActiveRecord::Schema.define(version: 20141205164302) do
     t.integer  "pass"
     t.string   "expected_result"
     t.string   "actual_result"
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
-  add_index "checksum_audit_logs", ["pid", "dsid"], name: "by_pid_and_dsid"
+  add_index "checksum_audit_logs", ["pid", "dsid"], name: "by_pid_and_dsid", using: :btree
 
   create_table "content_blocks", force: true do |t|
     t.string   "name"
@@ -48,16 +48,16 @@ ActiveRecord::Schema.define(version: 20141205164302) do
     t.string "term"
   end
 
-  add_index "domain_terms", ["model", "term"], name: "terms_by_model_and_term"
+  add_index "domain_terms", ["model", "term"], name: "terms_by_model_and_term", using: :btree
 
   create_table "domain_terms_local_authorities", id: false, force: true do |t|
     t.integer "domain_term_id"
     t.integer "local_authority_id"
   end
 
-  add_index "domain_terms_local_authorities", ["domain_term_id", "local_authority_id"], name: "domain_terms_by_domain_term_id_and_local_authority", unique: true
-  add_index "domain_terms_local_authorities", ["domain_term_id", "local_authority_id"], name: "dtla_by_ids2"
-  add_index "domain_terms_local_authorities", ["local_authority_id", "domain_term_id"], name: "dtla_by_ids1"
+  add_index "domain_terms_local_authorities", ["domain_term_id", "local_authority_id"], name: "domain_terms_by_domain_term_id_and_local_authority", unique: true, using: :btree
+  add_index "domain_terms_local_authorities", ["domain_term_id", "local_authority_id"], name: "dtla_by_ids2", using: :btree
+  add_index "domain_terms_local_authorities", ["local_authority_id", "domain_term_id"], name: "dtla_by_ids1", using: :btree
 
   create_table "featured_works", force: true do |t|
     t.integer  "order",           default: 5
@@ -66,8 +66,8 @@ ActiveRecord::Schema.define(version: 20141205164302) do
     t.datetime "updated_at"
   end
 
-  add_index "featured_works", ["generic_file_id"], name: "index_featured_works_on_generic_file_id"
-  add_index "featured_works", ["order"], name: "index_featured_works_on_order"
+  add_index "featured_works", ["generic_file_id"], name: "index_featured_works_on_generic_file_id", using: :btree
+  add_index "featured_works", ["order"], name: "index_featured_works_on_order", using: :btree
 
   create_table "file_download_stats", force: true do |t|
     t.datetime "date"
@@ -78,8 +78,8 @@ ActiveRecord::Schema.define(version: 20141205164302) do
     t.integer  "user_id"
   end
 
-  add_index "file_download_stats", ["file_id"], name: "index_file_download_stats_on_file_id"
-  add_index "file_download_stats", ["user_id"], name: "index_file_download_stats_on_user_id"
+  add_index "file_download_stats", ["file_id"], name: "index_file_download_stats_on_file_id", using: :btree
+  add_index "file_download_stats", ["user_id"], name: "index_file_download_stats_on_user_id", using: :btree
 
   create_table "file_view_stats", force: true do |t|
     t.datetime "date"
@@ -90,8 +90,8 @@ ActiveRecord::Schema.define(version: 20141205164302) do
     t.integer  "user_id"
   end
 
-  add_index "file_view_stats", ["file_id"], name: "index_file_view_stats_on_file_id"
-  add_index "file_view_stats", ["user_id"], name: "index_file_view_stats_on_user_id"
+  add_index "file_view_stats", ["file_id"], name: "index_file_view_stats_on_file_id", using: :btree
+  add_index "file_view_stats", ["user_id"], name: "index_file_view_stats_on_user_id", using: :btree
 
   create_table "follows", force: true do |t|
     t.integer  "followable_id",                   null: false
@@ -99,12 +99,12 @@ ActiveRecord::Schema.define(version: 20141205164302) do
     t.integer  "follower_id",                     null: false
     t.string   "follower_type",                   null: false
     t.boolean  "blocked",         default: false, null: false
-    t.datetime "created_at",                      null: false
-    t.datetime "updated_at",                      null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
-  add_index "follows", ["followable_id", "followable_type"], name: "fk_followables"
-  add_index "follows", ["follower_id", "follower_type"], name: "fk_follows"
+  add_index "follows", ["followable_id", "followable_type"], name: "fk_followables", using: :btree
+  add_index "follows", ["follower_id", "follower_type"], name: "fk_follows", using: :btree
 
   create_table "local_authorities", force: true do |t|
     t.string "name"
@@ -116,14 +116,16 @@ ActiveRecord::Schema.define(version: 20141205164302) do
     t.string  "uri"
   end
 
-  add_index "local_authority_entries", ["local_authority_id", "label"], name: "entries_by_term_and_label"
-  add_index "local_authority_entries", ["local_authority_id", "uri"], name: "entries_by_term_and_uri"
+  add_index "local_authority_entries", ["local_authority_id", "label"], name: "entries_by_term_and_label", using: :btree
+  add_index "local_authority_entries", ["local_authority_id", "uri"], name: "entries_by_term_and_uri", using: :btree
 
   create_table "mailboxer_conversation_opt_outs", force: true do |t|
     t.integer "unsubscriber_id"
     t.string  "unsubscriber_type"
     t.integer "conversation_id"
   end
+
+  add_index "mailboxer_conversation_opt_outs", ["conversation_id"], name: "mb_opt_outs_on_conversations_id", using: :btree
 
   create_table "mailboxer_conversations", force: true do |t|
     t.string   "subject",    default: ""
@@ -147,7 +149,7 @@ ActiveRecord::Schema.define(version: 20141205164302) do
     t.string   "attachment"
   end
 
-  add_index "mailboxer_notifications", ["conversation_id"], name: "index_mailboxer_notifications_on_conversation_id"
+  add_index "mailboxer_notifications", ["conversation_id"], name: "index_mailboxer_notifications_on_conversation_id", using: :btree
 
   create_table "mailboxer_receipts", force: true do |t|
     t.integer  "receiver_id"
@@ -161,7 +163,17 @@ ActiveRecord::Schema.define(version: 20141205164302) do
     t.datetime "updated_at",                                 null: false
   end
 
-  add_index "mailboxer_receipts", ["notification_id"], name: "index_mailboxer_receipts_on_notification_id"
+  add_index "mailboxer_receipts", ["notification_id"], name: "index_mailboxer_receipts_on_notification_id", using: :btree
+
+  create_table "migrate_audits", force: true do |t|
+    t.string   "f3_pid"
+    t.string   "f3_model"
+    t.string   "f3_title"
+    t.string   "f4_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string   "status"
+  end
 
   create_table "proxy_deposit_requests", force: true do |t|
     t.string   "pid",                                   null: false
@@ -171,51 +183,51 @@ ActiveRecord::Schema.define(version: 20141205164302) do
     t.string   "status",            default: "pending", null: false
     t.text     "sender_comment"
     t.text     "receiver_comment"
-    t.datetime "created_at",                            null: false
-    t.datetime "updated_at",                            null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
-  add_index "proxy_deposit_requests", ["receiving_user_id"], name: "index_proxy_deposit_requests_on_receiving_user_id"
-  add_index "proxy_deposit_requests", ["sending_user_id"], name: "index_proxy_deposit_requests_on_sending_user_id"
+  add_index "proxy_deposit_requests", ["receiving_user_id"], name: "index_proxy_deposit_requests_on_receiving_user_id", using: :btree
+  add_index "proxy_deposit_requests", ["sending_user_id"], name: "index_proxy_deposit_requests_on_sending_user_id", using: :btree
 
   create_table "proxy_deposit_rights", force: true do |t|
     t.integer  "grantor_id"
     t.integer  "grantee_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
-  add_index "proxy_deposit_rights", ["grantee_id"], name: "index_proxy_deposit_rights_on_grantee_id"
-  add_index "proxy_deposit_rights", ["grantor_id"], name: "index_proxy_deposit_rights_on_grantor_id"
+  add_index "proxy_deposit_rights", ["grantee_id"], name: "index_proxy_deposit_rights_on_grantee_id", using: :btree
+  add_index "proxy_deposit_rights", ["grantor_id"], name: "index_proxy_deposit_rights_on_grantor_id", using: :btree
 
   create_table "searches", force: true do |t|
     t.text     "query_params"
     t.integer  "user_id"
-    t.datetime "created_at",   null: false
-    t.datetime "updated_at",   null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.string   "user_type"
   end
 
-  add_index "searches", ["user_id"], name: "index_searches_on_user_id"
+  add_index "searches", ["user_id"], name: "index_searches_on_user_id", using: :btree
 
   create_table "single_use_links", force: true do |t|
     t.string   "downloadKey"
     t.string   "path"
     t.string   "itemId"
     t.datetime "expires"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   create_table "subject_local_authority_entries", force: true do |t|
     t.string   "label"
     t.string   "lowerLabel"
     t.string   "uri"
-    t.datetime "created_at", default: '2014-05-08 20:35:50', null: false
-    t.datetime "updated_at", default: '2014-05-08 20:35:50', null: false
+    t.datetime "created_at", default: '2014-08-20 15:18:33'
+    t.datetime "updated_at", default: '2014-08-20 15:18:33'
   end
 
-  add_index "subject_local_authority_entries", ["lowerLabel"], name: "entries_by_lower_label"
+  add_index "subject_local_authority_entries", ["lowerLabel"], name: "entries_by_lower_label", using: :btree
 
   create_table "superusers", force: true do |t|
     t.integer "user_id", null: false
@@ -230,8 +242,8 @@ ActiveRecord::Schema.define(version: 20141205164302) do
   create_table "trophies", force: true do |t|
     t.integer  "user_id"
     t.string   "generic_file_id"
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   create_table "user_stats", force: true do |t|
@@ -243,22 +255,22 @@ ActiveRecord::Schema.define(version: 20141205164302) do
     t.datetime "updated_at"
   end
 
-  add_index "user_stats", ["user_id"], name: "index_user_stats_on_user_id"
+  add_index "user_stats", ["user_id"], name: "index_user_stats_on_user_id", using: :btree
 
   create_table "users", force: true do |t|
-    t.string   "email",                              default: ""
-    t.string   "encrypted_password",                 default: ""
+    t.string   "email",                  default: ""
+    t.string   "encrypted_password",     default: ""
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",                      default: 0
+    t.integer  "sign_in_count",          default: 0
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.string   "current_sign_in_ip"
     t.string   "last_sign_in_ip"
-    t.datetime "created_at",                                         null: false
-    t.datetime "updated_at",                                         null: false
-    t.string   "login",                              default: "",    null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string   "login",                  default: "",    null: false
     t.string   "display_name"
     t.string   "address"
     t.string   "admin_area"
@@ -273,7 +285,7 @@ ActiveRecord::Schema.define(version: 20141205164302) do
     t.string   "avatar_content_type"
     t.integer  "avatar_file_size"
     t.datetime "avatar_updated_at"
-    t.text     "group_list",             limit: 255
+    t.text     "group_list"
     t.datetime "groups_last_update"
     t.boolean  "ldap_available"
     t.datetime "ldap_last_update"
@@ -282,21 +294,27 @@ ActiveRecord::Schema.define(version: 20141205164302) do
     t.string   "googleplus_handle"
     t.string   "linkedin_handle"
     t.string   "orcid"
-    t.boolean  "system_created",                     default: false
-    t.boolean  "logged_in",                          default: true
+    t.boolean  "system_created",         default: false
+    t.boolean  "logged_in",              default: true
   end
 
-  add_index "users", ["login"], name: "index_users_on_login", unique: true
-  add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  add_index "users", ["login"], name: "index_users_on_login", unique: true, using: :btree
+  add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 
   create_table "version_committers", force: true do |t|
     t.string   "obj_id"
     t.string   "datastream_id"
     t.string   "version_id"
     t.string   "committer_login"
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   Foreigner.load
+  add_foreign_key "mailboxer_conversation_opt_outs", "mailboxer_conversations", name: "mb_opt_outs_on_conversations_id", column: "conversation_id"
+
+  add_foreign_key "mailboxer_notifications", "mailboxer_conversations", name: "notifications_on_conversation_id_development", column: "conversation_id"
+
+  add_foreign_key "mailboxer_receipts", "mailboxer_notifications", name: "mailboxer_receipts_on_notification_id_development", column: "notification_id"
+
 end

--- a/lib/tasks/aftermigrate.rake
+++ b/lib/tasks/aftermigrate.rake
@@ -1,0 +1,28 @@
+require 'action_view'
+require 'blacklight/solr_helper'
+require 'rainbow'
+
+include ActionView::Helpers::NumberHelper
+include Blacklight::SolrHelper
+
+namespace :aftermigrate do
+
+  def logger
+    Rails.logger
+  end
+
+  # Updates the records in migrate_audit SQL table with the information from 
+  # the matching Fedora 4 objects.
+  # This task must be run from a version of the code that targets Fedora 4
+  # (mostly because it expects to find the settings for a Fedora 4 repo
+  # in the ActiveFedora.fedora_config.credentials object.)
+  desc "Updates migrate_audit SQL table with information from Fedora 4 objects"
+  task f4_audit: :environment do |cmd, args|
+    credentials = ActiveFedora.fedora_config.credentials
+    fedora_url = credentials[:url] + credentials[:base_path]
+    auditor = MigrateAuditFedora4.new(fedora_url, credentials[:user], credentials[:password])
+    MigrateAudit.f4_audit(auditor)
+  end
+
+end
+

--- a/lib/tasks/premigrate.rake
+++ b/lib/tasks/premigrate.rake
@@ -5,7 +5,7 @@ require 'rainbow'
 include ActionView::Helpers::NumberHelper
 include Blacklight::SolrHelper
 
-namespace :pre_migrate do
+namespace :premigrate do
 
   ALL_ROWS = 1_000_000
 
@@ -73,6 +73,11 @@ namespace :pre_migrate do
     missing_batches
   end
 
+  def fedora3_settings(file_name)
+    fedora3_settings = YAML.load_file(file_name)
+    fedora3_settings[Rails.env].symbolize_keys
+  end
+
   desc "Get a list of missing batches"
   task "list_missing_batches", [:verbose] => :environment do |cmd, args|
     verbose = args[:verbose] == "true"
@@ -98,5 +103,47 @@ namespace :pre_migrate do
       end
     end
   end
+
+  # This task is mostly for testing purposes to make sure we get all PIDs from Fedora 3.
+  # To allow this task to be run from a version of the code that targets Fedora 3 
+  # or Fedora 4 we must pass the file where the Fedora 3 settings are stored.
+  desc "Fetches PIDs for all objects in Fedora 3 for our namespace"
+  task "get_pids", [:fedora3_yml] => :environment do |cmd, args|
+    file_name = args[:fedora3_yml]
+    abort("Must specify a Fedora 3 YAML file") if file_name.nil?
+    credentials = fedora3_settings(file_name)
+    namespace = "scholarsphere"
+    auditor = MigrateAuditFedora3.new(credentials[:url], credentials[:user], credentials[:password], namespace)
+    puts auditor.pids
+  end
+
+  # This task is mostly for testing purposes to make sure we get all objects and their data.
+  # To allow this task to be run from a version of the code that targets Fedora 3 
+  # or Fedora 4 we must pass the file where the Fedora 3 settings are stored.
+  desc "Fetched basic info (PID, model, title) for all objects in Fedora 3 in our namespace"
+  task "get_info", [:fedora3_yml] => :environment do |cmd, args|
+    file_name = args[:fedora3_yml]
+    abort("Must specify a Fedora 3 YAML file") if file_name.nil?
+    credentials = fedora3_settings(file_name)
+    namespace = "scholarsphere"
+    auditor = MigrateAuditFedora3.new(credentials[:url], credentials[:user], credentials[:password], namespace)
+    auditor.pids.each do |pid|
+      puts auditor.get_info(pid)
+    end
+  end  
+
+  # Recreates data in migrate_audit SQL table with information about all Fedora 3 objects.
+  # To allow this task to be run from a version of the code that targets Fedora 3 
+  # or Fedora 4 we must pass the file where the Fedora 3 settings are stored.
+  desc "Creates an audit for all Fedora 3 objects in our namespace"
+  task "f3_audit", [:fedora3_yml] => :environment do |cmd, args|
+    file_name = args[:fedora3_yml]
+    abort("Must specify a Fedora 3 YAML file") if file_name.nil?
+    credentials = fedora3_settings(file_name)
+    namespace = "scholarsphere"
+    logger.info "Auditing Fedora 3 at #{credentials[:url]}..."
+    auditor = MigrateAuditFedora3.new(credentials[:url], credentials[:user], credentials[:password], namespace)
+    MigrateAudit.f3_audit!(auditor)
+  end  
 end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -45,4 +45,23 @@ FactoryGirl.define do
     login 'testapp'
   end
 
+  # Fedora 3 to Fedora 4 Migration Audit
+  factory :f3_file_migrated, class: MigrateAudit do |x|
+    f3_pid 'scholarsphere:111xyzfile'
+    f3_model "info:fedora/afmodel:GenericFile"
+    f3_title "Some file in Fedora 3"
+  end
+
+  factory :f3_file_not_migrated, class: MigrateAudit do |x|
+    f3_pid 'scholarsphere:222xyzfile'
+    f3_model "info:fedora/afmodel:GenericFile"
+    f3_title "Some file in Fedora 3 that won't be migrated"
+  end
+
+  factory :f3_file_migrated_wrong, class: MigrateAudit do |x|
+    f3_pid 'scholarsphere:333xyzfile'
+    f3_model "info:fedora/afmodel:GenericFileFake"
+    f3_title "Some file in Fedora 3 that will be migrated with the wrong model"
+  end
+
 end

--- a/spec/models/migrate_audit_spec.rb
+++ b/spec/models/migrate_audit_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+describe MigrateAudit, :type => :model do
+  let(:credentials) { ActiveFedora.fedora_config.credentials }
+  let(:fedora_url) { credentials[:url] + credentials[:base_path] }
+
+  let(:f3_file_migrated) { FactoryGirl.create(:f3_file_migrated) }
+  let(:f3_file_not_migrated) { FactoryGirl.create(:f3_file_not_migrated) }
+  let(:f3_file_migrated_wrong) { FactoryGirl.create(:f3_file_migrated_wrong) }
+  let(:f3_data) { [f3_file_migrated, f3_file_not_migrated, f3_file_migrated_wrong] }
+
+  let(:auditor) { MigrateAuditFedora4.new(fedora_url, credentials[:user], credentials[:password]) }
+
+  let(:results) do 
+    results = []
+    auditor.audit(f3_data) do |result|
+      results.push result
+    end
+    results
+  end
+
+  before do 
+    GenericFile.create(id: "111xyzfile") { |file| file.apply_depositor_metadata('dmc') }
+    GenericFile.create(id: "333xyzfile") { |file| file.apply_depositor_metadata('dmc') }
+  end
+
+  context "with a file migrated correctly" do 
+    subject { results.select {|r| r.f3_pid == f3_file_migrated.f3_pid}.first }
+    it "returns OK" do
+      expect(subject.status).to eq("OK")
+    end
+    it "has a valid Fedora 4 URI" do 
+      expect(subject.f4_id).to eq("#{fedora_url}/11/1x/yz/fi/111xyzfile")
+    end
+  end
+
+  context "with a file not migrated" do 
+    subject { results.select {|r| r.f3_pid == f3_file_not_migrated.f3_pid}.first }
+    it "reports not found" do
+      expect(subject.status).to eq("Not found")
+    end
+  end
+
+  context "with a file migrated incorrectly" do 
+    subject { results.select {|r| r.f3_pid == f3_file_migrated_wrong.f3_pid}.first }
+    it "reports models mismatch" do
+      expect(subject.status).to eq("Models mismatch. Expected: GenericFileFake but found: GenericFile")
+    end
+  end
+end


### PR DESCRIPTION
This pull request adds a few rake tasks to audit the migration of objects from Fedora 3 to Fedora 4. The idea is that these tasks will be run after deploying the Fedora 4 code base to production and immediately after the migration of data has been performed.

The code to perform the audit issues straight HTTP requests to Fedora 3 and Fedora 4 and bypasses Rubydora and ActiveFedora to make sure we query the Fedora repo as close to the metal as possible. 

The following Wiki page provides some information on how these rake tasks will be run in production: https://github.com/psu-stewardship/scholarsphere/wiki/Fedora-3-to-Fedora-4-Migration 
