### PR TITLE
Collection size is not zero bytes, ref #9753

### DIFF
--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -1,8 +1,31 @@
 require 'spec_helper'
 
 describe Collection do
+  
   describe "#bytes" do
-    subject { described_class.new.bytes }
-    it { is_expected.to eq 0 }
+    context "with no attached files" do
+      subject { described_class.new.bytes }
+      it { is_expected.to eq 0 }
+    end
+
+    context "with attached files" do
+      let(:file) do
+        GenericFile.create(title: ['Some title']) { |f| f.apply_depositor_metadata("agw") }
+      end
+      let(:file2) do
+        GenericFile.create(title: ['Some other title']) { |f| f.apply_depositor_metadata("agw") }
+      end
+      let(:collection) do
+        Collection.create(title: "My collection") { |c| c.apply_depositor_metadata("agw") }
+      end
+      let(:mock_file) { double("content", size: "100")}
+      before do
+        collection.members = [file, file2]
+        allow_any_instance_of(GenericFile).to receive(:content).and_return(mock_file)
+      end
+      subject { collection.bytes }
+      it { is_expected.to eq 200 }
+    end
+  
   end
 end


### PR DESCRIPTION
This was fixed in Sufia, but I avoided putting the follow-up test as a feature, since that would require uploading files and would slow down the test suite. Instead, the size property on the file is mocked in a unit environment, similarly to the way it is in the Sufia test.
