### PR TITLE
Make sure we don't create a batch with the same ID 

### DIFF
--- a/lib/tasks/premigrate.rake
+++ b/lib/tasks/premigrate.rake
@@ -61,7 +61,13 @@ namespace :pre_migrate do
     missing_batches = []
     batches_in_files.each do |id|
       unless all_batches.include? id
-        missing_batches.push(id)
+        if ActiveFedora::Base.exists?(pid: id)
+          # An object with this PID already exists 
+          # (it might exist as something other than a Batch)
+          logger.error "Skipping #{id} because it already exists!"
+        else
+          missing_batches.push(id)
+        end
       end
     end
     if verbose


### PR DESCRIPTION
...as an another existing object (e.g. we don't overwrite a GenericFile)
