### PR TITLE
Adding rack-maintenance to allow for a maintenance page to be served eas...

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ gem 'therubyracer'
 gem 'uglifier'
 gem 'whenever'
 gem 'yaml_db'
+gem 'rack-maintenance'
 
 group :development, :test do
   gem 'jettywrapper'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -402,6 +402,8 @@ GEM
       multi_json (~> 1.0)
       websocket-driver (>= 0.2.0)
     rack (1.5.2)
+    rack-maintenance (2.0.0)
+      rack (>= 1.0)
     rack-protection (1.5.3)
       rack
     rack-test (0.6.3)
@@ -728,6 +730,7 @@ DEPENDENCIES
   newrelic_rpm
   passenger
   poltergeist
+  rack-maintenance
   rails (= 4.1.9)
   rainbow
   resque-pool

--- a/config/application.rb
+++ b/config/application.rb
@@ -118,6 +118,10 @@ module ScholarSphere
     config.landing_from_email = 'PATRICIA M HSWE <pmh22@psu.edu>'
 
     config.max_upload_file_size = 20*1024*1024*1024 #20GB
+
+    # html maintenance response
+    config.middleware.use 'Rack::Maintenance',
+                          :file => Rails.root.join('public', 'maintenance.html')
   end
 end
 


### PR DESCRIPTION
...ily before the app gets hit

I'm wondering if we could use this to put up a maintenance page while we are upgrading the server.

The only down side I see is that we would not be able to testing without removing the maintenance page, but we would have to turn on the web apps test anyway
