### PR TITLE
Allow only editable collections in the collection list. fixes #109

### DIFF
--- a/app/controllers/my_controller.rb
+++ b/app/controllers/my_controller.rb
@@ -1,0 +1,6 @@
+class MyController < ApplicationController
+  include Sufia::MyControllerBehavior
+  skip_before_filter :find_collections, only: :index
+  before_filter :find_collections_with_edit_access, only: :index
+
+end

--- a/spec/features/dashboard/dashboard_files_spec.rb
+++ b/spec/features/dashboard/dashboard_files_spec.rb
@@ -7,6 +7,14 @@ describe 'Dashboard Files', :type => :feature do
 
   let!(:file) { create_file current_user, { title: 'little_file.txt', creator: 'little_file.txt_creator', resource_type: "stuff" } }
 
+  let(:jill) { create :jill }
+  let!(:other_collection) do
+    Collection.create(title: 'jill collection') do |col|
+    col.apply_depositor_metadata(jill.user_key)
+    col.read_groups= ['public']
+  end
+end
+
   before do
     sign_in_as current_user
     go_to_dashboard_files
@@ -213,6 +221,17 @@ describe 'Dashboard Files', :type => :feature do
         click_button("Refresh")
         expect(page).to have_content(file.title.first)
       end
+    end
+
+    context "with collection of other users" do
+
+      it "does not show other user's collection" do
+        first('input.batch_document_selector').click
+        click_button 'Add to Collection'
+        expect(page).to have_css('#collection-list-container')
+        expect(page).not_to have_content(other_collection.title)
+      end
+
     end
 
   end


### PR DESCRIPTION
Overriding to find only collections with edit access.  Sufia currently finds any collections (read, or edit access).

Doing this here for the moment to facilitate the release.  Need to have a community discussion to see if this is need/wanted in sufia.  I can not see why a a user might select a collection they do not have edit access to, but there may be a change in sufia I am unaware of.
