### PR TITLE
Setting edit access for shares so we only see files the user has edit ac...

### DIFF
--- a/app/controllers/my/shares_controller.rb
+++ b/app/controllers/my/shares_controller.rb
@@ -1,0 +1,22 @@
+module My
+  class SharesController < MyController
+
+    self.search_params_logic = [
+      :show_only_shared_files,
+      :show_only_generic_files
+    ] + self.search_params_logic
+
+
+    def index
+      super
+      @selected_tab = :shared
+    end
+
+    protected
+
+    def search_action_url *args
+      sufia.dashboard_shares_url *args
+    end
+
+  end
+end

--- a/app/search_builders/sufia/search_builder.rb
+++ b/app/search_builders/sufia/search_builder.rb
@@ -1,0 +1,53 @@
+module Sufia::SearchBuilder
+
+  include BlacklightAdvancedSearch::AdvancedSearchBuilder
+  include Hydra::Collections::SearchBehaviors
+  include Hydra::Controller::SearchBuilder
+
+  def show_only_collections(solr_parameters)
+    solr_parameters[:fq] ||= []
+    solr_parameters[:fq] += [
+      ActiveFedora::SolrQueryBuilder.construct_query_for_rel(has_model: Collection.to_class_uri)
+    ]
+  end
+
+  def show_only_files_deposited_by_current_user(solr_parameters)
+    solr_parameters[:fq] ||= []
+    solr_parameters[:fq] += [
+      ActiveFedora::SolrQueryBuilder.construct_query_for_rel(depositor: scope.current_user.user_key)
+    ]
+  end
+
+  def show_only_generic_files(solr_parameters)
+    solr_parameters[:fq] ||= []
+    solr_parameters[:fq] += [
+      ActiveFedora::SolrQueryBuilder.construct_query_for_rel(has_model: ::GenericFile.to_class_uri)
+    ]
+  end
+
+  def show_only_shared_files(solr_parameters)
+    # show only files I have edit access to
+    self.discovery_perms = [:edit]
+    solr_parameters[:fq] ||= []
+    solr_parameters[:fq] += [
+      "-" + ActiveFedora::SolrQueryBuilder.construct_query_for_rel(depositor: scope.current_user.user_key)
+    ]
+  end
+
+  def show_only_highlighted_files(solr_parameters)
+    ids = scope.current_user.trophies.pluck(:generic_file_id)
+    solr_parameters[:fq] ||= []
+    solr_parameters[:fq] += [
+      ActiveFedora::SolrQueryBuilder.construct_query_for_ids(ids)
+    ]
+  end
+
+  # Limits search results just to GenericFiles and collections
+  # @param solr_parameters the current solr parameters
+  # @param user_parameters the current user-subitted parameters
+  def only_generic_files_and_collections(solr_parameters)
+    solr_parameters[:fq] ||= []
+    solr_parameters[:fq] << "#{Solrizer.solr_name("has_model", :symbol)}:(\"GenericFile\" \"Collection\")"
+  end
+
+end

--- a/spec/features/dashboard/dashboard_shares_spec.rb
+++ b/spec/features/dashboard/dashboard_shares_spec.rb
@@ -28,10 +28,31 @@ describe 'Dashboard Shares', :type => :feature do
         c.save!
       end
     }
+    let!(:gf) do
+      GenericFile.new.tap do |gf|
+        gf.title = ["jill's files"]
+        gf.filename = ['test.pdf']
+        gf.read_groups = ['public']
+        gf.apply_depositor_metadata("jilluser")
+        gf.save!
+      end
+    end
 
-    scenario 'does not display collections' do
+    let!(:gf2) do
+      GenericFile.new.tap do |gf|
+        gf.title = ["jill's shared file"]
+        gf.filename = ['test.pdf']
+        gf.permissions << Hydra::AccessControls::Permission.new(type: 'person', name: current_user.user_key, access: 'edit')
+        gf.apply_depositor_metadata("jilluser")
+        gf.save!
+      end
+    end
+
+    scenario 'does not display collections and others files' do
       go_to_dashboard_shares
       expect(page).to_not have_content(collection_title)
+      expect(page).to_not have_content(gf.title[0])
+      expect(page).to have_content(gf2.title[0])
     end
   end
 


### PR DESCRIPTION
...cess to.  fixes #94 

Adding overrides to searchbuilder to add edit filter (self.discovery_perms = [:edit]) to show_only_shared_files

Adding shares_controller to change the order of the solr filers so the only_shares comes before the access control ones
