### PR TITLE
Fixes missing help option for collection creator

### DIFF
--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -31,3 +31,6 @@ en:
     labels:
       collection:
         description: "Description"
+    metadata_help:
+      collection:
+        creator_html: "The person or group responsible for the collection. Usually this is the author of the collected content. Personal names should be entered with the last name first, e.g. &quot;Smith, John.&quot; &lt;em&gt;This is a required field&lt;/em&gt;."


### PR DESCRIPTION
Puts @cam156 work back in so that the creator helper works again in collections.
