### PR TITLE
Redirect URLs with legacy scholarsphere prefix in the URL

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -63,6 +63,19 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def handle_legacy_url_prefix
+    legacy_prefix = "scholarsphere:".freeze
+    id = params[:id].to_s
+    if id.start_with?(legacy_prefix)
+      new_id = id[legacy_prefix.length..-1]
+      if block_given?
+        # block should execute something along the lines of
+        # redirect_to controller_name_path(new_id), status: :moved_permanently
+        yield new_id
+      end
+    end
+  end  
+
  protected
   def user_logged_in?
     user_signed_in? && ( valid_user?(request.headers) || Rails.env.test?)

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -1,6 +1,12 @@
 class CollectionsController < ApplicationController
   include Sufia::CollectionsControllerBehavior
 
+  prepend_before_filter only: [:show, :edit] do  
+    handle_legacy_url_prefix do |new_id|
+      redirect_to collections.collection_path(new_id), status: :moved_permanently
+    end
+  end 
+
   def presenter_class
     ::CollectionPresenter
   end

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -2,9 +2,7 @@ class CollectionsController < ApplicationController
   include Sufia::CollectionsControllerBehavior
 
   prepend_before_filter only: [:show, :edit] do  
-    handle_legacy_url_prefix do |new_id|
-      redirect_to collections.collection_path(new_id), status: :moved_permanently
-    end
+    handle_legacy_url_prefix { |new_id| redirect_to collections.collection_path(new_id), status: :moved_permanently }
   end 
 
   def presenter_class

--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -1,0 +1,10 @@
+class DownloadsController < ApplicationController
+  include Sufia::DownloadsControllerBehavior
+
+  prepend_before_filter only: [:show] do  
+    handle_legacy_url_prefix do |new_id|
+      redirect_to sufia.download_path(new_id), status: :moved_permanently
+    end
+  end 
+
+end

--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -2,9 +2,7 @@ class DownloadsController < ApplicationController
   include Sufia::DownloadsControllerBehavior
 
   prepend_before_filter only: [:show] do  
-    handle_legacy_url_prefix do |new_id|
-      redirect_to sufia.download_path(new_id), status: :moved_permanently
-    end
+    handle_legacy_url_prefix { |new_id| redirect_to sufia.download_path(new_id), status: :moved_permanently }
   end 
 
 end

--- a/app/controllers/generic_files_controller.rb
+++ b/app/controllers/generic_files_controller.rb
@@ -3,6 +3,12 @@ class GenericFilesController < ApplicationController
   include Sufia::FilesControllerBehavior
   include Behaviors::PermissionsNotificationBehavior
 
+  prepend_before_filter only: [:show, :edit] do  
+    handle_legacy_url_prefix do |new_id|
+      redirect_to sufia.generic_file_path(new_id), status: :moved_permanently
+    end
+  end 
+
   # TODO This is a temporary override of sufia to fix #101
   #      This can be removed once sufia has a solution and we upgrade or
   #      batches are no longer used when sufia migrates to PCDM

--- a/app/controllers/generic_files_controller.rb
+++ b/app/controllers/generic_files_controller.rb
@@ -4,9 +4,7 @@ class GenericFilesController < ApplicationController
   include Behaviors::PermissionsNotificationBehavior
 
   prepend_before_filter only: [:show, :edit] do  
-    handle_legacy_url_prefix do |new_id|
-      redirect_to sufia.generic_file_path(new_id), status: :moved_permanently
-    end
+    handle_legacy_url_prefix { |new_id| redirect_to sufia.generic_file_path(new_id), status: :moved_permanently }
   end 
 
   # TODO This is a temporary override of sufia to fix #101

--- a/spec/controllers/collection_controller_spec.rb
+++ b/spec/controllers/collection_controller_spec.rb
@@ -8,4 +8,13 @@ describe CollectionsController, type: :controller do
       expect(response.status).to eq(404)
     end
   end
+
+  context "when requesting a legacy URL" do
+    it "redirects to the proper URL" do
+      get :show, id: 'scholarsphere:123'
+      expect(response.status).to eq(301)
+      expect(response.location).to eq("http://test.host/collections/123")
+    end
+  end
+
 end


### PR DESCRIPTION
 to the new URL format without it.
