### PR TITLE
Potential solution to solr-only show view

### DIFF
--- a/app/controllers/generic_files_controller.rb
+++ b/app/controllers/generic_files_controller.rb
@@ -19,14 +19,14 @@ class GenericFilesController < ApplicationController
   around_action :notify_users_of_permission_changes, only: [:destroy,:create,:update]
   skip_before_action :has_access?, only: [:stats]
   
-  # TODO: load and authorize resource are causing problems (#9678)
-  #skip_load_resource(only: [:show])
-  #before_filter :load_resource_from_solr, only: [:show]
-  #authorize_resource only: [:show]
-  #def load_resource_from_solr
-  #  @generic_file = ::GenericFile.load_instance_from_solr(params[:id])
-  #  @generic_file
-  #end
+  skip_load_resource(only: [:show])
+  before_filter :load_resource_from_solr, only: [:show]
+  authorize_resource only: [:show]
+
+  def load_resource_from_solr
+    @generic_file = GenericFile.load_instance_from_solr(params[:id])
+    @generic_file
+  end
 
   def notify_users_of_permission_changes
     previous_permissions = @generic_file.permissions.map(&:to_hash) unless @generic_file.nil?
@@ -37,4 +37,9 @@ class GenericFilesController < ApplicationController
       notify_users(permission_state, @generic_file)
     end
   end
+
+  def audit_service
+    ScholarsphereAuditService.new(@generic_file)
+  end
+
 end

--- a/app/helpers/sufia_helper.rb
+++ b/app/helpers/sufia_helper.rb
@@ -3,4 +3,18 @@ module SufiaHelper
   include Blacklight::CatalogHelperBehavior
   include Sufia::BlacklightOverride
   include Sufia::SufiaHelperBehavior
+
+  def characterization_terms terms = Hash.new
+    FitsDatastream.terminology.terms.each_pair do |k, v|
+      next unless v.respond_to? :proxied_term
+      term = v.proxied_term
+      begin
+        value = @generic_file.send(term.name)
+        terms[term.name] = value unless value.empty?
+      rescue NoMethodError
+        next
+      end
+    end
+    terms
+  end
 end

--- a/app/services/scholarsphere_audit_service.rb
+++ b/app/services/scholarsphere_audit_service.rb
@@ -1,0 +1,18 @@
+class ScholarsphereAuditService < Sufia::GenericFileAuditService
+
+  def audit_stat
+    audit_results = ChecksumAuditLog.logs_for(generic_file.id, "content").collect { |result| result["pass"] }
+
+    # check how many non runs we had
+    non_runs = audit_results.reduce(0) { |sum, value| value == NO_RUNS ? sum += 1 : sum }
+    if non_runs == 0
+      audit_results.reduce(true) { |sum, value| sum && value }
+    elsif non_runs < audit_results.length
+      result = audit_results.reduce(true) { |sum, value| value == NO_RUNS ? sum : sum && value }
+      "Some audits have not been run, but the ones run were #{result ? 'passing' : 'failing'}."
+    else
+      'Audits have not yet been run on this file.'
+    end
+  end
+
+end

--- a/app/views/generic_files/_show_details.html.erb
+++ b/app/views/generic_files/_show_details.html.erb
@@ -1,0 +1,45 @@
+<h2>File Details</h2>
+<dl class="dl-horizontal file-show-term file-show-details">
+  <dt>Depositor</dt>
+  <dd itemprop="accountablePerson" itemscope itemtype="http://schema.org/Person"><span itemprop="name"><%= link_to_profile @generic_file.depositor %></span></dd>
+  <dt>Date Uploaded</dt>
+  <dd itemprop="datePublished"><%= @generic_file.date_uploaded %></dd>
+  <dt>Date Modified</dt>
+  <dd itemprop="dateModified"><%= @generic_file.date_modified %></dd>
+  <dt>Audit Status</dt>
+  <dd><%= @audit_status %></dd>
+  <% unless @generic_file.related_files.empty? %>
+  <dt>Related Files</dt>
+      <% @generic_file.related_files.each do |f| %>
+          <dd><%= link_to(f.label, sufia.generic_file_url(f)) %></dd>
+      <% end %>
+  <% end %>
+  <dt>Characterization</dt>
+  <dd>
+    <%= "not yet characterized" if characterization_terms.values.flatten.map(&:empty?).reduce(true) { |sum, value| sum && value } %>
+    <% characterization_terms.each_pair do |term, values| %>
+        <div>
+          <% label = term.to_s %>
+          <% if label == "format_label" %>
+              <% label = "File Format"  %>
+              <% values = @generic_file.file_format %>
+          <% end %>
+          <% label = label.humanize %>
+          <% if values.is_a? Array %>
+              <% length = values.length %>
+              <% length = Sufia.config.fits_message_length-1  if term == :status_message && values.length > Sufia.config.fits_message_length-1  %>
+              <% values[0..length].each_with_index do |value, idx| %>
+                  <% next if value.empty? %>
+                  <%= "#{label}: #{value.truncate(250)}" %>
+                  <%= "<br />".html_safe unless idx == length %>
+              <% end %>
+              <% if length != values.length %>
+                  <%= render partial: "generic_files/extra_fields_modal", locals: {name: term, values: values, start: Sufia.config.fits_message_length}%>
+              <% end %>
+          <% else %>
+              <%= "#{label}: #{values.truncate(250)}" %><br />
+          <% end %>
+        </div>
+    <% end %>
+  </dd>
+</dl>


### PR DESCRIPTION
Address a solr-only view in #146. This still needs some work, namely that the AuditService ought to have more separate concerns when it comes to getting the status of an audit versus performing one.

This work should eventually make it back into Sufia as well.
