### PR TITLE
solr:compare task was not working as expected, ref #164

### DIFF
--- a/lib/tasks/scholarsphere-solr.rake
+++ b/lib/tasks/scholarsphere-solr.rake
@@ -10,11 +10,10 @@ namespace :scholarsphere do
 
     desc "Compares number of objects in Solr with those in Fedora"
     task compare: :environment do
-      if number_of_objects_in_fedora > number_of_objects_in_solr
-        raise "Fedora's #{fedora.to_s} objects exceeds Solr's #{solr}"
-      else
-        puts "Things appear to be OK"
-      end
+      fedora = number_of_objects_in_fedora
+      solr = number_of_objects_in_solr
+      raise "Fedora's #{fedora.to_s} objects exceeds Solr's #{solr}" if fedora > solr
+      puts "Things appear to be OK"
     end
     
   end

--- a/spec/rake/solr_spec.rb
+++ b/spec/rake/solr_spec.rb
@@ -33,6 +33,12 @@ describe "scholarsphere:solr" do
     describe "compare" do
       subject { capture_stdout { Rake::Task["scholarsphere:solr:compare"].invoke } }
       it { is_expected.to start_with("Things appear to be OK") }
+      context "when solr and fedora are out of sync" do
+        before { ActiveFedora::Cleaner.cleanout_solr }
+        it "raises an error" do
+          expect { run_task "scholarsphere:solr:compare" }.to raise_error(RuntimeError, "Fedora's 2 objects exceeds Solr's 0")
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Although it would have exited properly if solr and fedora were in sync, it would have failed because variables weren't set correctly. This fixes that problem, but it remains to be seen if it reports correctly in our staging and production environments.
