### PR TITLE
Adding filtered lists to allow an array of GenericFiles to be filtere…

### DIFF
--- a/app/models/public_filtered_list.rb
+++ b/app/models/public_filtered_list.rb
@@ -1,0 +1,14 @@
+class PublicFilteredList
+
+  attr_reader :generic_files, :filters
+
+  def initialize(generic_files)
+    @generic_files = generic_files
+    @filters = []
+  end
+
+  def filter
+    @public_members ||= generic_files.reject{|gf| !gf.public?}
+  end
+
+end

--- a/app/models/resource_filtered_list.rb
+++ b/app/models/resource_filtered_list.rb
@@ -1,0 +1,14 @@
+class ResourceFilteredList
+
+  attr_reader :generic_files, :resource_types
+
+  def initialize(generic_files, resource_types = ["Dataset", "Posters", "Thesis", "Dissertation", "Report"] )
+    @generic_files = generic_files
+    @resource_types = resource_types
+  end
+
+  def filter
+    @filtered ||= generic_files.reject{|gf| !((gf.resource_type & resource_types).count >0)}
+  end
+
+end

--- a/spec/models/public_filtered_list_spec.rb
+++ b/spec/models/public_filtered_list_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe PublicFilteredList, type: :model do
+  let(:file_list) { [ GenericFile.new(title: ["private"]), GenericFile.new( title: ['public']) { |f| f.visibility = 'open' } ] }
+
+  subject {PublicFilteredList.new(file_list).filter}
+
+  it "keeps public files" do
+    expect(subject.count).to eq(1)
+    expect(subject.map(&:title)).to include(['public'])
+    expect(subject.map(&:title)).not_to include(['private'])
+  end
+end

--- a/spec/models/resource_filtered_list_spec.rb
+++ b/spec/models/resource_filtered_list_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+describe ResourceFilteredList, type: :model do
+  let(:file_list) do
+    [ GenericFile.new(title: ["Dataset"], resource_type: ["Dataset"]),
+      GenericFile.new(title: ["Posters"], resource_type: ["Posters"]),
+      GenericFile.new(title: ["Thesis"], resource_type: ["Thesis"]),
+      GenericFile.new(title: ["Dissertation"], resource_type: ["Dissertation"]),
+      GenericFile.new(title: ["Report"], resource_type: ["Report"]),
+      GenericFile.new( title: ['none'])
+    ]
+  end
+
+  context "when using default resource types" do
+    subject {ResourceFilteredList.new(file_list).filter}
+
+    it "keeps default resource types" do
+      expect(subject.count).to eq(5)
+      expect(subject.map(&:title)).to include(['Dataset'])
+      expect(subject.map(&:title)).to include(['Posters'])
+      expect(subject.map(&:title)).to include(['Thesis'])
+      expect(subject.map(&:title)).to include(['Dissertation'])
+      expect(subject.map(&:title)).to include(['Report'])
+      expect(subject.map(&:title)).not_to include(['none'])
+    end
+  end
+
+  context "when using other resource types" do
+    subject {ResourceFilteredList.new(file_list,['Dataset', 'Report']).filter}
+
+    it "keeps default resource types" do
+      expect(subject.count).to eq(2)
+      expect(subject.map(&:title)).to include(['Dataset'])
+      expect(subject.map(&:title)).to include(['Report'])
+      expect(subject.map(&:title)).not_to include(['Posters'])
+      expect(subject.map(&:title)).not_to include(['Thesis'])
+      expect(subject.map(&:title)).not_to include(['Dissertation'])
+      expect(subject.map(&:title)).not_to include(['none'])
+    end
+  end
+
+end


### PR DESCRIPTION
…d based on visibility and resource type refs #205 

These FilteredLists can be used to add filtering need before a file is sen to share.  Implementing them as separate lists so they would be easy to test.

Intending for the final answer to be something like:
send_list =   ResourceFilteredList.new(PublicFilteredList.new(files).filter).filter

There still needs to be an additional filter for not sending ones already sent to Share, but we have yet to define where that data is going to be stored.
