### PR TITLE
Use ScholarsphereLockManager for Redis 2.4 compatibility

### DIFF
--- a/app/services/scholarsphere_lock_manager.rb
+++ b/app/services/scholarsphere_lock_manager.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+# Implements file-based locking which is incompatible with Redis 2.4
+# Remove this when we've upgraded to Redis 2.6+
+class ScholarsphereLockManager
+  def lock(key)
+    state_file = "#{ScholarSphere::Application.config.statefile}_#{key}"
+    File.open(state_file, File::RDWR | File::CREAT, 0644) do |f|
+      f.flock(File::LOCK_EX)
+      yield
+    end
+  end
+end

--- a/app/services/sufia/lockable.rb
+++ b/app/services/sufia/lockable.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+# Monkeypatch Sufia::Lockable to use a Redis 2.4-compatible lock manager.
+# Remove this when we've upgraded to Redis 2.6+
+module Sufia
+  module Lockable
+    extend ActiveSupport::Concern
+
+    def acquire_lock_for(lock_key, &block)
+      lock_manager.lock(lock_key, &block)
+    end
+
+    def lock_manager
+      @lock_manager ||= ::ScholarsphereLockManager.new
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -135,5 +135,8 @@ module ScholarSphere
 
     # allow errors to be raised in callbacks
     config.active_record.raise_in_transactional_callbacks = true
+
+    # Needed for ScholarsphereLockManager, remove this when we've upgraded to Redis 2.6+
+    config.statefile = '/tmp/lockmanager-state'
   end
 end

--- a/spec/models/batch_spec.rb
+++ b/spec/models/batch_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe Batch do
+  context "when using Sufia::Lockable" do
+    let(:manager) { ScholarsphereLockManager.new }
+    let(:key) { "batch" }
+    it "works with Redis 2.4" do
+      expect(described_class).to receive(:lock_manager).and_return(manager)
+      expect(manager).to receive(:lock).with(key)
+      described_class.find_or_create(key)
+    end
+  end
+end


### PR DESCRIPTION
This implements a file-based locking mechanism that we use in Archivesphere. I'm testing against Batch, which uses locking in `find_or_create`. It is also used in `Sufia::GenericFile::Actor#add_file_to_collection` but I'm not explicitly testing it there.

The travis build is passing, but it doesn't use Redis 2.4. To test it against 2.4, you'll need to do that locally. I installed 2.4 on my laptop, and the test suite passes except for two errors in `spec/models/migrate_audit_spec.rb`. However, if run that entire spec file in isolation, or even the entire set of model spec tests, they all pass.

Because the failures only pertain to the migration audit, which we're not using anymore, and aren't reproducible, I'm inclined to say this is acceptable and try regression testing on QA.

Thoughts? @cam156 @hectorcorrea @mtribone
