### PR TITLE
Don't merge until after #271 - Verify links work in static pages

### DIFF
--- a/spec/features/static_pages_spec.rb
+++ b/spec/features/static_pages_spec.rb
@@ -1,85 +1,76 @@
 # frozen_string_literal: true
 require 'feature_spec_helper'
 
-$in_travis = !ENV['TRAVIS'].nil? && ENV['TRAVIS'] == 'true'
-
 describe 'Static pages:', type: :feature do
-  shared_examples 'verify each static page' do |user|
-    [
-      '/about',
-      '/help',
-      '/contact'
-    ].each do |path|
-      describe "The '#{path}' page" do
-        it 'has verified hyperlinks' do
-          verify_links path
-        end
-        unless user
-          # Verifying youtube links is done via visiting an external url.
-          # We can only do so if we are not logged in as a user.
-          it 'has verified videos exist', unless: $in_travis do
-            verfiy_youtube_links path
-          end
-        end
+  shared_examples "a page with links" do
+    it "has links to external pages", unless: travis? do
+      external_links.each do |link|
+        visit(link)
+        expect(status_code).to eq(200)
+      end
+    end
+
+    it "has links to anchors" do
+      anchor_links.each do |link|
+        visit(link)
+        expect(status_code).to eq(200)
+      end
+    end
+  end
+
+  shared_examples "a page with YouTube links" do
+    it "has links to YouTube videos", unless: travis? do
+      youtube_links.each do |link|
+        visit(link)
+        expect(status_code).to eq(200)
       end
     end
   end
 
   context 'when not logged in' do
-    we_can 'verify each static page', user: false
+    before do
+      sign_in_with_js(nil, js_errors: false)
+      visit(path)
+    end
+
+    describe "the about page" do
+      let(:path) { "/about" }
+      it_behaves_like "a page with links"
+    end
+
+    describe "the contact page" do
+      let(:path) { "/contact" }
+      it_behaves_like "a page with links"
+    end
+
+    describe "the help page" do
+      let(:path) { "/help" }
+      it_behaves_like "a page with YouTube links"
+      it_behaves_like "a page with links"
+    end
   end
 
   context 'when logged in' do
     let(:user) { create(:user) }
-    before { sign_in_with_js(user) }
-    we_can 'verify each static page', user: true
-  end
-
-  def verify_links(path)
-    visit path
-    links_on_page = []
-    anchored_links = []
-
-    all('#content a').each do |page_link|
-      unless ['delete', 'post', 'put'].include? page_link[:method]
-        links_on_page << page_link[:href]
-        anchored_links << page_link[:href] if page_link[:href].include?('#')
-      end
+    before do
+      sign_in_with_js(user, js_errors: false)
+      visit(path)
     end
 
-    unique_anchored_links = []
-    unique_links = links_on_page.uniq
-    unique_anchored_links = anchored_links.uniq
-
-    unique_links.each do |href|
-      next if href == '#'
-      next if href.blank?
-      next if href =~ /^(http|mailto|tel)/
-      if href =~ /^\//m
-        # link to different page
-        visit href
-      else
-        # link on same page
-        visit "#{path}/#{href}"
-      end
-      if unique_anchored_links.include?(href)
-        anchor = href.split('#').last
-        expect(page).to have_selector "##{anchor}", visible: false
-      end
-      expect(status_code).to be 200
+    describe "the about page" do
+      let(:path) { "/about" }
+      it_behaves_like "a page with links"
     end
-  end
 
-  def verfiy_youtube_links(path)
-    # Check all iframes containing youtube links for valid youtube ids
-    visit path
-    srcs = []
-    all('iframe[src*="youtube"]').each do |iframe|
-      srcs << iframe[:src]
+    describe "the contact page" do
+      let(:path) { "/contact" }
+      it_behaves_like "a page with links"
     end
-    srcs.each do |url|
-      visit url
-      expect(status_code).to be 200
+
+    describe "the help page" do
+      let(:path) { "/help" }
+      it_behaves_like "a page with YouTube links"
+      it_behaves_like "a page with links"
     end
   end
 end

--- a/spec/features/support/feature_sessions.rb
+++ b/spec/features/support/feature_sessions.rb
@@ -13,12 +13,9 @@ module Features
       Capybara.current_driver = driver
     end
 
-    def sign_in_with_js(user = nil)
+    def sign_in_with_js(user = nil, opts = {})
       Capybara.register_driver :poltergeist do |app|
-        Capybara::Poltergeist::Driver.new(app,
-                                          js_errors: true,
-                                          timeout: 90,
-                                          phantomjs_options: ['--ssl-protocol=ANY'])
+        Capybara::Poltergeist::Driver.new(app, defaults.merge(opts))
       end
       Capybara.current_driver = :poltergeist
       page.driver.headers = request_headers(user)
@@ -39,6 +36,14 @@ module Features
         else
           "rack_test_authenticated_header_anonymous"
         end
+      end
+
+      def defaults
+        {
+          js_errors: true,
+          timeout: 90,
+          phantomjs_options: ['--ssl-protocol=ANY']
+        }
       end
   end
 end

--- a/spec/services/name_disabiguation_service_spec.rb
+++ b/spec/services/name_disabiguation_service_spec.rb
@@ -1,10 +1,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-# only run the test locally when we have a valid connection to ldap
-in_travis = !ENV['TRAVIS'].nil? && ENV['TRAVIS'] == 'true'
-
-describe NameDisambiguationService, unless: in_travis do
+describe NameDisambiguationService, unless: travis? do
   subject { described_class.new(name).disambiguate }
 
   context "when we have a normal name" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,10 @@ require 'rspec/rails'
 require 'equivalent-xml/rspec_matchers'
 require 'byebug' unless ENV['TRAVIS']
 
+def travis?
+  ENV.fetch("TRAVIS", false)
+end
+
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }

--- a/spec/support/helpers/link_checker.rb
+++ b/spec/support/helpers/link_checker.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+module LinkChecker
+  # Returns an array of all iframe links containing YouTube videos
+  def youtube_links
+    all('iframe[src*="youtube"]').map do |iframe|
+      iframe[:src]
+    end
+  end
+
+  def anchor_links
+    links = all('a').map do |page_link|
+      page_link[:href] if page_link[:href].include?('#')
+    end
+    links.uniq.compact.delete_if(&:blank?)
+  end
+
+  def external_links
+    links = all('a').map do |page_link|
+      page_link[:href] unless page_link[:href].match(Capybara.current_session.server.host)
+    end
+    links.uniq.compact.delete_if(&:blank?)
+  end
+end
+
+RSpec.configure do |config|
+  config.include LinkChecker
+end


### PR DESCRIPTION
This is a follow-up PR after #271 is merged. I discovered the static pages feature test wasn't testing external links or anchor links. This fixes that and refactors things for clarity, removing the rubocop exceptions.

Also, we can test for the presence of YouTube links with and without a current, logged-in user.
