### PR TITLE
Fixes problem with create collection feature tests

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -29,11 +29,6 @@ class SolrDocument
     collections
   end
 
-  def creator
-    return nil if self[Solrizer.solr_name(:creator)].blank?
-    "#{ul_start_tags} #{self[Solrizer.solr_name(:creator)].join(ul_join_tags)} #{ul_end_tags}".html_safe
-  end
-
   private
 
     def ul_start_tags

--- a/spec/features/collection/create_and_delete_spec.rb
+++ b/spec/features/collection/create_and_delete_spec.rb
@@ -29,7 +29,7 @@ describe Collection, type: :feature do
     let!(:file1) { create(:file, title: ["First file"], depositor: current_user.login) }
     let!(:file2) { create(:file, title: ["Second file"], depositor: current_user.login) }
     before do
-      go_to_dashboard_files
+      go_to_dashboard_works
       check 'check_all'
       click_button 'Add to Collection'
       db_create_populated_collection_button.click


### PR DESCRIPTION
Updated test to visit the correct page and let the creator be provided by the normal SolrDocument (rather than overwriting it and embedding HTML on it) since now the view does the HTML part.

This PR fixes the two tests to _create_ a collection. The test for delete collection is still failing and will be addressed in a separate PR.
