### PR TITLE
Fixes header/footer layout and responsiveness and width of containing elements

### DIFF
--- a/app/assets/stylesheets/scholarsphere/header.scss
+++ b/app/assets/stylesheets/scholarsphere/header.scss
@@ -1,0 +1,96 @@
+@media screen and (min-width: 400px) {
+
+  a .user-util-text {
+    color: #FFF;
+  }
+
+  li.open a .user-util-text {
+    color: #000
+  }
+
+  a:hover .user-util-text {
+    color: #000;
+  }
+
+  .lion-logo {
+    margin-top: 0.15em;
+    width: 125px;
+  }
+
+  #masthead .navbar-header > .logo-padding-fix {
+    padding-left: 0; /* Needs to be very specific to override code from 3 gems */
+    margin-left: -5px;
+  }
+
+  #masthead .navbar-nav > li > a {
+    color: #FFF; /* Needs to be very specific to override code from 3 gems */
+  }
+
+  .navbar-default .navbar-nav > li > a {
+    text-align: center;
+  }
+
+  .navbar-header {
+    background-color: #036;
+  }
+
+  .ss-logo a:link, .ss-logo a:visited, .ss-logo a:hover {
+    color: #FFF;
+    display: block;
+    font-family: 'Lato', Verdana, Arail, Helvetica, sans-serif;
+    font-weight: 300;
+    text-decoration: none;
+
+    font-size: 1.25em;
+    padding-top: 0.5em;
+    padding-left: .75em;
+  }
+
+  .ss-toolbar {
+    background-color: #2C76C7;
+  }
+}
+
+@media screen and (min-width: 600px) {
+  .navbar-inline > .nav > li {
+    display: inline-block;
+  }
+}
+
+@media screen and (max-width: 767px) {
+  #masthead .navbar-nav .open .dropdown-menu {
+    background-color: #FFF; /* Needs to be very specific to override code from 3 gems */
+  }
+  #masthead .navbar-nav .open .dropdown-menu > li > a {
+    color: #333; /* Needs to be very specific to override code from 3 gems */
+  }
+  #masthead .navbar-nav .open .dropdown-menu > li > a:hover {
+    background-color: #f5f5f5; /* Needs to be very specific to override code from 3 gems */
+  }
+}
+
+@media screen and (min-width: 768px) {
+  .lion-logo {
+    width: 150px;
+  }
+  .navbar-inline .nav li {
+    margin-top: 0.5em;
+  }
+  .ss-logo a:link, .ss-logo a:visited, .ss-logo a:hover {
+    padding-top: 0.5em;
+    font-size: 1.5em;
+  }
+}
+
+@media screen and (min-width: 960px) {
+  .lion-logo {
+    width: 175px;
+  }
+  .navbar-inline .nav li {
+    margin-top: 0.5em;
+  }
+  .ss-logo a:link, .ss-logo a:visited, .ss-logo a:hover {
+    padding-top: 0.5em;
+    font-size: 1.75em;
+  }
+}

--- a/app/views/_controls.html.erb
+++ b/app/views/_controls.html.erb
@@ -1,0 +1,19 @@
+<nav class="navbar navbar-default navbar-static-top" role="navigation">
+  <div class="container-fluid">
+    <div class="row">
+      <ul class="nav navbar-nav col-sm-5 col-md-6">
+        <li <%= 'class=active' if current_page?(sufia.root_path) %>>
+          <%= link_to t(:'sufia.controls.home'), sufia.root_path, :'data-no-turbolink'=>"true" %></li>
+        <li <%= 'class=active' if current_page?(sufia.about_path) %>>
+          <%= link_to t(:'sufia.controls.about'), sufia.about_path, :'data-no-turbolink'=>"true" %></li>
+        <li <%= 'class=active' if action_name == "help" %>>
+          <%= link_to t(:'sufia.controls.help'), sufia.help_path %></li>
+        <li <%= 'class=active' if current_page?(sufia.contact_path) %>>
+          <%= link_to t(:'sufia.controls.contact'), sufia.contact_path %></li>
+      </ul><!-- /.nav -->
+      <div class="searchbar-right navbar-right col-sm-7 col-md-6">
+        <%= render partial: 'catalog/search_form' %>
+      </div>
+    </div>
+  </div>
+</nav>

--- a/app/views/_logo.html.erb
+++ b/app/views/_logo.html.erb
@@ -1,4 +1,4 @@
-<a id="shield" href="http://psu.edu/"><%= image_tag "site_images/penn-state-mark.png" %></a>
-<span class="logo">
+<a id="shield" href="http://psu.edu/"><%= image_tag "site_images/penn-state-mark.png", class: "lion-logo pull-left" %></a>
+<span class="ss-logo">
   <a href="/">ScholarSphere</a>
 </span>

--- a/app/views/_masthead.html.erb
+++ b/app/views/_masthead.html.erb
@@ -1,0 +1,25 @@
+<nav id="masthead" class="masthead navbar navbar-inverse navbar-static-top" role="navigation">
+  <div class="container-fluid">
+    <div class="row">
+      <div class="navbar-header col-xs-12">
+        <div class="col-xs-6 logo-padding-fix">
+          <%= render partial: '/logo' %>
+        </div>
+        <div class="col-xs-6 navbar-inline">
+          <%= render partial: '/user_util_links' %>
+        </div>
+      </div>
+    </div>
+    <div class="row ss-toolbar">
+      <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#top-navbar-collapse" aria-expanded="false">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+      </button>
+      <div class="col-xs-12 collapse navbar-collapse" id="top-navbar-collapse">
+        <%= render partial: '/toolbar' %>
+      </div>
+    </div>
+  </div>
+</nav>

--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -1,0 +1,31 @@
+<ul id="user_utility_links" class="nav navbar-right">
+  <% if user_signed_in? %>
+      <li>
+        <%= link_to sufia.notifications_path do %>
+            <span class="user-util-text">Notifications</span>
+            <%= render partial: 'users/notify_number' %>
+        <% end %>
+      </li>
+      <li class="dropdown">
+        <%= link_to sufia.profile_path(current_user), role: 'button', data: { toggle: 'dropdown' }, aria: { haspopup: true, expanded: false} do %>
+            <span class="sr-only">View</span>
+            <span class="hidden-xs user-util-text">&nbsp;<%= current_user.name %></span>
+            <span class="sr-only"> profile</span>
+            <span class="fa fa-user user-util-text"></span>
+            <span class="caret user-util-text" ></span>
+        <% end %>
+        <ul class="dropdown-menu dropdown-menu-right" role="menu">
+          <li><%= link_to 'View Profile', sufia.profile_path(current_user) %></li>
+          <li><%= link_to 'Edit Profile', sufia.edit_profile_path(current_user) %></li>
+          <li class="divider"></li>
+          <li><%= link_to 'Logout', main_app.destroy_user_session_path %></li>
+        </ul>
+      </li><!-- /.btn-group -->
+  <% else %>
+      <li>
+        <%= link_to main_app.new_user_session_path do %>
+            <span class="glyphicon glyphicon-log-in" aria-hidden="true"></span> Login
+        <% end %>
+      </li>
+  <% end %>
+</ul>

--- a/app/views/layouts/sufia-dashboard.html.erb
+++ b/app/views/layouts/sufia-dashboard.html.erb
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="<%= t("sufia.document_language", default: '') %>">
+<head><%= render 'layouts/head_tag_content' %></head>
+<body>
+<a href="#skip_to_content" class="sr-only">Skip to Content</a>
+<%= render '/masthead' %>
+<%= render '/controls' %>
+<%= render '/flash_msg' %>
+
+<div id="content-wrapper" class="container-fluid dashboard" role="main">
+  <% if content_for?(:page_header) %>
+      <div class="row">
+        <div class="col-xs-12 main-header">
+          <div class="row">
+            <%= yield(:page_header) %>
+          </div>
+        </div>
+      </div>
+  <% end %>
+  <a name="skip_to_content"></a>
+  <div class="row">
+    <% if content_for?(:sidebar) %>
+        <div class="col-xs-12 col-sm-9 col-sm-push-3"><%= yield %></div>
+        <div id="sidebar" class="col-xs-12 col-sm-3 col-sm-pull-9"><%= yield :sidebar %></div>
+    <% else %>
+        <div class="col-xs-12">
+          <%= yield %>
+        </div>
+    <% end %>
+  </div>
+</div>
+
+<%= render 'shared/footer' %>
+<%= render 'shared/ajax_modal' %>
+</body>
+</html>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,12 +1,12 @@
 <footer id="footer" class="footer-wrapper container-fluid">
   <div class="row">
     <div class="col-xs-6">
-      <span class="footer-logo pull-left"><a href="/app/assets/stylesheets"><span class="footer-logo-bold">Scholar</span>Sphere</a></span>
+      <span class="footer-logo pull-left"><a href="/"><span class="footer-logo-bold">Scholar</span>Sphere</a></span>
       <span class="footer-version"><a href="/versions/"><%= ScholarSphere::Application::config.scholarsphere_version %></a></span>
       <p class="footer-service">A service of the University Libraries and Information Technology Services.</p>
     </div>
     <div class="col-xs-6 footer-text">
-        <p><strong>Copyright &copy; <%= Date.today.year %> The Pennsylvania State University</strong></p>
+        <p>Copyright &copy; <%= Date.today.year %> The Pennsylvania State University</p>
         <ul>
           <li><a href="http://psu.edu">Penn State</a></li>&nbsp;&#124;&nbsp;
           <li><a href="http://libraries.psu.edu">University Libraries</a></li>&nbsp;&#124;&nbsp;


### PR DESCRIPTION
Improves layout, text, styles for header elements 400-768px. Updates footer and header for 960px. Overrides dashboard layout with container-fluid. Makes drop down links white when screen is mobile.Overall better layout and responsiveness.

![screen shot 2016-10-24 at 3 44 07 pm](https://cloud.githubusercontent.com/assets/4163828/19687749/b391f724-9a94-11e6-9114-617577f36df3.png)
