### PR TITLE
Unified Search Dropdown Text on the Home Page

### DIFF
--- a/app/assets/stylesheets/scholarsphere/home_page.scss
+++ b/app/assets/stylesheets/scholarsphere/home_page.scss
@@ -1,0 +1,8 @@
+.image-masthead .searchbar-right .dropdown-menu li > a {
+  color: #333; /* Needs to be very specific to override Sufia */
+}
+
+.image-masthead .searchbar-right .dropdown-menu li > a:hover {
+  background-color: #f5f5f5; /* Needs to be very specific to override Sufia */
+  color: #262626;
+}


### PR DESCRIPTION
Overrides styles from main Sufia masthead navbar so that the text is visible when hovering over the dropdown.

Fixes #385 

![screen shot 2016-10-25 at 12 59 53 pm](https://cloud.githubusercontent.com/assets/4163828/19695961/2336645c-9ab3-11e6-8387-5e9fea089b19.png)
