### PR TITLE
Moved User Profile Info from Left-Hand Column into Tab Pane

### DIFF
--- a/app/assets/stylesheets/scholarsphere/user_profile.scss
+++ b/app/assets/stylesheets/scholarsphere/user_profile.scss
@@ -1,0 +1,14 @@
+.highlighted-works {
+  margin-top: 1em;
+}
+
+.highlighted-works td {
+  padding: 0.5em 0.5em 0.35em 0.25em;
+}
+
+.profile dd {
+  color: #a3a3a3;
+}
+.panel-user h2 {
+  font-size: 1.65em;
+}

--- a/app/views/users/_contributions.html.erb
+++ b/app/views/users/_contributions.html.erb
@@ -1,0 +1,33 @@
+<div class="tab-pane" id="contributions">
+    <% if presenter.trophies.count > 0 %>
+        <table class="highlighted-works">
+          <thead>
+          <tr>
+            <th scope="col" class="sr-only">Thumbnail</th>
+            <th scope="col" class="sr-only">Highlighted Work</th>
+          </tr>
+          </thead>
+          <tbody>
+          <% presenter.trophies.each do |t| %>
+              <tr id="trophyrow_<%= t.id %>">
+                <td>
+                  <%= link_to t do %>
+                      <%= image_tag t.thumbnail_path, width: 90 %>
+                  <% end %>
+                </td>
+                <td>
+                  <%= link_to t.to_s, t %>
+                  <% if presenter.current_user? %>
+                      <%= display_trophy_link current_user, t.id, class: 'glyphicon glyphicon-star', data: { removerow: true } do %>
+                          <span class='trophy-on glyphicon glyphicon-remove'></span>
+                      <% end %>
+                  <% end %>
+                </td>
+              </tr>
+          <% end %>
+          </tbody>
+        </table>
+    <% else %>
+        <%= presenter.name %> has no highlighted works.
+    <% end %>
+</div>

--- a/app/views/users/_edit_secondary.html.erb
+++ b/app/views/users/_edit_secondary.html.erb
@@ -1,9 +1,9 @@
-<h2><i class="glyphicon glyphicon-user"></i> Directory Info (LDAP) <%= link_to 'Edit Instructions', 'http://www.psu.edu/directory/#update', class: 'btn btn-mini btn-primary' %></h3>
+<h3><span class="glyphicon glyphicon-user"></span> Directory Info (LDAP) <%= link_to 'Edit Instructions', 'http://www.psu.edu/directory/#update', class: 'btn btn-mini btn-primary' %></h3>
 <%= render 'user_info',  {user: @user } %>
 
 <hr />
 
-<h2><i class="glyphicon glyphicon-group"></i> User Managed Groups Info (UMG) <%= link_to 'Manage UMG', 'http://umg.its.psu.edu/', class: 'btn btn-xs btn-primary' %> </h3>
+<h3><span class="glyphicon glyphicon-group"></span> User Managed Groups Info (UMG) <%= link_to 'Manage UMG', 'http://umg.its.psu.edu/', class: 'btn btn-xs btn-primary' %> </h3>
 <% current_user.groups.each do |g| %>
   <i class="glyphicon glyphicon-asterisk"></i> <%= g %><br />
 <% end %>

--- a/app/views/users/_profile_tabs.html.erb
+++ b/app/views/users/_profile_tabs.html.erb
@@ -1,0 +1,11 @@
+<ul class="nav nav-tabs" id="myTab">
+  <li class="active"><a href="#user_info"><span class="glyphicon glyphicon-user"></span> <%= I18n.t('sufia.user_profile.tab_user_info') %></a></li>
+  <li><a href="#contributions"><span class="glyphicon glyphicon-star"></span> <%= I18n.t('sufia.user_profile.tab_highlighted') %></a></li>
+  <li><a href="#activity_log" ><span class="glyphicon glyphicon-calendar"></span> <%= I18n.t('sufia.user_profile.tab_activity') %></a></li>
+</ul>
+
+<div class="tab-content">
+  <%= render 'user_info', user: @user %>
+  <%= render 'contributions', presenter: presenter %>
+  <%= render 'activity', presenter: presenter %>
+</div> <!-- /tab-content -->

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -1,0 +1,27 @@
+<div class="panel panel-default panel-user">
+  <div class="panel-heading">
+    <%= image_tag user.avatar.url(:thumb), width: 100 if user.avatar.present? %>
+    <h2>
+      <% if user.name != user.user_key %>
+          <%= user.name %><br />
+      <% end %>
+      <%= user.user_key %>
+    </h2>
+  </div>
+
+  <div class="list-group">
+    <%= render "users/vitals", user: user %>
+  </div>
+
+  <div class="panel-footer clearfix">
+    <% unless current_page? sufia.profile_path(user) %>
+        <%= link_to t("sufia.view_profile"), sufia.profile_path(user), class: "btn btn-default" %>
+    <% end %>
+
+    <% if can? :edit, user %>
+        <%= link_to sufia.edit_profile_path(user), class: "btn btn-default pull-right" do %>
+            <i class="glyphicon glyphicon-edit"></i> <%= t("sufia.edit_profile") %>
+        <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/users/_user_info.html.erb
+++ b/app/views/users/_user_info.html.erb
@@ -1,0 +1,88 @@
+<div class="tab-pane active row" id="user_info">
+  <div class="col-xs-12 col-sm-6">
+    <h3>Directory Information</h3>
+    <dl>
+      <% if user.title %>
+          <dt>Title</dt>
+          <dd><%= user.title %></dd>
+      <% end %>
+
+      <% if user.admin_area %>
+          <dt>Administrative Area</dt>
+          <dd><%= user.admin_area %></dd>
+      <% end %>
+
+      <% if user.department %>
+          <dt>Department</dt>
+          <dd><%= user.department %></dd>
+      <% end %>
+
+      <% if user.office %>
+          <dt>Office</dt>
+          <dd><%= user.office %></dd>
+      <% end %>
+
+      <% if user.address %>
+          <dt><i class="glyphicon glyphicon-map-marker"></i> Address</dt>
+          <dd><%= user.address %></dd>
+      <% end %>
+
+      <% if user.affiliation %>
+          <dt>Affiliation</dt>
+          <dd><%= user.affiliation %></dd>
+      <% end %>
+
+      <% if user.telephone %>
+          <dt><i class="glyphicon glyphicon-earphone"></i> Telephone</dt>
+          <dd><%= link_to_telephone(user) %></dd>
+      <% end %>
+    </dl>
+  </div>
+  <div class="col-xs-12 col-sm-6">
+    <h3>Additional Profile Information</h3>
+    <dl>
+      <% if user.orcid.present? %>
+          <dt><%= orcid_label('profile') %></dt>
+          <dd><%= link_to user.orcid, user.orcid, { target: '_blank' } %></dd>
+      <% end %>
+
+      <% if Sufia.config.arkivo_api && user.zotero_userid.present? %>
+          <dt><%= zotero_label(html_class: 'profile') %></dt>
+          <dd><%= link_to zotero_profile_url(user.zotero_userid), zotero_profile_url(user.zotero_userid), { target: '_blank' } %></dd>
+      <% end %>
+
+      <% if user.facebook_handle.present? %>
+          <dt><i class="fa fa-facebook"></i> Facebook Handle</dt>
+          <dd><%= link_to user.facebook_handle, "http://facebook.com/#{user.facebook_handle}", {target:'_blank'} %></dd>
+      <% end %>
+
+      <% if user.twitter_handle.present? %>
+          <dt><i class="fa fa-twitter"></i> Twitter Handle</dt>
+          <dd><%= link_to user.twitter_handle, "http://twitter.com/#{user.twitter_handle}", {target:'_blank'} %></dd>
+      <% end %>
+
+      <% if user.googleplus_handle.present? %>
+          <dt><i class="fa fa-google-plus"></i> Google+ Handle</dt>
+          <dd><%= link_to user.googleplus_handle, "http://google.com/+#{user.googleplus_handle}", {target:'_blank'} %></dd>
+      <% end %>
+
+      <% if user.linkedin_handle.present? %>
+          <dt><i class="fa fa-linkedin"></i> LinkedIn</dt>
+          <dd><%= link_to "#{@linkedInUrl}", "#{@linkedInUrl}", { target: '_blank' } %></dd>
+      <% end %>
+
+      <dt><i class="fa fa-envelope"></i> Email</dt>
+      <dd><%= mail_to user.email %></dd>
+
+      <% if user.chat_id %>
+          <dt><i class="glyphicon glyphicon-bullhorn"></i> Chat ID</dt>
+          <dd><%= user.chat_id %></dd>
+      <% end %>
+
+      <% if user.website %>
+          <dt><i class="glyphicon glyphicon-globe"></i> Website(s)</dt>
+          <dd><%= iconify_auto_link(user.website) %></dd>
+      <% end %>
+    </dl>
+  </div>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,9 @@
+<div class="profile">
+  <h1 class="sr-only">User Profile</h1>
+  <div class="col-xs-12 col-sm-3">
+    <%= render 'left_sidebar' %>
+  </div>
+  <div class="col-xs-12 col-sm-9">
+    <%= render 'profile_tabs', presenter: @presenter %>
+  </div>
+</div>

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -32,6 +32,8 @@ en:
         create_new: "Create New Collection"
     upload:
       cloud_timeout_message_html: "Please note that if you upload a large number of files within a short period of time, the cloud provider may not be able to accommodate your request. If you experience any errors uploading from the cloud, let us know via the %{contact_href}."
+    user_profile:
+      tab_user_info: "User Info"
   simple_form:
     labels:
       collection:

--- a/spec/features/dashboard/dashboard_works_spec.rb
+++ b/spec/features/dashboard/dashboard_works_spec.rb
@@ -78,7 +78,7 @@ describe 'Dashboard Works', type: :feature do
       end
       specify 'It is highlighted' do
         # It is highlighted on my profile
-        visit "/users/#{current_user.login}"
+        visit "/users/#{current_user.login}\#contributions"
         expect(page).to have_css '.active a', text: "Highlighted"
         within '#contributions' do
           expect(page).to have_link file.title.first

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -12,9 +12,9 @@ describe "User Profile", type: :feature do
   context "with any user" do
     specify do
       sign_in_with_js(admin_user)
-      visit("/users/#{admin_user}")
+      visit("/users/#{admin_user}\#contributions")
 
-      # allows to view profile with trophies
+      # allows to view profile with highlighted works
       expect(page).to have_css '.active a', text: "Highlighted"
       expect(page).to have_content file1.title.first
 
@@ -23,8 +23,13 @@ describe "User Profile", type: :feature do
       expect(page).to have_selector('li.active', text: "Activity")
       expect(page).to have_content(event_text)
 
+      # allows clicking on User Info tab
+      click_link "User Info"
+      expect(page).to have_selector('h3', text: "Directory Information")
+      expect(page).to have_selector('dt', text: "Title")
+
       # allows editing the user's profile
-      click_link "Edit Your Profile"
+      click_link "Edit Profile"
       fill_in 'user_twitter_handle', with: 'curatorOfData'
       fill_in 'user_orcid', with: '0000-0000-0000-0000'
       click_button 'Save Profile'


### PR DESCRIPTION
Moves the user info from the left pane and into its own tab panel. Removes extra col-xs-12 and sets up left sidebar and tab content to behave and display more consistently on mobile and up.

Swaps the active tab to the user info and adds header information to each column, adds h1 to page and hides it visually for screen readers, makes user name h2, removes the extra edit button, and updates spec test for the correct link text.

Adds I18n translation for User Info tab. Font size and color tweaks.

Fix up the table a bit for style, display, and accessibility.