### PR TITLE
Keyboard Navigation and Associated Accessibility Work for New/Edit Work Interface

### DIFF
--- a/app/assets/javascripts/scholarsphere_fileupload.js
+++ b/app/assets/javascripts/scholarsphere_fileupload.js
@@ -5,3 +5,11 @@ max_file_size_str = "500 MB";
 max_total_file_size = 1000000000;
 max_total_file_size_str = "1000 MB";
 
+Blacklight.onLoad(function() {
+    $(":input").focusin(function () {
+        $(this).addClass("has-focus");
+    });
+    $(":input").focusout(function () {
+        $(this).removeClass("has-focus");
+    });
+});

--- a/app/assets/stylesheets/scholarsphere/add_edit_work.scss
+++ b/app/assets/stylesheets/scholarsphere/add_edit_work.scss
@@ -1,0 +1,49 @@
+.inputfile {
+  width: 0.1px;
+  height: 0.1px;
+  opacity: 0;
+  overflow: hidden;
+  position: absolute;
+  z-index: -1;
+}
+
+.inputfile + label:before {
+  font-family: FontAwesome;
+  content: "\f067"
+}
+
+.inputfile + label {
+  background-color: #5CB85C;
+  border: 1px solid #4CAE4C;
+  border-radius: 4px;
+  color: white;
+  cursor: pointer;
+  display: inline-block;
+  font-size: 1.04em;
+  font-weight: normal;
+  line-height: 1.4em;
+  margin-bottom: 0;
+  padding: 6px 12px;
+  text-align: center;
+  vertical-align: middle;
+}
+
+.inputfile:focus + label,
+.inputfile + label:hover {
+  background-color: #449D44;
+  border-color: #398439;
+}
+
+.inputfile:focus + label,
+.inputfile.has-focus + label {
+  border-color: #66AFE9;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6);
+  outline: 2px;
+  outline: -webkit-focus-ring-color auto 5px;
+}
+
+select.form-control.select_perm { /* Needs specific override for form-control and only target the permissions select */
+  display: inline-block;
+  width: auto;
+}
+

--- a/app/views/curation_concerns/base/_form_files.html.erb
+++ b/app/views/curation_concerns/base/_form_files.html.erb
@@ -1,0 +1,43 @@
+<div id="fileupload">
+  <!-- Redirect browsers with JavaScript disabled to the origin page -->
+  <noscript><input type="hidden" name="redirect" value="<%= main_app.root_path %>"></noscript>
+  <!-- The table listing the files available for upload/download -->
+  <table role="presentation" class="table table-striped"><tbody class="files"></tbody></table>
+
+  <h2><%= t('curation_concerns.base.form_files.local_upload') %></h2>
+  <!-- The fileupload-buttonbar contains buttons to add/delete files and start/cancel the upload -->
+  <div class="row fileupload-buttonbar">
+    <div class="col-xs-7">
+        <input type="file" name="files[]" id="inputfiles" class="inputfile" multiple />
+        <label for="inputfiles"> Add files</label>
+      <% if browser_supports_directory_upload? %>
+          <input type="file" name="files[]" id="inputfolder" class="inputfile" multiple directory webkitdirectory>
+          <label for="inputfolder"> Add folder</label>
+      <% end %>
+      <button type="reset" class="btn btn-warning cancel hidden">
+        <span class="glyphicon glyphicon-ban-circle"></span>
+        <span>Cancel upload</span>
+      </button>
+      <!-- The global file processing state -->
+      <span class="fileupload-process"></span>
+    </div>
+    <!-- The global progress state -->
+    <div class="col-xs-5 fileupload-progress fade">
+      <!-- The global progress bar -->
+      <div class="progress progress-striped active" role="progressbar" aria-valuemin="0" aria-valuemax="100">
+        <div class="progress-bar progress-bar-success" style="width:0%;"></div>
+      </div>
+      <!-- The extended global progress state -->
+      <div class="progress-extended">&nbsp;</div>
+    </div>
+  </div>
+  <div class="dropzone">
+    <%= t('curation_concerns.base.form_files.dropzone') %>
+  </div>
+</div>
+
+<%= render 'sufia/uploads/js_templates' %>
+<% if Sufia.config.browse_everything %>
+    <h2><%= t('curation_concerns.base.form_files.external_upload') %></h2>
+    <%= render 'browse_everything', f: f %>
+<% end %>

--- a/app/views/curation_concerns/base/_form_share.html.erb
+++ b/app/views/curation_concerns/base/_form_share.html.erb
@@ -1,0 +1,96 @@
+<h2>Sharing With</h2>
+<% depositor = f.object.depositor %>
+
+<div class="alert alert-info hidden" id="save_perm_note">Permissions are
+  <strong>not</strong> saved until the &quot;Save&quot; button is pressed at the bottom of the page.</div>
+
+<div class="alert alert-warning hidden" role="alert" id="permissions_error">
+  <span id="permissions_error_text"></span>
+</div>
+
+<table class="table">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Access Level</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr id="file_permissions">
+      <td>
+        <span id="file_owner" data-depositor="<%= depositor %>"><%= link_to_profile depositor %> (Depositor)</span>
+      </td>
+      <td>
+        <%= Sufia.config.owner_permission_levels.keys[0] %>
+      </td>
+    </tr>
+    <%= f.fields_for :permissions do |permission_fields| %>
+      <%# skip the public, registered, and depositor perms as they are displayed first at the top %>
+      <% next if ['public', 'registered', depositor].include? permission_fields.object.agent_name.downcase %>
+      <tr>
+        <td>
+          <%= permission_fields.label :agent_name, class: "control-label" do %>
+              <%= user_display_name_and_key(permission_fields.object.agent_name) %>
+          <% end %>
+        </td>
+        <td>
+          <%= permission_fields.select :access, Sufia.config.permission_levels, {}, class: 'form-control select_perm' %>
+          <button class="btn close remove_perm" data-index="<%= permission_fields.index %>">&times;</button>
+        </td>
+      </tr>
+  <% end %>
+  </tbody>
+</table>
+
+
+<h2>Share work with other users</h2>
+  <ol class="list-inline help-block">
+    <li>Search by name or <%= t('sufia.account_label') %>.</li>
+    <li>Select the access level you wish to grant</li>
+    <li>Click on "Add <%= t('sufia.account_label') %>" to give access to one <%=t('sufia.account_label') %> at a time.</li>
+  </ol>
+<div class="form-group row">
+  <div class="col-sm-5">
+    <label for="new_user_name_skel" class="sr-only"><%= t('sufia.account_label') %> (without the <%= t('sufia.directory.suffix') %> part)</label>
+    <%= text_field_tag 'new_user_name_skel', nil %>
+  </div>
+  <div class="col-sm-4">
+    <label for="new_user_permission_skel" class="sr-only">Access type to grant</label>
+    <%= select_tag 'new_user_permission_skel', options_for_select(Sufia.config.permission_levels), class: 'form-control' %>
+  </div>
+  <div class="col-sm-3">
+    <button class="btn btn-default" id="add_new_user_skel">
+      <span class="glyphicon glyphicon-plus"></span>
+      Add <%= t('sufia.account_label') %>
+    </button>
+    <br /> <span id="directory_user_result"></span>
+  </div>
+</div>
+
+<h2>Share work with groups of users</h2>
+<ol class="list-inline help-block">
+  <li>Select the group.</li>
+  <li>Select the access level you wish to grant</li>
+  <li>Click on "Add Group" to give access to one group at a time.</li>
+</ol>
+<div class="form-group row">
+  <div class="col-sm-5">
+    <label for="new_group_name_skel" class="sr-only">Group</label>
+    <%= select_tag 'new_group_name_skel', options_for_select(["Select a group"] + current_user.groups), class: 'form-control' %>
+  </div>
+  <div class="col-sm-4">
+    <label for="new_group_permission_skel" class="sr-only">Access type to grant</label>
+    <%= select_tag 'new_group_permission_skel', options_for_select(Sufia.config.permission_levels), class: 'form-control' %>
+  </div>
+  <div class="col-sm-3">
+    <button class="btn btn-default" id="add_new_group_skel"><span class="glyphicon glyphicon-plus"></span> Add Group</button>
+    <br /><span id="directory_group_result"></span>
+  </div>
+</div>
+
+<script type="text/x-tmpl" id="tmpl-work-grant">
+<tr>
+  <td>{%= o.name %}</td>
+  <td>{%= o.accessLabel %} <button class="btn close">&times;</button></td>
+</tr>
+</script>

--- a/app/views/curation_concerns/base/_form_visibility_component.html.erb
+++ b/app/views/curation_concerns/base/_form_visibility_component.html.erb
@@ -1,0 +1,72 @@
+<% if f.object.embargo_release_date %>
+    <%= render 'form_permission_under_embargo', f: f %>
+<% elsif f.object.lease_expiration_date %>
+    <%= render 'form_permission_under_lease', f: f %>
+<% else %>
+    <fieldset>
+      <legend class="legend-save-work">Visibility</legend>
+      <ul class="visibility">
+        <li class="radio">
+          <label>
+            <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, data: { 'target': '#collapsePublic' }  %>
+            <%= t('curation_concerns.visibility.open.label_html') %>
+            <div class="collapse" id="collapsePublic">
+              <p>
+                <strong>Please note</strong>, making something visible to the world (i.e.
+                marking this as <%= t('curation_concerns.visibility.open.label_html') %>) may be
+                viewed as publishing which could impact your ability to:
+              </p>
+              <ul>
+                <li>Patent your work</li>
+                <li>Publish your work in a journal</li>
+              </ul>
+              <p>
+                Check out <a href="http://www.sherpa.ac.uk/romeo/">SHERPA/RoMEO</a> for more
+                information about publisher copyright policies.
+              </p>
+            </div>
+          </label>
+        </li>
+        <li class="radio">
+          <label>
+            <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED %>
+            <%= t('curation_concerns.visibility.authenticated.label_html', institution: t('curation_concerns.institution.name')) %>
+          </label>
+        </li>
+        <li class="radio">
+          <label>
+            <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO, data: { 'target': '#collapseEmbargo' } %>
+            <%= t('curation_concerns.visibility.embargo.label_html') %>
+          </label>
+            <div class="collapse" id="collapseEmbargo">
+              <div class="form-inline">
+                <%= f.input :visibility_during_embargo, wrapper: :inline, collection: visibility_options(:restrict), include_blank: false %>
+                <%= f.label :embargo_release_date, class: 'control-label' %>
+                <%= f.date_field :embargo_release_date, wrapper: :inline, value: f.object.embargo_release_date || Date.tomorrow, class: 'datepicker form-control' %>
+                <%= f.input :visibility_after_embargo, wrapper: :inline, collection: visibility_options(:loosen), include_blank: false %>
+              </div>
+            </div>
+        </li>
+        <li class="radio">
+          <label>
+            <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LEASE, data: { 'target': '#collapseLease' } %>
+            <%= t('curation_concerns.visibility.lease.label_html') %>
+          </label>
+            <div class="collapse" id="collapseLease">
+              <div class="form-inline">
+                <%= f.input :visibility_during_lease, wrapper: :inline, collection: visibility_options(:loosen), include_blank: false %>
+                <%= f.label :lease_expiration_date, class: 'control-label' %>
+                <%= f.date_field :lease_expiration_date, wrapper: :inline, value: f.object.lease_expiration_date || Date.tomorrow, class: 'datepicker form-control' %>
+                <%= f.input :visibility_after_lease, wrapper: :inline, collection: visibility_options(:restrict), include_blank: false %>
+              </div>
+            </div>
+        </li>
+        <li class="radio">
+          <label>
+            <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE %>
+            <%= t('curation_concerns.visibility.private.label_html') %>
+          </label>
+        </li>
+      </ul>
+    </fieldset>
+<% end %>

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -38,6 +38,9 @@ en:
     labels:
       collection:
         description: "Description"
+      defaults:
+        lease_expiration_date:     'until date'
+        embargo_release_date:      'until date'
     hints:
       generic_work:
         rights: "Licensing and distribution information governing access to the work. See <a href=\"/licenses\" target=\"_blank\">Licenses</a> for more information"


### PR DESCRIPTION
Makes `<span />` a `<label />` and updates styles for padding, font weight, and increasing the clickable area of the button.

Moves the main label for embargo and lease to surround just those elements and not around a huge nested set of inputs. Adds values to the add buttons for better usability and removes several sr-only to provide instructions for all users in the interface.

Unhides help text, puts it into an inline ordered list, and adds the help block styles. Removes a label element from a span element for better accessibility and reworks the sharing table to be a bit easier to read and understand for users with differing abilities.

Adjust the display of the select buttons and make room for the remove button. Wordsmith help text. Refactors the sharing table abit and adds labels to the date picker on the new work form. Removes some extra parameters which weren't really working and adds label defaults to sufia yml.

Remove the bootstrap btn and btn-success to add own styles for tabbed focus. Fixes up the file names and IDs plus CSS for better alignment. Adds jquery event listeners for tabbed focus. Updates border, box shadow and outline to match system highlighting.