### PR TITLE
Bootlint, CSS styles, dashboard, and visual tidyness 

### DIFF
--- a/app/assets/stylesheets/scholarsphere/add_edit_work.scss
+++ b/app/assets/stylesheets/scholarsphere/add_edit_work.scss
@@ -1,10 +1,17 @@
+/* Inputfile and label are used to style the input like a button, but use the label as the functional element.
+The Bootstrap btn classes interfere with the input functioning like a button, especially when
+tabbing through the interface, so we replicated the look of the Bootstrap button here. The goal of the whole thing
+was to make the input button with type file be accessible to keyboard users and users of assistive technology and
+visually have a focus just like the other form elements.
+*/
+
 .inputfile {
-  width: 0.1px;
-  height: 0.1px;
-  opacity: 0;
-  overflow: hidden;
   position: absolute;
   z-index: -1;
+  width: .1px;
+  height: .1px;
+  opacity: 0;
+  overflow: hidden;
 }
 
 .inputfile + label:before {
@@ -13,37 +20,37 @@
 }
 
 .inputfile + label {
-  background-color: #5CB85C;
-  border: 1px solid #4CAE4C;
-  border-radius: 4px;
-  color: white;
-  cursor: pointer;
   display: inline-block;
+  color: white;
   font-size: 1.04em;
   font-weight: normal;
   line-height: 1.4em;
-  margin-bottom: 0;
-  padding: 6px 12px;
   text-align: center;
   vertical-align: middle;
+  background-color: #5cb85c;
+  border: 1px solid #4cae4c;
+  border-radius: 4px;
+  cursor: pointer;
+  margin-bottom: 0;
+  padding: 6px 12px;
 }
 
 .inputfile:focus + label,
 .inputfile + label:hover {
-  background-color: #449D44;
+  background-color: #449d44;
   border-color: #398439;
 }
 
 .inputfile:focus + label,
 .inputfile.has-focus + label {
-  border-color: #66AFE9;
-  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6);
+  border-color: #66aFe9;
+  box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(102,175,233,.6);
   outline: 2px;
   outline: -webkit-focus-ring-color auto 5px;
 }
 
-select.form-control.select_perm { /* Needs specific override for form-control and only target the permissions select */
+/* Needs specific override for form-control and only target the permissions select */
+select.form-control.select_perm {
   display: inline-block;
   width: auto;
 }
-

--- a/app/assets/stylesheets/scholarsphere/blacklight_gallery.scss
+++ b/app/assets/stylesheets/scholarsphere/blacklight_gallery.scss
@@ -3,10 +3,11 @@
 #documents .grid .document .thumbnail {
   padding: 0;
 }
+
 #documents .grid .document .thumbnail > a > img {
+  position: absolute;
   left: 0;
   top: 0;
   max-width: 100%;
   max-height: none;
-  position: absolute;
 }

--- a/app/assets/stylesheets/scholarsphere/collection.scss
+++ b/app/assets/stylesheets/scholarsphere/collection.scss
@@ -1,3 +1,4 @@
-.collection-icon, .collection-icon-search {
+.collection-icon,
+.collection-icon-search {
   color: #0072bc;
 }

--- a/app/assets/stylesheets/scholarsphere/dashboard.scss
+++ b/app/assets/stylesheets/scholarsphere/dashboard.scss
@@ -1,3 +1,4 @@
-.media-heading a.small {
+.media-heading a.small,
+.heading-tile a:hover {
   text-decoration: none;
 }

--- a/app/assets/stylesheets/scholarsphere/footer.scss
+++ b/app/assets/stylesheets/scholarsphere/footer.scss
@@ -1,14 +1,14 @@
 .footer-wrapper {
-  background: #036;
-  color: #FFF;
   margin-top: 2em;
   padding: 1em;
   min-height: 4em;
+  background: #036;
+  color: #fff;
 }
 
 .footer-wrapper a:link,
 .footer-wrapper a:visited {
-  color: #FFF;
+  color: #fff;
 }
 
 .footer-logo {
@@ -21,24 +21,25 @@
 }
 
 .footer-version {
-  padding: 0.5em;
-  a:link {
-    text-decoration: underline;
-  }
+  padding: .5em;
+}
+
+.footer-version a:link {
+  text-decoration: underline;
 }
 
 .footer-service {
   clear: both;
 }
 
-.footer-text {
-  ul {
-    padding-left: 0;
-  }
-  li {
-    display: inline;
-  }
-  a:link {
-    text-decoration: underline;
-  }
+.footer-text a:link {
+  text-decoration: underline;
+}
+
+.footer-text-links-list {
+  padding-left: 0;
+}
+
+.footer-text-links-list li {
+  display: inline;
 }

--- a/app/assets/stylesheets/scholarsphere/header.scss
+++ b/app/assets/stylesheets/scholarsphere/header.scss
@@ -1,7 +1,7 @@
 @media screen and (min-width: 400px) {
 
   a .user-util-text {
-    color: #FFF;
+    color: #fff;
   }
 
   li.open a .user-util-text {
@@ -13,17 +13,19 @@
   }
 
   .lion-logo {
-    margin-top: 0.15em;
+    margin-top: .15em;
     width: 125px;
   }
 
+  /* Needs to be very specific to override code from 3 gems */
   #masthead .navbar-header > .logo-padding-fix {
-    padding-left: 0; /* Needs to be very specific to override code from 3 gems */
+    padding-left: 0;
     margin-left: -5px;
   }
 
+  /* Needs to be very specific to override code from 3 gems */
   #masthead .navbar-nav > li > a {
-    color: #FFF; /* Needs to be very specific to override code from 3 gems */
+    color: #fff;
   }
 
   .navbar-default .navbar-nav > li > a {
@@ -34,20 +36,21 @@
     background-color: #036;
   }
 
-  .ss-logo a:link, .ss-logo a:visited, .ss-logo a:hover {
-    color: #FFF;
+  .ss-logo a:link,
+  .ss-logo a:visited,
+  .ss-logo a:hover {
     display: block;
+    color: #fff;
+    padding-top: .5em;
+    padding-left: .75em;
     font-family: 'Lato', Verdana, Arail, Helvetica, sans-serif;
+    font-size: 1.25em;
     font-weight: 300;
     text-decoration: none;
-
-    font-size: 1.25em;
-    padding-top: 0.5em;
-    padding-left: .75em;
   }
 
   .ss-toolbar {
-    background-color: #2C76C7;
+    background-color: #2c76c7;
   }
 }
 
@@ -58,14 +61,19 @@
 }
 
 @media screen and (max-width: 767px) {
+  /* Needs to be very specific to override code from 3 gems */
   #masthead .navbar-nav .open .dropdown-menu {
-    background-color: #FFF; /* Needs to be very specific to override code from 3 gems */
+    background-color: #fff;
   }
+
+  /* Needs to be very specific to override code from 3 gems */
   #masthead .navbar-nav .open .dropdown-menu > li > a {
-    color: #333; /* Needs to be very specific to override code from 3 gems */
+    color: #333;
   }
+
+  /* Needs to be very specific to override code from 3 gems */
   #masthead .navbar-nav .open .dropdown-menu > li > a:hover {
-    background-color: #f5f5f5; /* Needs to be very specific to override code from 3 gems */
+    background-color: #f5f5f5;
   }
 }
 
@@ -73,11 +81,15 @@
   .lion-logo {
     width: 150px;
   }
+
   .navbar-inline .nav li {
-    margin-top: 0.5em;
+    margin-top: .5em;
   }
-  .ss-logo a:link, .ss-logo a:visited, .ss-logo a:hover {
-    padding-top: 0.5em;
+
+  .ss-logo a:link,
+  .ss-logo a:visited,
+  .ss-logo a:hover {
+    padding-top: .5em;
     font-size: 1.5em;
   }
 }
@@ -86,11 +98,15 @@
   .lion-logo {
     width: 175px;
   }
+
   .navbar-inline .nav li {
-    margin-top: 0.5em;
+    margin-top: .5em;
   }
-  .ss-logo a:link, .ss-logo a:visited, .ss-logo a:hover {
-    padding-top: 0.5em;
+
+  .ss-logo a:link,
+  .ss-logo a:visited,
+  .ss-logo a:hover {
+    padding-top: .5em;
     font-size: 1.75em;
   }
 }

--- a/app/assets/stylesheets/scholarsphere/home_page.scss
+++ b/app/assets/stylesheets/scholarsphere/home_page.scss
@@ -1,8 +1,10 @@
+/* Needs to be very specific to override Sufia */
 .image-masthead .searchbar-right .dropdown-menu li > a {
-  color: #333; /* Needs to be very specific to override Sufia */
+  color: #333;
 }
 
+/* Needs to be very specific to override Sufia */
 .image-masthead .searchbar-right .dropdown-menu li > a:hover {
-  background-color: #f5f5f5; /* Needs to be very specific to override Sufia */
+  background-color: #f5f5f5;
   color: #262626;
 }

--- a/app/assets/stylesheets/scholarsphere/user_profile.scss
+++ b/app/assets/stylesheets/scholarsphere/user_profile.scss
@@ -3,12 +3,13 @@
 }
 
 .highlighted-works td {
-  padding: 0.5em 0.5em 0.35em 0.25em;
+  padding: .5em .5em .35em .25em;
 }
 
 .profile dd {
   color: #a3a3a3;
 }
+
 .panel-user h2 {
   font-size: 1.65em;
 }

--- a/app/views/_masthead.html.erb
+++ b/app/views/_masthead.html.erb
@@ -2,21 +2,25 @@
   <div class="container-fluid">
     <div class="row">
       <div class="navbar-header col-xs-12">
-        <div class="col-xs-6 logo-padding-fix">
-          <%= render partial: '/logo' %>
-        </div>
-        <div class="col-xs-6 navbar-inline">
-          <%= render partial: '/user_util_links' %>
+        <div class="row">
+          <div class="col-xs-6 logo-padding-fix">
+            <%= render partial: '/logo' %>
+          </div>
+          <div class="col-xs-6 navbar-inline">
+            <%= render partial: '/user_util_links' %>
+          </div>
         </div>
       </div>
     </div>
     <div class="row ss-toolbar">
-      <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#top-navbar-collapse" aria-expanded="false">
-        <span class="sr-only">Toggle navigation</span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-      </button>
+      <div class="col-xs-12">
+        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#top-navbar-collapse" aria-expanded="false">
+          <span class="sr-only">Toggle navigation</span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+        </button>
+      </div>
       <div class="col-xs-12 collapse navbar-collapse" id="top-navbar-collapse">
         <%= render partial: '/toolbar' %>
       </div>

--- a/app/views/dashboard/_index_partials/_heading_greetings.html.erb
+++ b/app/views/dashboard/_index_partials/_heading_greetings.html.erb
@@ -1,8 +1,9 @@
-<div class="col-md-12">
-  <div class="col-xs-3 hidden-xs">
-    <h1 class="page-header"><%= t("sufia.dashboard.title") %></h1>
-  </div>
-  <div class="col-xs-9">
-    <h2><%= t("sufia.dashboard.greeting") + current_user.name %><%= link_to("System Statistics", sufia.admin_stats_path, class: "admin_stats_link") if can? :admin_stats, current_user %></h2>
-  </div>
+<div class="col-xs-3 hidden-xs">
+  <h1><%= t("sufia.dashboard.title") %></h1>
+</div>
+<div class="col-xs-9">
+  <h2><%= t("sufia.dashboard.greeting") + " " + current_user.name %>
+    <span class="small"><%= link_to("System Statistics", sufia.admin_stats_path,
+                    class: "admin_stats_link") if can? :admin_stats, current_user %></span>
+  </h2>
 </div>

--- a/app/views/layouts/homepage.html.erb
+++ b/app/views/layouts/homepage.html.erb
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="<%= t("sufia.document_language") %>">
+<head>
+  <%= render "layouts/head_tag_content"%>
+</head>
+
+<body>
+<%= render '/masthead' %>
+
+<div class="image-masthead">
+  <div class="background-container" style="background-image: url('<%= Sufia.config.banner_image %>')"></div>
+  <span class="background-container-gradient"></span>
+
+  <div class="container site-title-container">
+    <div class="site-title h1" style="text-align: center;">
+      <%= render "sufia/homepage/marketing" if controller_name == 'homepage' %>
+    </div>
+  </div>
+
+  <nav class="navbar" role="navigation">
+    <div class="container">
+      <div class="row">
+        <ul class="nav navbar-nav col-sm-5 col-md-6">
+          <li <%= 'class=active' if current_page?(sufia.root_path) %>>
+            <%= link_to t(:'sufia.controls.home'), sufia.root_path, :'data-no-turbolink'=>"true" %></li>
+          <li <%= 'class=active' if current_page?(sufia.about_path) %>>
+            <%= link_to t(:'sufia.controls.about'), sufia.about_path, :'data-no-turbolink'=>"true" %></li>
+          <li <%= 'class=active' if action_name == "help" %>>
+            <%= link_to t(:'sufia.controls.help'), sufia.help_path %></li>
+          <li <%= 'class=active' if current_page?(sufia.contact_path) %>>
+            <%= link_to t(:'sufia.controls.contact'), sufia.contact_path %></li>
+        </ul><!-- /.nav -->
+        <div class="searchbar-right navbar-right col-sm-7 col-md-6">
+          <%= render partial: 'catalog/search_form' %>
+        </div>
+      </div>
+    </div>
+  </nav><!-- /.navbar -->
+</div>
+
+<%= render '/flash_msg' %>
+<%= render 'sufia/homepage/announcement' if controller_name == 'homepage' %>
+
+<div id="content-wrapper" class="container">
+  <%= yield %>
+</div><!-- /#content-wrapper -->
+<%= render 'shared/footer' %>
+<%= render 'shared/ajax_modal' %>
+</body>
+</html>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,4 +1,4 @@
-<footer id="footer" class="footer-wrapper container-fluid">
+<footer class="footer-wrapper container-fluid">
   <div class="row">
     <div class="col-xs-6">
       <span class="footer-logo pull-left"><a href="/"><span class="footer-logo-bold">Scholar</span>Sphere</a></span>
@@ -7,7 +7,7 @@
     </div>
     <div class="col-xs-6 footer-text">
         <p>Copyright &copy; <%= Date.today.year %> The Pennsylvania State University</p>
-        <ul>
+        <ul class="footer-text-links-list">
           <li><a href="http://psu.edu">Penn State</a></li>&nbsp;&#124;&nbsp;
           <li><a href="http://libraries.psu.edu">University Libraries</a></li>&nbsp;&#124;&nbsp;
           <li><a href="http://its.psu.edu">Information Technology Services</a></li>&nbsp;&#124;&nbsp;

--- a/app/views/sufia/homepage/_announcement.html.erb
+++ b/app/views/sufia/homepage/_announcement.html.erb
@@ -1,0 +1,9 @@
+<% if display_editable_content_block? @announcement_text %>
+    <div id="announcement" class="container-fluid">
+      <div class="row">
+        <div class="col-xs-12">
+          <%= editable_content_block @announcement_text %>
+        </div>
+      </div>
+    </div>
+<% end %>


### PR DESCRIPTION
Breaks up Sass nesting and updates code for new style. Adds comments, switches uppercase hex values to lower per style, removes values prefixed 0., spacing per style. Adds container fluid and moves row to another DIV for bootlint.

Overrides homepage.html.erb and adds col-sm-5 and col-md-6 for bootlint and better display.

Refactors the heading greeting and removes the hover states from the icons.

Inspiration:
http://codeguide.co/#css

Resolves #279 and #418 