### PR TITLE
[WIP] Hide thumbnails from screen readers

### DIFF
--- a/app/views/catalog/_index_gallery.html.erb
+++ b/app/views/catalog/_index_gallery.html.erb
@@ -1,0 +1,8 @@
+<div class="document col-xs-6 col-md-3">
+  <div class="thumbnail">
+    <%= render_thumbnail_tag(document, { alt: '', "aria-hidden" => true }, :counter => document_counter_with_offset(document_counter)) %>
+    <div class="caption">
+      <%= render_document_partials document, blacklight_config.view_config(:gallery).partials, :document_counter => document_counter %>
+    </div>
+  </div>
+</div>

--- a/app/views/catalog/_index_masonry.html.erb
+++ b/app/views/catalog/_index_masonry.html.erb
@@ -1,0 +1,8 @@
+<div class="masonry document col-xs-6 col-md-3">
+  <div class="thumbnail">
+    <%= render_thumbnail_tag(document, { alt: '', "aria-hidden" => true }, :counter => document_counter_with_offset(document_counter)) %>
+    <div class="caption">
+      <%= render_document_partials document, blacklight_config.view_config(:masonry).partials, :document_counter => document_counter %>
+    </div>
+  </div>
+</div>

--- a/app/views/catalog/_thumbnail_list_default.html.erb
+++ b/app/views/catalog/_thumbnail_list_default.html.erb
@@ -1,0 +1,3 @@
+<div class="col-sm-3">
+  <%= render_thumbnail_tag document, { alt: '', "aria-hidden" => true } %>
+</div>

--- a/app/views/my/_index_partials/_list_collections.html.erb
+++ b/app/views/my/_index_partials/_list_collections.html.erb
@@ -1,0 +1,44 @@
+<% id = document.id %>
+<tr id="document_<%= id %>">
+  <td></td>
+  <td>
+    <div class="media">
+      <span class="fa fa-cubes collection-icon-small pull-left" aria-hidden="true"></span>
+      <div class="media-body">
+        <div class="media-heading">
+          <%= link_to document, id: "src_copy_link#{id}" do %>
+              <span class="sr-only"><%= t("sufia.dashboard.my.sr.show_label") %> </span>
+              <%= document.title_or_label %>
+          <% end %>
+          <a href="#" class="small" title="Click for more details">
+            <span id="expand_<%= id %>" class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
+            <span class="sr-only"> <%= "#{t("sufia.dashboard.my.sr.detail_label")} #{document.title_or_label}" %></span>
+          </a>
+        </div>
+      </div>
+    </div>
+  </td>
+  <td class="text-center"><%= document.create_date %> </td>
+  <td class="text-center">
+    <%= render_visibility_link(document) %>
+  </td>
+  <td class="text-center">
+    <%= render 'collection_action_menu', id: id %>
+  </td>
+</tr>
+<tr id="detail_<%= id %>"> <!--  collection detail"> -->
+  <td colspan="6">
+    <dl class="expanded-details row">
+      <dt class="col-xs-3 col-lg-2"><%= t("sufia.dashboard.my.collection_list.description") %></dt>
+      <dd class="col-xs-9 col-lg-10"><%= document.description.first %></dd>
+      <dt class="col-xs-3 col-lg-2"><%= t("sufia.dashboard.my.collection_list.edit_access") %></dt>
+      <dd class="col-xs-9 col-lg-10">
+        <% if document.edit_groups.present? %>
+            <%= t("sufia.dashboard.my.collection_list.groups") %> <%= document.edit_groups.join(', ') %>
+            <br/>
+        <% end %>
+        <%= t("sufia.dashboard.my.collection_list.users") %> <%= document.edit_people.join(', ') %>
+      </dd>
+    </dl>
+  </td>
+</tr>

--- a/app/views/my/_index_partials/_list_works.html.erb
+++ b/app/views/my/_index_partials/_list_works.html.erb
@@ -8,7 +8,7 @@
   <td>
     <div class='media'>
       <%= link_to document, class: 'media-left', 'aria-hidden' => true do %>
-        <%= render_thumbnail_tag document, { class: 'hidden-xs file_listing_thumbnail' }, { suppress_link: true } %>
+        <%= render_thumbnail_tag document, { class: 'hidden-xs file_listing_thumbnail', alt: '', "aria-hidden" => true }, { suppress_link: true } %>
       <% end %>
 
       <div class='media-body'>

--- a/app/views/sufia/homepage/_featured.html.erb
+++ b/app/views/sufia/homepage/_featured.html.erb
@@ -1,0 +1,11 @@
+<% presenter = featured.presenter %>
+<li class="featured-item" data-id="<%= presenter.id %>">
+  <div class="main row">
+    <div class="col-sm-3">
+      <%= render_thumbnail_tag presenter, { width: 90, alt: '', "aria-hidden" => true } %>
+    </div>
+    <div class="col-sm-9">
+      <%= render 'sufia/homepage/featured_fields', featured: presenter %>
+    </div>
+  </div>
+</li>

--- a/app/views/sufia/homepage/_recent_document.html.erb
+++ b/app/views/sufia/homepage/_recent_document.html.erb
@@ -1,0 +1,16 @@
+<tr>
+  <td class="col-sm-2">
+    <%= link_to_profile recent_document.depositor("no depositor value") %>
+    <%= link_to recent_document do %>
+        <%= render_thumbnail_tag recent_document, { width: 45, alt: '', "aria-hidden" => true }, false %>
+    <% end %>
+  </td>
+  <td>
+    <h3>
+      <span class="sr-only">Title</span><%= link_to truncate(recent_document.to_s, length: 28, separator: ' '), recent_document  %>
+    </h3>
+    <p>
+      <span class="sr-only">Keywords</span><%= link_to_facet_list(recent_document.keyword, 'keyword', 'no keywords specified').html_safe %>
+    </p>
+  </td>
+</tr>

--- a/spec/features/dashboard/dashboard_collections_spec.rb
+++ b/spec/features/dashboard/dashboard_collections_spec.rb
@@ -28,7 +28,7 @@ describe 'Dashboard Collections:', type: :feature do
   end
 
   specify 'toggle displays additional information' do
-    first('i.glyphicon-chevron-right').click
+    first('span.glyphicon-chevron-right').click
     expect(page).to have_content(collection.description.first)
     expect(page).to have_content(current_user)
   end


### PR DESCRIPTION
*** THERE MAY BE A BETTER WAY ***

Override the featured and recent views on the home page to add aria hidden true to the thumbnail image options. Updates the catalog views from Blacklight to hide the thumb via aria hidden. Updates the works and collections listings in the MY index partials.

Adds empty alt tag as an option for render thumbnail tag. Update spec test to switch i element to span element per Bootstrap styles.