### PR TITLE
Home Page Overhaul

### DIFF
--- a/app/assets/stylesheets/scholarsphere/footer.scss
+++ b/app/assets/stylesheets/scholarsphere/footer.scss
@@ -1,5 +1,4 @@
 .footer-wrapper {
-  margin-top: 2em;
   padding: 1em;
   min-height: 4em;
   background: #036;

--- a/app/assets/stylesheets/scholarsphere/header.scss
+++ b/app/assets/stylesheets/scholarsphere/header.scss
@@ -28,6 +28,10 @@
     color: #fff;
   }
 
+  .navbar-default .navbar-nav {
+    margin-top: 0;
+  }
+
   .navbar-default .navbar-nav > li > a {
     text-align: center;
   }
@@ -43,7 +47,6 @@
     color: #fff;
     padding-top: .5em;
     padding-left: .75em;
-    font-family: 'Lato', Verdana, Arail, Helvetica, sans-serif;
     font-size: 1.25em;
     font-weight: 300;
     text-decoration: none;

--- a/app/assets/stylesheets/scholarsphere/home_page.scss
+++ b/app/assets/stylesheets/scholarsphere/home_page.scss
@@ -1,15 +1,98 @@
-/* Needs to be very specific to override Sufia */
-.image-masthead .searchbar-right .dropdown-menu li > a {
-  color: #333;
+/* Override styles coming from Sufia for better contrast */
+html > body .navbar-default .navbar-nav > li > a {
+  color: #686868;
 }
 
-/* Needs to be very specific to override Sufia */
-.image-masthead .searchbar-right .dropdown-menu li > a:hover {
-  background-color: #f5f5f5;
-  color: #262626;
+.marketing {
+  margin-bottom: 1.5em;
 }
+/* Overrides style coming from Sufia */
+.marketing > .home_marketing_text {
+  text-shadow: none !important;
+}
+
+.home_marketing_text p {
+  font-size: 1.5em;
+}
+
+/* Overrides style coming from Sufia */
+.marketing-share > .home-share-work {
+  margin-bottom: 0;
+  padding: 1em 0;
+  background-color: #ece6d8;
+  border-radius: 4px;
+}
+
+.home-share-work .btn {
+  border: 2px solid #fff;
+  font-size: 1.4em;
+}
+
+.home-share-work p a:link,
+.home-tabs .nav a:link,
+.collection-highlights a:link {
+  color: #2d699e;
+}
+
+.home-search {
+  padding-bottom: 1.5em;
+}
+
+.home-content {
+  margin-top: 1.5em;
+}
+
+/* Override Very specific set of declarations coming from Sufia */
 
 div#announcement.container-fluid {
-  background-color: #fad466;
-  color: black
+  font-size: 1.25em;
+  text-align: left;
+  color: black;
+  background-color: #00948a;
+  border: none;
+  padding-top: 0;
+  border-radius: 0;
+}
+
+.announcement {
+  padding-bottom: 1em;
+}
+
+.announcement h2 {
+  display: inline-block;
+  color: #fff;
+  padding-left: .35em;
+  padding-right: .35em;
+}
+
+.announcement p {
+  color: #fff;
+  font-size: 1.4em;
+  font-weight: 300;
+  padding: 0 .5em .5em .5em;
+}
+
+.home-tabs {
+  background-color: whitesmoke;
+}
+
+/* Overrides specific styles coming from Sufia */
+html > body #content-wrapper {
+  padding-bottom: 2em;
+}
+
+#content-wrapper.home-tabs ul {
+  margin-bottom: 0;
+}
+
+.home-content {
+  margin-bottom: 2em;
+}
+
+.home-content .tab-content {
+  padding: 1em .75em;
+  background-color: #fff;
+  border-left: 1px solid #ddd;
+  border-right: 1px solid #ddd;
+  border-bottom: 1px solid #ddd;
 }

--- a/app/assets/stylesheets/scholarsphere/typography.scss
+++ b/app/assets/stylesheets/scholarsphere/typography.scss
@@ -1,0 +1,6 @@
+/* Needs to be overly specific to override Bootstrap styles coming from 3 gems */
+
+html > body h1,
+html > body h2 {
+  font-weight: 300;
+}

--- a/app/views/layouts/homepage.html.erb
+++ b/app/views/layouts/homepage.html.erb
@@ -6,42 +6,41 @@
 
 <body>
 <%= render '/masthead' %>
-
-<div class="image-masthead">
-  <div class="background-container" style="background-image: url('<%= Sufia.config.banner_image %>')"></div>
-  <span class="background-container-gradient"></span>
-
-  <div class="container site-title-container">
-    <div class="site-title h1" style="text-align: center;">
-      <%= render "sufia/homepage/marketing" if controller_name == 'homepage' %>
+<nav class="navbar navbar-default navbar-static-top" role="navigation">
+  <div class="container-fluid">
+    <div class="row">
+      <ul class="nav navbar-nav col-sm-5 col-md-6">
+        <li <%= 'class=active' if current_page?(sufia.root_path) %>>
+          <%= link_to t(:'sufia.controls.home'), sufia.root_path, :'data-no-turbolink'=>"true" %></li>
+        <li <%= 'class=active' if current_page?(sufia.about_path) %>>
+          <%= link_to t(:'sufia.controls.about'), sufia.about_path, :'data-no-turbolink'=>"true" %></li>
+        <li <%= 'class=active' if action_name == "help" %>>
+          <%= link_to t(:'sufia.controls.help'), sufia.help_path %></li>
+        <li <%= 'class=active' if current_page?(sufia.contact_path) %>>
+          <%= link_to t(:'sufia.controls.contact'), sufia.contact_path %></li>
+      </ul><!-- /.nav -->
     </div>
   </div>
+</nav><!-- /.navbar -->
 
-  <nav class="navbar" role="navigation">
-    <div class="container">
-      <div class="row">
-        <ul class="nav navbar-nav col-sm-5 col-md-6">
-          <li <%= 'class=active' if current_page?(sufia.root_path) %>>
-            <%= link_to t(:'sufia.controls.home'), sufia.root_path, :'data-no-turbolink'=>"true" %></li>
-          <li <%= 'class=active' if current_page?(sufia.about_path) %>>
-            <%= link_to t(:'sufia.controls.about'), sufia.about_path, :'data-no-turbolink'=>"true" %></li>
-          <li <%= 'class=active' if action_name == "help" %>>
-            <%= link_to t(:'sufia.controls.help'), sufia.help_path %></li>
-          <li <%= 'class=active' if current_page?(sufia.contact_path) %>>
-            <%= link_to t(:'sufia.controls.contact'), sufia.contact_path %></li>
-        </ul><!-- /.nav -->
-        <div class="searchbar-right navbar-right col-sm-7 col-md-6">
-          <%= render partial: 'catalog/search_form' %>
-        </div>
-      </div>
+<div class="container-fluid">
+  <div class="row">
+    <div class="col-xs-12 col-sm-8 marketing">
+      <%= render "sufia/homepage/marketing" if controller_name == 'homepage' %>
     </div>
-  </nav><!-- /.navbar -->
+    <div class="col-xs-12 col-sm-4 marketing-share">
+      <%= render "sufia/homepage/share" if controller_name == 'homepage' %>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-xs-12 col-sm-offset-2 col-sm-8 home-search">
+      <%= render partial: 'catalog/search_form' %>
+    </div>
+  </div>
 </div>
-
-<%= render '/flash_msg' %>
 <%= render 'sufia/homepage/announcement' if controller_name == 'homepage' %>
 
-<div id="content-wrapper" class="container">
+<div id="content-wrapper" class="container-fluid home-tabs">
   <%= yield %>
 </div><!-- /#content-wrapper -->
 <%= render 'shared/footer' %>

--- a/app/views/sufia/homepage/_announcement.html.erb
+++ b/app/views/sufia/homepage/_announcement.html.erb
@@ -1,7 +1,7 @@
 <% if display_editable_content_block? @announcement_text %>
     <div id="announcement" class="container-fluid">
       <div class="row">
-        <div class="col-xs-12">
+        <div class="col-xs-12 announcement">
           <%= editable_content_block @announcement_text %>
         </div>
       </div>

--- a/app/views/sufia/homepage/_share.html.erb
+++ b/app/views/sufia/homepage/_share.html.erb
@@ -1,0 +1,9 @@
+<% if @presenter.display_share_button? %>
+    <div class="home-share-work text-center">
+      <%= link_to [:new, Sufia.primary_work_type.model_name.singular_route_key],
+                  class: "btn btn-primary btn-lg" do %>
+          <span class="glyphicon glyphicon-upload"></span> <%= t('sufia.share_button') %>
+      <% end %>
+      <p><a href="/terms/">Terms of Use</a></p>
+    </div>
+<% end %>

--- a/app/views/sufia/homepage/index.html.erb
+++ b/app/views/sufia/homepage/index.html.erb
@@ -1,0 +1,6 @@
+<% provide :page_title, application_name %>
+
+<div class="row home-content">
+  <%= render 'home_content' %>
+</div>
+<%= tiny_mce_stuff if can? :update, ContentBlock%>


### PR DESCRIPTION
Overrides home page index from Sufia to start customizing page. Hides other partials to work on customization. Moves the share section out of the index, removes a lot of extra divs and styles, makes a row and two columns for the marketing text and share.

Adds typography style sheet to override default Bootstrap styles. Fixes up some styles with overrides and roughs in the basic spacing and layout.

Adds the announcement box back in, super horrible overrides for style, and adds moar bootstrap syntax. Updates the styles for the announcement section and uses moar ugly overrides because of the very specific declarations from Sufia. Adjusts spacing and styles for the announcement section and the home tabs with content.

Moves the search box to its own row below the marketing row.

Removes the white background on the announcement text and makes the text white.

Addresses the following:
1. #437 
1. #438 
1. #439 
1. #481 