### PR TITLE
Hide Thumbnails from Screen Readers

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,12 +34,14 @@ Metrics/CyclomaticComplexity:
     - 'spec/support/helpers/generic_files.rb'
     - 'spec/features/static_pages_spec.rb'
     - 'app/models/generic_file.rb'
+    - 'app/helpers/catalog_helper.rb'
 
 Metrics/PerceivedComplexity:
   Exclude:
     - 'spec/support/helpers/generic_files.rb'
     - 'spec/features/static_pages_spec.rb'
     - 'app/models/generic_file.rb'
+    - 'app/helpers/catalog_helper.rb'
 
 Style/BlockDelimiters:
   Exclude:

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+module CatalogHelper
+  include Blacklight::CatalogHelperBehavior
+
+  ##
+  # Render the thumbnail, if available, for a document and
+  # link it to the document record.
+  #
+  # @param [SolrDocument] document
+  # @param [Hash] image_options to pass to the image tag
+  # @param [Hash] url_options to pass to #link_to_document
+  # @return [String]
+  def render_thumbnail_tag(document, image_options = {}, url_options = {})
+    image_options[:alt] = ""
+    image_options["aria-hidden"] = true
+    value = if blacklight_config.view_config(document_index_view_type).thumbnail_method
+              send(blacklight_config.view_config(document_index_view_type).thumbnail_method, document, image_options)
+            elsif blacklight_config.view_config(document_index_view_type).thumbnail_field
+              url = thumbnail_url(document)
+
+              image_tag url, image_options if url.present?
+            end
+
+    if value
+      if url_options == false || url_options[:suppress_link]
+        value
+      else
+        link_to_document document, value, url_options
+      end
+    end
+  end
+end

--- a/spec/features/generic_work/thumbnail_spec.rb
+++ b/spec/features/generic_work/thumbnail_spec.rb
@@ -18,8 +18,10 @@ describe "Generic Work Thumbnail Display:", type: :feature do
       go_to_dashboard_works
     end
 
-    it "renders the thumbnail" do
+    it "renders the thumbnail without the filename as the alt attribute and hides from screen readers" do
       expect(page).to have_css("img[src*='#{thumbnail_path}']")
+      expect(page).to have_css("img[aria-hidden='true']")
+      expect(page).to have_css("img[alt='']")
     end
   end
 


### PR DESCRIPTION
Overrides the image_tag helper default behavior by merging the empty alt and aria-hidden. Removes the catalog_helper_spec and uses the thumbnail feature test. 