### PR TITLE
Override uploader.js

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -8,5 +8,10 @@
 // Required by Blacklight
 //= require blacklight/blacklight
 
-//= require_tree .
+// Requiring each file individually so we can load Sufia's JS, with our overrides, at the end.
+//= require batch_edit
+//= require blacklight_gallery
+//= require openseadragon
+//= require scholarsphere_fileupload
+//= require scholarsphere_layout
 //= require sufia

--- a/app/assets/javascripts/sufia/uploader.js
+++ b/app/assets/javascripts/sufia/uploader.js
@@ -1,0 +1,74 @@
+// This is overriding Sufia's uploader.js so we can change the value of limitConcurrentUploads
+
+//= require fileupload/tmpl
+//= require fileupload/jquery.iframe-transport
+//= require fileupload/jquery.fileupload.js
+//= require fileupload/jquery.fileupload-process.js
+//= require fileupload/jquery.fileupload-validate.js
+//= require fileupload/jquery.fileupload-ui.js
+//
+/*
+ * jQuery File Upload Plugin JS Example
+ * https://github.com/blueimp/jQuery-File-Upload
+ *
+ * Copyright 2010, Sebastian Tschan
+ * https://blueimp.net
+ *
+ * Licensed under the MIT license:
+ * http://www.opensource.org/licenses/MIT
+ */
+
+(function( $ ){
+  'use strict';
+
+  $.fn.extend({
+    sufiaUploader: function( options ) {
+      // Initialize our jQuery File Upload widget.
+      // TODO: get these values from configuration.
+      this.fileupload($.extend({
+        // xhrFields: {withCredentials: true},              // to send cross-domain cookies
+        // acceptFileTypes: /(\.|\/)(png|mov|jpe?g|pdf)$/i, // not a strong check, just a regex on the filename
+        // limitMultiFileUploadSize: 500000000, // bytes
+        // limit to one file at a time (see #453)
+        limitConcurrentUploads: 1,
+        maxNumberOfFiles: 100,
+        maxFileSize: 500000000, // bytes, i.e. 500 MB
+        autoUpload: true,
+        url: '/uploads/',
+        type: 'POST',
+        dropZone: $(this).find('.dropzone')
+      }, options))
+      .bind('fileuploadadded', function (e, data) {
+        $(e.currentTarget).find('button.cancel').removeClass('hidden');
+      });
+
+      $(document).bind('dragover', function(e) {
+        var dropZone = $('.dropzone'),
+            timeout = window.dropZoneTimeout;
+        if (!timeout) {
+            dropZone.addClass('in');
+        } else {
+            clearTimeout(timeout);
+        }
+        var found = false,
+            node = e.target;
+        do {
+            if (node === dropZone[0]) {
+                found = true;
+                break;
+            }
+            node = node.parentNode;
+        } while (node !== null);
+        if (found) {
+            dropZone.addClass('hover');
+        } else {
+            dropZone.removeClass('hover');
+        }
+        window.dropZoneTimeout = setTimeout(function () {
+            window.dropZoneTimeout = null;
+            dropZone.removeClass('in hover');
+        }, 100);
+      });
+    }
+  });
+})(jQuery);


### PR DESCRIPTION
Requires some rearranging of the javascript so we can limit concurrent uploads to only 1 file at a time.

This fixes #453 but it's not ideal. The ideal solution would be to have multiple concurrent uploads in our current deployment, however, I'm not sure if that possible give server setup, etc.

If you all are okay with this, we can merge. You can try it out on QA. It doesn't slow things down too much to do one file at a time. Let me know what you think: @cam156 @mtribone @olendorf 