### PR TITLE
Update <head><title> in Works and Collections for Better Accessibility

### DIFF
--- a/app/helpers/title_helper.rb
+++ b/app/helpers/title_helper.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+module TitleHelper
+  include CurationConcerns::TitleHelper
+
+  def construct_page_title(*elements)
+    (elements.flatten.compact + [application_name]).join(' | ')
+  end
+end

--- a/app/presenters/work_show_presenter.rb
+++ b/app/presenters/work_show_presenter.rb
@@ -20,4 +20,8 @@ class WorkShowPresenter < Sufia::WorkShowPresenter
   def uploading?
     QueuedFile.where(work_id: id).present?
   end
+
+  def page_title
+    "Work | #{title.first} | Work ID: #{solr_document.id} | ScholarSphere"
+  end
 end

--- a/app/views/collections/edit.html.erb
+++ b/app/views/collections/edit.html.erb
@@ -1,0 +1,29 @@
+<% provide :page_title, "Edit Collection | #{@form.title.first} | Collection ID: #{@collection.id} | ScholarSphere" %>
+
+<%= provide :page_header do %>
+    <h1>Edit Collection: <%= @form.title.first %></h1>
+<% end %>
+
+<% unless has_collection_search_parameters? %>
+    <div class="row">
+      <div class="col-xs-12 col-sm-10 pull-right">
+        <%= render 'collections/form' %>
+      </div>
+      <div class="col-xs-12 col-sm-2">
+        <%= render 'collections/media_display', presenter: @collection %>
+        <%= render 'collections/edit_actions' %>
+      </div>
+    </div>
+<% end %>
+
+<div class="row m-t-3">
+  <h2 class="col-xs-12 col-sm-6"><%= t('sufia.collection.edit.manage_items') %></h2>
+  <div class="col-xs-12 col-sm-6">
+    <%= render 'search_form', presenter: @collection %>
+  </div>
+</div>
+<%= render 'my/did_you_mean' %>
+<%= render 'my/facet_selected' %>
+<%= render 'collections/sort_and_per_page', collection: @collection if @response.response['numFound'] > 0 %>
+<%= render 'document_list', documents: @member_docs, document_list_format: "dashboard" %>
+<%= render 'paginate' %>

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -1,0 +1,36 @@
+<% provide :page_title, "Collection | #{@presenter.title.first} | Collection ID: #{@presenter.id} | ScholarSphere" %>
+<div itemscope itemtype="http://schema.org/CollectionPage" class="row">
+  <div class="col-sm-10 pull-right">
+    <header>
+      <%= render 'collection_title', presenter: @presenter %>
+    </header>
+    <%= render 'collection_description', presenter: @presenter %>
+
+    <% unless has_collection_search_parameters? %>
+        <%= render 'collections/show_descriptions' %>
+    <% end %>
+  </div>
+  <div class="col-sm-2">
+    <%= render 'collections/media_display', presenter: @presenter %>
+    <% unless has_collection_search_parameters? %>
+        <%= render 'collections/show_actions', presenter: @presenter %>
+    <% end %>
+  </div>
+</div>
+
+<div class="row">
+  <h2 class="col-xs-6 col-md-7 col-lg-6">
+    <% if has_collection_search_parameters? %>
+        Search Results within this Collection
+    <% else %>
+        Items in this Collection
+    <% end %>
+  </h2>
+  <div class="col-xs-6 col-md-5 col-lg-6"><%= render 'search_form', presenter: @presenter %></div>
+</div>
+
+<%= render 'sort_and_per_page', collection: @presenter %>
+
+<%= render_document_index @member_docs %>
+
+<%= render 'paginate' %>

--- a/app/views/curation_concerns/base/edit.html.erb
+++ b/app/views/curation_concerns/base/edit.html.erb
@@ -1,0 +1,6 @@
+<% provide :page_title, "Edit Work | #{@form.title.first} | Work ID: #{curation_concern.to_param} | ScholarSphere" %>
+<% provide :page_header do %>
+    <h1><%= t("sufia.works.#{action_name}.header") %></h1>
+<% end %>
+
+<%= render 'form' %>


### PR DESCRIPTION
Fixes https://github.com/psu-stewardship/scholarsphere/issues/526 and https://github.com/psu-stewardship/scholarsphere/issues/515

Overrides construct_page_title method  and replaces `//` with ` | ` and defines page_title in work show presenter.

Adds the collection show page so that we can override the page title to keep it consistent with the style of the work show page.

Updates edit page for collections to follow style from work edit page.

Removes the construct_page_title method to just pass a string with dynamic elements to output contents of title element.