### PR TITLE
Hyperlink Underlines and Color

### DIFF
--- a/app/assets/stylesheets/scholarsphere/header.scss
+++ b/app/assets/stylesheets/scholarsphere/header.scss
@@ -2,6 +2,7 @@
 
   a .user-util-text {
     color: #fff;
+    text-decoration: none;
   }
 
   li.open a .user-util-text {
@@ -26,6 +27,7 @@
   /* Needs to be very specific to override code from 3 gems */
   #masthead .navbar-nav > li > a {
     color: #fff;
+    text-decoration: none;
   }
 
   .navbar-default .navbar-nav {

--- a/app/assets/stylesheets/scholarsphere/home_page.scss
+++ b/app/assets/stylesheets/scholarsphere/home_page.scss
@@ -1,6 +1,7 @@
 /* Override styles coming from Sufia for better contrast */
 html > body .navbar-default .navbar-nav > li > a {
   color: #686868;
+  text-decoration: none;
 }
 
 .marketing {
@@ -27,6 +28,8 @@ html > body .navbar-default .navbar-nav > li > a {
   border: 2px solid #fff;
   font-size: 1.4em;
 }
+
+.home-tabs .nav a:link { text-decoration: none; }
 
 .home-share-work p a:link,
 .home-tabs .nav a:link,

--- a/app/assets/stylesheets/scholarsphere/typography.scss
+++ b/app/assets/stylesheets/scholarsphere/typography.scss
@@ -4,3 +4,26 @@ html > body h1,
 html > body h2 {
   font-weight: 300;
 }
+
+html > body a {
+  color: #2d699e;
+  text-decoration: underline;
+}
+
+/* Overrides that hop onto existing classes where the UI convention is enough */
+a.btn,
+.breadcrumb a,
+.dropdown-menu > li > a,
+.facets h3 a,
+.facets h4 a,
+.heading-tile a,
+.nav-tabs > li > a,
+.no-underline,
+.visibility-link { text-decoration: none; }
+
+/* Overrides the heavy default underline on H2 titles in the search */
+.blacklight-genericwork h2 > a {
+  text-decoration: none;
+  text-shadow: 0 2px #fff;
+  border-bottom: 1px solid;
+}

--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -1,13 +1,13 @@
 <% if user_signed_in? %>
     <ul id="user_utility_links" class="nav navbar-right">
       <li>
-        <%= link_to sufia.notifications_path do %>
+        <%= link_to sufia.notifications_path, class: 'no-underline' do %>
             <span class="user-util-text">Notifications</span>
             <%= render partial: 'users/notify_number' %>
         <% end %>
       </li>
       <li class="dropdown">
-        <%= link_to sufia.profile_path(current_user), role: 'button', data: { toggle: 'dropdown' }, aria: { haspopup: true, expanded: false } do %>
+        <%= link_to sufia.profile_path(current_user), class: 'no-underline', role: 'button', data: { toggle: 'dropdown' }, aria: { haspopup: true, expanded: false } do %>
             <span class="sr-only">View</span>
             <span class="hidden-xs user-util-text">&nbsp;<%= current_user.name %></span>
             <span class="sr-only"> profile</span>


### PR DESCRIPTION
Big swing at bringing the link underlines back, then removing the underlines on certain UI elements like buttons, facets, labels, and dropdown menus. 

Overrides the default underline for clickable h2 in the search index. Updates link color to pass contrast error and adds text shadow to h2 links for descenders.