### PR TITLE
Contrast Errors for Buttons and Labels

### DIFF
--- a/app/assets/stylesheets/scholarsphere/add_edit_work.scss
+++ b/app/assets/stylesheets/scholarsphere/add_edit_work.scss
@@ -27,7 +27,7 @@ visually have a focus just like the other form elements.
   line-height: 1.4em;
   text-align: center;
   vertical-align: middle;
-  background-color: #5cb85c;
+  background-color: #387f38;
   border: 1px solid #4cae4c;
   border-radius: 4px;
   cursor: pointer;

--- a/app/assets/stylesheets/scholarsphere/typography.scss
+++ b/app/assets/stylesheets/scholarsphere/typography.scss
@@ -27,3 +27,14 @@ a.btn,
   text-shadow: 0 2px #fff;
   border-bottom: 1px solid;
 }
+
+/* Label and Button overrides for better contrast ratio */
+html > body .label { font-weight: normal; }
+html > body .label-success,
+html > body .btn-success { background-color: #387f38; }
+html > body .label-danger,
+html > body .btn-danger { background-color: #d33a35; }
+html > body .label-info,
+html > body .btn-info { background-color: #2c76c7; }
+html > body .label-warning,
+html > body .btn-warning { background-color: #F0AD1B; }


### PR DESCRIPTION
Adjust color ratio for text and background on labels and buttons using Bootstrap's default styles for labels and buttons. Fixes #528 