### PR TITLE
Original File Name on the File Set Show Page

### DIFF
--- a/app/views/curation_concerns/file_sets/_show_details.html.erb
+++ b/app/views/curation_concerns/file_sets/_show_details.html.erb
@@ -1,0 +1,21 @@
+<h2>File Details</h2>
+<dl class="dl-horizontal file-show-term file-show-details">
+  <dt>Depositor</dt>
+    <dd itemprop="accountablePerson" itemscope itemtype="http://schema.org/Person"><span itemprop="name"><%= link_to_profile @presenter.depositor %></span></dd>
+  <dt>Original File Name</dt>
+    <dd><%= @presenter.label %></dd>
+  <dt>Date Uploaded</dt>
+    <dd itemprop="datePublished"><%= @presenter.date_uploaded %></dd>
+  <dt>Date Modified</dt>
+    <dd itemprop="dateModified"><%= @presenter.date_modified %></dd>
+  <dt>Audit Status</dt>
+    <dd><%= @presenter.audit_status %></dd>
+  <dt>Characterization</dt>
+    <dd>
+      <% if @presenter.characterized? %>
+          <%= render 'show_characterization_details' %>
+      <% else %>
+          not yet characterized
+      <% end %>
+    </dd>
+</dl>

--- a/app/views/curation_concerns/file_sets/edit.html.erb
+++ b/app/views/curation_concerns/file_sets/edit.html.erb
@@ -14,13 +14,13 @@
   <div class="col-xs-12 col-sm-8">
     <ul class="nav nav-tabs" role="tablist">
       <li id="edit_descriptions_link" class="active">
-        <a href="#descriptions_display" data-toggle="tab"><i class="fa fa-tags"></i> Descriptions</a>
+        <a href="#descriptions_display" data-toggle="tab"><span class="fa fa-tags" aria-hidden="true"></span> Descriptions</a>
       </li>
       <li id="edit_versioning_link">
-        <a href="#versioning_display" data-toggle="tab"><i class="fa fa-sitemap"></i> Versions</a>
+        <a href="#versioning_display" data-toggle="tab"><span class="fa fa-sitemap" aria-hidden="true"></span> Versions</a>
       </li>
       <li id="edit_permissions_link">
-        <a href="#permissions_display" data-toggle="tab"><i class="fa fa-key"></i> Permissions</a>
+        <a href="#permissions_display" data-toggle="tab"><span class="fa fa-key" aria-hidden="true"></span> Permissions</a>
       </li>
     </ul>
     <div class="tab-content">


### PR DESCRIPTION
Fixes `<i>` elements per style and adds aria-hidden true. Calls presenter.label to get the original file name. Fixes #547 