### PR TITLE
Fixes alignment of number and work title in search results

### DIFF
--- a/app/views/catalog/_document.html.erb
+++ b/app/views/catalog/_document.html.erb
@@ -1,0 +1,3 @@
+<li id="document_<%= document.to_param %>" class="document <%= render_document_class document %>" itemscope itemtype="<%= document.itemtype %>">
+  <%= render_document_partials document, blacklight_config.view_config(document_index_view_type).partials, document_counter: document_counter %>
+</li>

--- a/app/views/catalog/_index_list_default.html.erb
+++ b/app/views/catalog/_index_list_default.html.erb
@@ -1,0 +1,14 @@
+  <div class="col-sm-9">
+    <table class="table">
+      <% doc_presenter = index_presenter(document) %>
+      <% index_fields(document).each do |field_name, field| -%>
+          <% if should_render_index_field? document, field %>
+              <tr>
+                <th><span class="attribute-label h4"><%= render_index_field_label document, field: field_name %></span></th>
+                <td><%= doc_presenter.field_value field_name %></td>
+              </tr>
+          <% end %>
+      <% end %>
+    </table>
+  </div>
+</div>

--- a/app/views/catalog/_thumbnail_list_default.html.erb
+++ b/app/views/catalog/_thumbnail_list_default.html.erb
@@ -1,0 +1,4 @@
+<div class="row">
+  <div class="col-sm-3">
+    <%= render_thumbnail_tag document %>
+  </div>


### PR DESCRIPTION
Overrides the render_document_partials to move the `<h2>` out of the Bootstrap row to align the work title with the numbered list number. Fixes #581 


![screen shot 2017-01-30 at 3 54 59 pm](https://cloud.githubusercontent.com/assets/4163828/22441288/c54a5e9a-e704-11e6-80d5-41532120a918.png)
