### PR TITLE
Adding the ability to set the system to read only mode

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -83,9 +83,14 @@ class ApplicationController < ActionController::Base
     end
 
     def has_access?
-      return if current_user && current_user.ldap_exist?
-      logger.error "User: `#{current_user.user_key}' does not exist in ldap"
-      render template: '/error/401', layout: "error", formats: [:html], status: 401
+      return if current_user && current_user.ldap_exist? && !ReadOnly.read_only?
+      if ReadOnly.read_only?
+        @announcement = ReadOnly.announcement_text
+        render template: '/error/read_only', layout: "homepage", formats: [:html], status: 503
+      else
+        logger.error "User: `#{current_user.user_key}' does not exist in ldap"
+        render template: '/error/401', layout: "error", formats: [:html], status: 401
+      end
     end
 
     def filtered_flash_messages

--- a/app/services/read_only.rb
+++ b/app/services/read_only.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+class ReadOnly
+  class << self
+    def read_only?
+      ScholarSphere::Application.config.respond_to?(:read_only) && ScholarSphere::Application.config.read_only
+    end
+
+    def announcement_text
+      homepage_text.blank? ? default_read_only_announcement : homepage_text
+    end
+
+    private
+
+      def homepage_text
+        block = ContentBlock.find_by(name: 'annoucement_text')
+        return "" unless block
+        block.value.html_safe
+      end
+
+      def default_read_only_announcement
+        'The system is currently in read only mode for maintenance. Please try again later to upload or modify your ScholarSphere content.'
+      end
+  end
+end

--- a/app/views/error/read_only.html.erb
+++ b/app/views/error/read_only.html.erb
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="<%= t("sufia.document_language") %>">
+<head>
+  <title>Read Only</title>
+</head>
+<body>
+<h1>Read Only</h1>
+<div id="announcement" class="row">
+  <%= @announcement %>
+</div>
+</body>
+</html>

--- a/config/application.rb
+++ b/config/application.rb
@@ -138,5 +138,8 @@ module ScholarSphere
 
     # Needed for ScholarsphereLockManager, remove this when we've upgraded to Redis 2.6+
     config.statefile = '/tmp/lockmanager-state'
+
+    # Set the  system to read only mode.  Does not allow new uploads, file edits, new collections, and collection edits
+    # config.read_only = true
   end
 end

--- a/spec/features/generic_file/upload_and_delete_spec.rb
+++ b/spec/features/generic_file/upload_and_delete_spec.rb
@@ -15,18 +15,10 @@ describe 'Generic File uploading and deletion:', type: :feature do
       sign_in_with_js(current_user)
     end
 
-    context 'the user agreement' do
-      before do
-        Sufia::Engine.routes.url_helpers.new_generic_file_path
-      end
-      it "does not show Sufia's user agreement" do
-        expect(page).not_to have_content("Sufia's Deposit Agreement")
-      end
-    end
-
     context 'user needs help' do
       before do
         visit Sufia::Engine.routes.url_helpers.new_generic_file_path
+        expect(page).not_to have_content("Sufia's Deposit Agreement")
         expect(page).to have_content "Agree to the deposit agreement and then select files.  Press the Start Upload Button once all files have been selected"
         check 'terms_of_service'
         attach_file('files[]', test_file_path(filename), visible: false)

--- a/spec/features/read_only_spec.rb
+++ b/spec/features/read_only_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+require 'feature_spec_helper'
+
+describe 'Read only system', type: :feature do
+  let(:current_user) { create(:user) }
+  let(:file) { create(:file, depositor: current_user.login) }
+  let(:collection) { create(:collection, depositor: current_user.login) }
+
+  before do
+    sign_in(current_user)
+    allow(ScholarSphere::Application.config).to receive(:read_only).and_return(true)
+  end
+
+  specify 'I cannot access the upload page' do
+    visit Sufia::Engine.routes.url_helpers.new_generic_file_path
+    expect(page).to have_content 'Read Only'
+    expect(page).not_to have_content 'Upload'
+    visit Hydra::Collections::Engine.routes.url_helpers.new_collection_path
+    expect(page).to have_content 'Read Only'
+    expect(page).not_to have_content 'Create Collection'
+    visit Sufia::Engine.routes.url_helpers.edit_generic_file_path(file.id)
+    expect(page).to have_content 'Read Only'
+    expect(page).not_to have_content 'Edit'
+    visit Hydra::Collections::Engine.routes.url_helpers.edit_collection_path(collection.id)
+    expect(page).to have_content 'Read Only'
+    expect(page).not_to have_content 'Edit Collection'
+  end
+end

--- a/spec/services/read_only_spec.rb
+++ b/spec/services/read_only_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe ReadOnly do
+  describe "#read_only?" do
+    subject { described_class.read_only? }
+    context "configuration not set" do
+      before do
+        allow(ScholarSphere::Application.config).to receive(:respond_to?).with(:read_only).and_return(false)
+      end
+      it { is_expected.to be_falsey }
+    end
+
+    context "read only flag false" do
+      before do
+        allow(ScholarSphere::Application.config).to receive(:read_only).and_return(false)
+      end
+      it { is_expected.to be_falsey }
+    end
+
+    context "read only flag true" do
+      before do
+        allow(ScholarSphere::Application.config).to receive(:read_only).and_return(true)
+      end
+      it { is_expected.to be_truthy }
+    end
+  end
+
+  describe "#announcement_text" do
+    subject { described_class.announcement_text }
+    before do
+      allow(ContentBlock).to receive(:find_by).and_return(content_block)
+    end
+
+    context "no homepage announcement" do
+      let(:content_block) { instance_double ContentBlock, value: '' }
+      it { is_expected.to eq("The system is currently in read only mode for maintenance. Please try again later to upload or modify your ScholarSphere content.") }
+    end
+
+    context "homepage announcement" do
+      let(:content_block) { instance_double ContentBlock, value: 'Announcment' }
+      it { is_expected.to eq('Announcment') }
+    end
+  end
+end

--- a/spec/support/not_read_only.rb
+++ b/spec/support/not_read_only.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+RSpec.configure do |config|
+  config.before do
+    allow(ScholarSphere::Application.config).to receive(:read_only).and_return(false)
+  end
+end


### PR DESCRIPTION
This will allow users to continue to view the system while not allowing for new Files & Collections, and updates to existing Files & Collections

The read only page will either show a default message, or show the announcement block from the home page.

Default:
![screen shot 2017-02-01 at 11 38 33 am](https://cloud.githubusercontent.com/assets/1599081/22516302/63a00472-e873-11e6-9b3c-fd281b6f383e.png)

Home Page Announcement:
![screen shot 2017-02-01 at 11 40 15 am](https://cloud.githubusercontent.com/assets/1599081/22516261/3d9f2532-e873-11e6-8ec8-cf92c88b9464.png)
