### PR TITLE
Better Heading Hierarchy for Search Results

### DIFF
--- a/app/assets/stylesheets/scholarsphere/search_results.scss
+++ b/app/assets/stylesheets/scholarsphere/search_results.scss
@@ -1,0 +1,1 @@
+.inline-block { display: inline-block; }

--- a/app/assets/stylesheets/scholarsphere/typography.scss
+++ b/app/assets/stylesheets/scholarsphere/typography.scss
@@ -1,7 +1,8 @@
 /* Needs to be overly specific to override Bootstrap styles coming from 3 gems */
 
 html > body h1,
-html > body h2 {
+html > body h2,
+html > body h3 {
   font-weight: 300;
 }
 
@@ -22,7 +23,7 @@ a.btn,
 .visibility-link { text-decoration: none; }
 
 /* Overrides the heavy default underline on H2 titles in the search */
-.blacklight-genericwork h2 > a {
+.blacklight-genericwork h3 > a {
   text-decoration: none;
   text-shadow: 0 2px #fff;
   border-bottom: 1px solid;

--- a/app/views/catalog/_index_header_list_default.html.erb
+++ b/app/views/catalog/_index_header_list_default.html.erb
@@ -1,0 +1,1 @@
+<h3><%= link_to document.title_or_label, document %></h3>

--- a/app/views/catalog/_per_page_widget.html.erb
+++ b/app/views/catalog/_per_page_widget.html.erb
@@ -1,0 +1,16 @@
+<% if show_sort_and_per_page? and !blacklight_config.per_page.blank? %>
+    <fieldset class="inline-block">
+      <legend class="sr-only"><%= t('blacklight.search.per_page.title') %></legend>
+      <div id="per_page-dropdown" class="btn-group">
+        <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+          <%= t(:'blacklight.search.per_page.button_label', :count => current_per_page) %> <span class="caret"></span>
+        </button>
+
+        <ul class="dropdown-menu" role="menu">
+          <%- per_page_options_for_select.each do |(label, count)| %>
+              <li><%= link_to(label, url_for(search_state.params_for_search(per_page: count))) %></li>
+          <%- end -%>
+        </ul>
+      </div>
+    </fieldset>
+<% end %>

--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -1,0 +1,28 @@
+<% provide :page_title, "Search Results | ScholarSphere" %>
+
+<h1 class="sr-only"><%= t('blacklight.search.search_results_header') %></h1>
+
+<% content_for(:head) do -%>
+    <%= render_opensearch_response_metadata %>
+    <%= rss_feed_link_tag %>
+    <%= atom_feed_link_tag %>
+<% end %>
+
+<% content_for(:container_header) do -%>
+    <%= render 'constraints' %>
+<% end %>
+
+
+<%= render 'search_header' %>
+
+<h2 class="sr-only"><%= t('blacklight.search.search_results') %></h2>
+
+<%- if @response.empty? %>
+    <%= render "zero_results" %>
+<%- elsif render_grouped_response? %>
+    <%= render_grouped_document_index %>
+<%- else %>
+    <%= render_document_index %>
+<%- end %>
+
+<%= render 'results_pagination' %>

--- a/app/views/catalog/_sort_widget.html.erb
+++ b/app/views/catalog/_sort_widget.html.erb
@@ -1,0 +1,16 @@
+<% if show_sort_and_per_page? and !active_sort_fields.blank? %>
+    <fieldset class="inline-block">
+      <legend class="sr-only"><%= t('blacklight.search.sort.controls') %></legend>
+      <div id="sort-dropdown" class="btn-group">
+        <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+          <%= t('blacklight.search.sort.label', :field => current_sort_field.label) %> <span class="caret"></span>
+        </button>
+
+        <ul class="dropdown-menu" role="menu">
+          <%- active_sort_fields.each do |sort_key, field_config| %>
+              <li><%= link_to(field_config.label, url_for(search_state.params_for_search(sort: sort_key))) %></li>
+          <%- end -%>
+        </ul>
+      </div>
+    </fieldset>
+<% end %>

--- a/app/views/catalog/_view_type_group.html.erb
+++ b/app/views/catalog/_view_type_group.html.erb
@@ -1,0 +1,15 @@
+<% if show_sort_and_per_page? and has_alternative_views? -%>
+    <fieldset class="inline-block">
+      <legend class="sr-only"><%= t('blacklight.search.view_title') %></legend>
+      <div class="view-type">
+        <div class="view-type-group btn-group">
+          <%  document_index_views.each do |view, config| %>
+              <%= link_to url_for(search_state.to_h.merge(view: view)), title: view_label(view), class: "btn btn-default view-type-#{ view.to_s.parameterize } #{"active" if document_index_view_type == view}" do %>
+                  <%= render_view_type_group_icon view %>
+                  <span class="caption"><%= view_label(view) %></span>
+              <% end %>
+          <% end %>
+        </div>
+      </div>
+    </fieldset>
+<% end %>

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -1,0 +1,6 @@
+<div id="content" class="col-sm-8 col-sm-push-4 col-md-9 col-md-push-3">
+  <%= render 'search_results' %>
+</div>
+<div id="sidebar" class="col-sm-4 col-sm-pull-8 col-md-3 col-md-pull-9">
+  <%= render 'search_sidebar' %>
+</div>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -1,3 +1,8 @@
 en:
   blacklight:
     application_name: 'Blacklight'
+    search:
+      search_results: 'Listing of Search Results'
+      search_results_header: 'Search Results'
+      sort:
+        controls: 'Sort Results'

--- a/spec/features/catalog_search_spec.rb
+++ b/spec/features/catalog_search_spec.rb
@@ -27,7 +27,12 @@ describe 'catalog searching', type: :feature do
     end
 
     # All fields are displayed in the list view
-    expect(page).to have_content('Search Results')
+    expect(page).to have_selector('h1', text: "Search Results")
+    expect(page).to have_selector('fieldset')
+    expect(page).to have_selector('legend', text: "Sort Results")
+    expect(page).to have_selector('legend', text: "Number of results to display per page")
+    expect(page).to have_selector('legend', text: "View results as:")
+    expect(page).to have_selector('h2', text: "Listing of Search Results")
     within("#search-results") do
       expect(page).to have_link(work1.title.first)
       expect(page).to have_content(work1.description.first)


### PR DESCRIPTION
Swaps the order of the columns visually, adds H1 and H2 values in yml, hard codes page title. Updates the work header for better hierarchy, adjusts H3 weight, makes H1 and H2 sr-only. Hops onto the catalog search feature test to check for the presence of new HTML for better accessibility.

Fixes #582 