### PR TITLE
Toolbar displays when not logged in on small screens

### DIFF
--- a/app/views/_masthead.html.erb
+++ b/app/views/_masthead.html.erb
@@ -12,6 +12,7 @@
         </div>
       </div>
     </div>
+    <% if user_signed_in? %>
     <div class="row ss-toolbar">
       <div class="col-xs-12">
         <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#top-navbar-collapse" aria-expanded="false">
@@ -25,5 +26,6 @@
         <%= render partial: '/toolbar' %>
       </div>
     </div>
+    <% end %>
   </div>
 </nav>


### PR DESCRIPTION
If a user is signed in, then they get the collapsable toolbar. Otherwise don't render the toolbar. Fixes #484 