### PR TITLE
Removing the sort by date modified and allowing dates to be displayed…

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -18,14 +18,18 @@ class CatalogController < ApplicationController
   end
 
   def self.update_show_fields(config, fields)
-    fields.each do |key, field_config|
-      config.add_show_field solr_name(key.to_s, :stored_searchable), label: field_config.label
-    end
+    set_config(:add_show_field, config, fields)
   end
 
   def self.update_index_fields(config, fields)
+    set_config(:add_index_field, config, fields)
+  end
+
+  def self.set_config(method, config, fields)
     fields.each do |key, field_config|
-      config.add_index_field solr_name(key.to_s, :stored_searchable), label: field_config.label
+      solr_type = field_config.opts.fetch(:index_solr_type, :stored_searchable)
+      type = field_config.opts.fetch(:index_type, :text_en)
+      config.send(method, solr_name(key.to_s, solr_type, type: type), label: field_config.label)
     end
   end
 
@@ -287,8 +291,6 @@ class CatalogController < ApplicationController
     config.add_sort_field "score desc, #{uploaded_field} desc", label: "relevance \u25BC"
     config.add_sort_field "#{uploaded_field} desc", label: "date uploaded \u25BC"
     config.add_sort_field "#{uploaded_field} asc", label: "date uploaded \u25B2"
-    config.add_sort_field "#{modified_field} desc", label: "date modified \u25BC"
-    config.add_sort_field "#{modified_field} asc", label: "date modified \u25B2"
 
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.

--- a/app/services/field_configurator.rb
+++ b/app/services/field_configurator.rb
@@ -16,8 +16,8 @@ class FieldConfigurator
   def self.index_fields
     { description: FieldConfig.new("Description") }.merge(
       common_fields).merge(contributor: FieldConfig.new("Contributor"),
-                           date_uploaded: FieldConfig.new("Date Uploaded"),
-                           date_modified: FieldConfig.new("Date Modified"),
+                           date_uploaded: FieldConfig.new(label: "Date Uploaded", index_solr_type: :stored_sortable, index_type: :date),
+                           date_modified: FieldConfig.new(label: "Date Modified", index_solr_type: :stored_sortable, index_type: :date),
                            date_created: FieldConfig.new("Date Created"),
                            rights: FieldConfig.new("Rights"),
                            identifier: FieldConfig.new("Identifier"))

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -22,6 +22,33 @@ describe CatalogController, type: :controller do
   # Default depositor if none is supplied
   let(:user) { "user" }
 
+  describe "config" do
+    describe "index_fields" do
+      subject { described_class.blacklight_config.index_fields.keys }
+      it { is_expected.to contain_exactly("based_near_tesim", "date_modified_dtsi", "date_uploaded_dtsi",
+                                          "description_tesim", "file_format_tesim", "identifier_tesim", "keyword_tesim",
+                                          "language_tesim", "publisher_tesim", "resource_type_tesim", "rights_tesim",
+                                          "subject_tesim", "contributor_tesim", "creator_tesim", "date_created_tesim")
+      }
+    end
+    describe "show_fields" do
+      subject { described_class.blacklight_config.show_fields.keys }
+      it { is_expected.to contain_exactly("depositor_tesim", "based_near_tesim", "date_modified_dtsi", "date_uploaded_dtsi",
+                                          "description_tesim", "file_format_tesim", "identifier_tesim", "keyword_tesim",
+                                          "language_tesim", "publisher_tesim", "resource_type_tesim", "rights_tesim",
+                                          "subject_tesim", "contributor_tesim", "creator_tesim", "date_created_tesim")
+      }
+    end
+    describe "facet_fields" do
+      subject { described_class.blacklight_config.facet_fields.keys }
+      it { is_expected.to contain_exactly("based_near_sim", "collection_sim", "has_model_ssim",
+                                          "file_format_sim", "keyword_sim",
+                                          "language_sim", "publisher_sim", "resource_type_sim",
+                                          "subject_sim", "creator_sim")
+      }
+    end
+  end
+
   describe "#index" do
     before do
       ActiveFedora::Cleaner.cleanout_solr
@@ -35,103 +62,103 @@ describe CatalogController, type: :controller do
         xhr :get, :index, q: "pdf"
         expect(response).to be_success
         expect(response).to render_template('catalog/index')
-        expect(assigns(:document_list).count).to eql(1)
+        expect(assigns(:document_list).count).to be(1)
         expect(assigns(:document_list)[0].fetch(solr_field("title"))[0]).to eql('Test Document PDF')
       end
       it "finds a file by title" do
         xhr :get, :index, q: "titletitle"
         expect(response).to be_success
         expect(response).to render_template('catalog/index')
-        expect(assigns(:document_list).count).to eql(1)
+        expect(assigns(:document_list).count).to be(1)
         expect(assigns(:document_list)[0].fetch(solr_field("title"))[0]).to eql('titletitle')
       end
       it "finds a file by keyword" do
         xhr :get, :index, q: "tagtag"
         expect(response).to be_success
         expect(response).to render_template('catalog/index')
-        expect(assigns(:document_list).count).to eql(1)
+        expect(assigns(:document_list).count).to be(1)
         expect(assigns(:document_list)[0].fetch(solr_field("keyword"))[0]).to eql('tagtag')
       end
       it "finds a file by subject" do
         xhr :get, :index, q: "subjectsubject"
         expect(response).to be_success
         expect(response).to render_template('catalog/index')
-        expect(assigns(:document_list).count).to eql(1)
+        expect(assigns(:document_list).count).to be(1)
         expect(assigns(:document_list)[0].fetch(solr_field("subject"))[0]).to eql('subjectsubject')
       end
       it "finds a file by creator" do
         xhr :get, :index, q: "creatorcreator"
         expect(response).to be_success
         expect(response).to render_template('catalog/index')
-        expect(assigns(:document_list).count).to eql(1)
+        expect(assigns(:document_list).count).to be(1)
         expect(assigns(:document_list)[0].fetch(solr_field("creator"))[0]).to eql('creatorcreator')
       end
       it "finds a file by contributor" do
         xhr :get, :index, q: "contributorcontributor"
         expect(response).to be_success
         expect(response).to render_template('catalog/index')
-        expect(assigns(:document_list).count).to eql(1)
+        expect(assigns(:document_list).count).to be(1)
         expect(assigns(:document_list)[0].fetch(solr_field("contributor"))[0]).to eql('contributorcontributor')
       end
       it "finds a file by publisher" do
         xhr :get, :index, q: "publisherpublisher"
         expect(response).to be_success
         expect(response).to render_template('catalog/index')
-        expect(assigns(:document_list).count).to eql(1)
+        expect(assigns(:document_list).count).to be(1)
         expect(assigns(:document_list)[0].fetch(solr_field("publisher"))[0]).to eql('publisherpublisher')
       end
       it "finds a file by based_near" do
         xhr :get, :index, q: "based_nearbased_near"
         expect(response).to be_success
         expect(response).to render_template('catalog/index')
-        expect(assigns(:document_list).count).to eql(1)
+        expect(assigns(:document_list).count).to be(1)
         expect(assigns(:document_list)[0].fetch(solr_field("based_near"))[0]).to eql('based_nearbased_near')
       end
       it "finds a file by language" do
         xhr :get, :index, q: "languagelanguage"
         expect(response).to be_success
         expect(response).to render_template('catalog/index')
-        expect(assigns(:document_list).count).to eql(1)
+        expect(assigns(:document_list).count).to be(1)
         expect(assigns(:document_list)[0].fetch(solr_field("language"))[0]).to eql('languagelanguage')
       end
       it "finds a file by resource_type" do
         xhr :get, :index, q: "resource_typeresource_type"
         expect(response).to be_success
         expect(response).to render_template('catalog/index')
-        expect(assigns(:document_list).count).to eql(1)
+        expect(assigns(:document_list).count).to be(1)
         expect(assigns(:document_list)[0].fetch(solr_field("resource_type"))[0]).to eql('resource_typeresource_type')
       end
       it "finds a file by format_label" do
         xhr :get, :index, q: "format_labelformat_label"
         expect(response).to be_success
         expect(response).to render_template('catalog/index')
-        expect(assigns(:document_list).count).to eql(1)
+        expect(assigns(:document_list).count).to be(1)
         expect(assigns(:document_list)[0].fetch(solr_field("file_format"))[0]).to eql('plain (format_labelformat_label)')
       end
       it "finds a file by description" do
         xhr :get, :index, q: "descriptiondescription"
         expect(response).to be_success
         expect(response).to render_template('catalog/index')
-        expect(assigns(:document_list).count).to eql(1)
+        expect(assigns(:document_list).count).to be(1)
         expect(assigns(:document_list)[0].fetch(solr_field("description"))[0]).to eql('descriptiondescription')
       end
       it "finds a file by full_text" do
         xhr :get, :index, q: "full_textfull_text"
         expect(response).to be_success
         expect(response).to render_template('catalog/index')
-        expect(assigns(:document_list).count).to eql(1)
+        expect(assigns(:document_list).count).to be(1)
       end
       it "finds a file by depositor" do
         xhr :get, :index, q: user
         expect(response).to be_success
         expect(response).to render_template('catalog/index')
-        expect(assigns(:document_list).count).to eql(3)
+        expect(assigns(:document_list).count).to be(3)
       end
       it "finds a file by depositor in advanced search" do
         xhr :get, :index, depositor: user, search_field: "advanced"
         expect(response).to be_success
         expect(response).to render_template('catalog/index')
-        expect(assigns(:document_list).count).to eql(3)
+        expect(assigns(:document_list).count).to be(3)
       end
     end
     describe "facet search" do
@@ -141,7 +168,7 @@ describe CatalogController, type: :controller do
       it "finds facet files" do
         expect(response).to be_success
         expect(response).to render_template('catalog/index')
-        expect(assigns(:document_list).count).to eql(1)
+        expect(assigns(:document_list).count).to be(1)
       end
     end
     describe "user with group search" do
@@ -152,7 +179,7 @@ describe CatalogController, type: :controller do
       it "finds facet files" do
         expect(response).to be_success
         expect(response).to render_template('catalog/index')
-        expect(assigns(:document_list).count).to eql(1)
+        expect(assigns(:document_list).count).to be(1)
       end
     end
   end

--- a/spec/features/dashboard/dashboard_works_spec.rb
+++ b/spec/features/dashboard/dashboard_works_spec.rb
@@ -187,10 +187,10 @@ describe 'Dashboard Works', type: :feature do
 
     describe 'Sorting:' do
       specify 'Items are sorted correctly' do
-        find('#sort').find(:xpath, 'option[4]').select_option
+        find('#sort').find(:xpath, 'option[2]').select_option
         click_button("Refresh")
         expect(page).to have_content(file.title.first)
-        find('#sort').find(:xpath, 'option[5]').select_option
+        find('#sort').find(:xpath, 'option[3]').select_option
         click_button("Refresh")
         expect(page).to have_content(file.title.first)
       end


### PR DESCRIPTION
… in the search results

The reason the dates were not being displayed is that the code was looking for date_tesim instead of date_dtsi which is how the date_uploaded and the date_modified are stored in solr.