### PR TITLE
Cleanup creator and other facets prior to indexing

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -165,3 +165,4 @@ RSpec/DescribeClass:
     - 'spec/rake/**/*'
     - 'spec/config/**/*'
     - 'spec/models/batch_spec.rb'
+    - 'spec/features/**/*'

--- a/app/indexers/work_indexer.rb
+++ b/app/indexers/work_indexer.rb
@@ -7,6 +7,7 @@ class WorkIndexer < Sufia::WorkIndexer
       solr_doc[Solrizer.solr_name('file_format', :stored_searchable)] = representative.file_format
       solr_doc[Solrizer.solr_name('file_format', :facetable)] = representative.file_format
       solr_doc[Solrizer.solr_name(:bytes, CurationConcerns::CollectionIndexer::STORED_LONG)] = object.bytes
+      SolrDocumentGroomer.call(solr_doc)
     end
   end
 

--- a/app/presenters/work_show_presenter.rb
+++ b/app/presenters/work_show_presenter.rb
@@ -33,6 +33,13 @@ class WorkShowPresenter < Sufia::WorkShowPresenter
     @representative_presenter ||= build_representative_presenter
   end
 
+  # @return [Array<Hash>] maps a facet's entered value from the user to its cleaned value
+  # @example { original_value => cleaned_value }
+  def facet_mapping(field)
+    config = FieldConfigurator.facet_fields[field]
+    send(field).zip(FacetValueCleaningService.call(send(field), config)).to_h
+  end
+
   private
 
     # Override to add rows parameter

--- a/app/renderers/translated_facet_attribute_renderer.rb
+++ b/app/renderers/translated_facet_attribute_renderer.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+# Override CurationConcerns::Renderers::FacetedAttributeRenderer so we can pass different values
+# for facets. This allows us to display a faceted search link using the text that the user
+# originally entered while using the normalized text that was created when the facet was
+# "cleaned" using the SolrDocumentGroomer.
+class TranslatedFacetAttributeRenderer < CurationConcerns::Renderers::FacetedAttributeRenderer
+  private
+
+    def li_value(value)
+      link_to(ERB::Util.h(value), search_path(value_for_facet(value)))
+    end
+
+    def value_for_facet(value)
+      return value unless options.key?(:mapping)
+      options[:mapping][value]
+    end
+end

--- a/app/services/facet_value_cleaning_service.rb
+++ b/app/services/facet_value_cleaning_service.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+class FacetValueCleaningService
+  # @param [Array<String>] values
+  # @param [FieldConfig] config of the field that we need to process the values
+  # @return [Array<String>] the processed values
+  def self.call(values, config)
+    cleaners = config.opts.fetch(:facet_cleaners, [])
+    return values unless cleaners.present? && values.is_a?(Array)
+
+    if cleaners.include?(:titleize)
+      values.map { |name| name.titleize.gsub(/[\.\,]/, "") }
+    elsif cleaners.include?(:downcase)
+      values.map { |name| name.downcase.gsub(/[\.\,]/, "") }
+    else
+      values
+    end
+  end
+end

--- a/app/services/field_configurator.rb
+++ b/app/services/field_configurator.rb
@@ -3,12 +3,12 @@ class FieldConfigurator
   def self.common_fields
     {
       resource_type: FieldConfig.new("Resource Type"),
-      creator: FieldConfig.new("Creator"),
-      keyword:  FieldConfig.new("Keyword"),
+      creator: FieldConfig.new(label: "Creator", facet_cleaners: [:titleize]),
+      keyword:  FieldConfig.new(label: "Keyword", facet_cleaners: [:downcase]),
       subject: FieldConfig.new("Subject"),
       language: FieldConfig.new("Language"),
       based_near: FieldConfig.new("Location"),
-      publisher: FieldConfig.new("Publisher"),
+      publisher: FieldConfig.new(label: "Publisher", facet_cleaners: [:titleize]),
       file_format: FieldConfig.new("File Format")
     }
   end

--- a/app/services/solr_document_groomer.rb
+++ b/app/services/solr_document_groomer.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+# Cleans up existing fields in the solr document before it is sent on for indexing
+class SolrDocumentGroomer
+  attr_reader :document
+
+  # @param [SolrDocument, Hash]
+  # @return [SolrDocument, Hash]
+  def self.call(document)
+    new(document).groom
+  end
+
+  def initialize(document)
+    @document = document
+  end
+
+  def groom
+    FieldConfigurator.facet_fields.each do |field, config|
+      cleaned_fields = FacetValueCleaningService.call(document.fetch(Solrizer.solr_name(field.to_s, :facetable), []), config)
+      document[Solrizer.solr_name(field.to_s, :facetable)] = cleaned_fields
+    end
+  end
+end

--- a/app/views/curation_concerns/base/_attribute_rows.html.erb
+++ b/app/views/curation_concerns/base/_attribute_rows.html.erb
@@ -1,11 +1,19 @@
-<%= presenter.attribute_to_html(:creator, render_as: :faceted) %>
+<%= presenter.attribute_to_html(:creator, render_as: :translated_facet,
+                                          mapping: presenter.facet_mapping(:creator)) %>
+
 <%= presenter.attribute_to_html(:contributor, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:admin_set, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:subject, render_as: :faceted) %>
-<%= presenter.attribute_to_html(:publisher, render_as: :faceted) %>
+
+<%= presenter.attribute_to_html(:publisher, render_as: :translated_facet,
+                                          mapping: presenter.facet_mapping(:publisher)) %>
+
 <%= presenter.attribute_to_html(:language, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:identifier, render_as: :linked, search_field: 'identifier_tesim') %>
-<%= presenter.attribute_to_html(:keyword, render_as: :faceted) %>
+
+<%= presenter.attribute_to_html(:keyword, render_as: :translated_facet,
+                                          mapping: presenter.facet_mapping(:keyword)) %>
+
 <%= presenter.attribute_to_html(:date_created, render_as: :linked, search_field: 'date_created_tesim') %>
 <%= presenter.attribute_to_html(:based_near, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:related_url, render_as: :external_link) %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -46,6 +46,7 @@ module ScholarSphere
     config.autoload_paths << Rails.root.join('lib')
     config.autoload_paths += %W(#{config.root}/app/models/datastreams)
     config.autoload_paths += %W(#{config.root}/app/forms/concerns)
+    config.autoload_paths += %W(#{config.root}/app/renderers)
 
     config.i18n.enforce_available_locales = true
 

--- a/spec/features/facet_spec.rb
+++ b/spec/features/facet_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+require 'feature_spec_helper'
+
+describe "Catalog facets" do
+  let(:work1) { build(:public_work, id: "1",
+                                    contributor: ["Contri B. Utor"],
+                                    publisher: ["Pu B. Lisher"],
+                                    keyword: ["Key. Word."],
+                                    creator: ["Patricia M. Hswe"]) }
+  let(:work2) { build(:public_work, id: "2",
+                                    contributor: ["CONTRI B. UTOR"],
+                                    publisher: ["PU B. LISHER"],
+                                    keyword: ["KEY. WORD."],
+                                    creator: ["PATRICIA M. HSWE"]) }
+  let(:work3) { build(:public_work, id: "3",
+                                    contributor: ["Contri B Utor"],
+                                    publisher: ["Pu B Lisher"],
+                                    keyword: ["Key Word"],
+                                    creator: ["Patricia M Hswe"]) }
+
+  before do
+    index_works_and_collections(work1, work2, work3)
+    visit '/catalog'
+    click_link("Creator")
+  end
+
+  it "displays case and punctuation-corrected facets" do
+    within("div#facet-creator_sim") do
+      expect(page).not_to have_content("Patricia M. Hswe")
+      expect(page).to have_content("Patricia M Hswe")
+      expect(page).to have_selector("span.facet-count", text: "(3)")
+    end
+
+    # Pending: #659
+    # within("div#facet-contributor_sim") do
+    #   expect(page).not_to have_content("Contri B. Utor")
+    #   expect(page).to have_content("Contri B Utor")
+    #   expect(page).to have_selector("span.facet-count", text: "(3)")
+    # end
+
+    within("div#facet-publisher_sim") do
+      expect(page).not_to have_content("Pu B. Lisher")
+      expect(page).to have_content("Pu B Lisher")
+      expect(page).to have_selector("span.facet-count", text: "(3)")
+    end
+    within("div#facet-keyword_sim") do
+      expect(page).not_to have_content("Key. Word.")
+      expect(page).to have_content("key word")
+      expect(page).to have_selector("span.facet-count", text: "(3)")
+    end
+
+    visit("/concern/generic_works/#{work2.id}")
+
+    click_link("PATRICIA M. HSWE")
+    within("div#search-results") do
+      expect(page).to have_content("Patricia M. Hswe")
+      expect(page).to have_content("Patricia M Hswe")
+      expect(page).to have_content("PATRICIA M. HSWE")
+    end
+
+    visit("/concern/generic_works/#{work2.id}")
+    click_link("PU B. LISHER")
+    within("div#search-results") do
+      expect(page).to have_content("Pu B. Lisher")
+      expect(page).to have_content("Pu B Lisher")
+      expect(page).to have_content("PU B. LISHER")
+    end
+
+    visit("/concern/generic_works/#{work2.id}")
+    click_link("KEY. WORD.")
+    within("div#search-results") do
+      expect(page).to have_content("Key Word")
+      expect(page).to have_content("Key. Word.")
+      expect(page).to have_content("KEY. WORD.")
+    end
+
+    # Pending: #659?
+    # visit("/concern/generic_works/#{work2.id}")
+    # click_link("CONTRI B. UTOR")
+    # within("div#search-results") do
+    #   expect(page).to have_content("Contri B Utor")
+    #   expect(page).to have_content("Contri B. Utor")
+    #   expect(page).to have_content("CONTRI B. UTOR")
+    # end
+  end
+end

--- a/spec/indexers/work_indexer_spec.rb
+++ b/spec/indexers/work_indexer_spec.rb
@@ -5,7 +5,9 @@ describe WorkIndexer do
   include FactoryHelpers
 
   let(:file_set) { build(:file_set) }
-  let(:work)     { build(:work, representative: file_set) }
+  let(:work)     { build(:work, representative: file_set,
+                                creator: ["BIG. Name"],
+                                keyword: ["Bird"]) }
   let(:indexer)  { described_class.new(work) }
 
   let(:file) do
@@ -40,6 +42,13 @@ describe WorkIndexer do
         before { allow(work).to receive(:representative).and_return(nil) }
         it { is_expected.to be_nil }
       end
+    end
+
+    describe "a groomed document" do
+      it { is_expected.to include("creator_sim" => ["Big Name"]) }
+      it { is_expected.to include("creator_tesim" => ["BIG. Name"]) }
+      it { is_expected.to include("keyword_sim" => ["bird"]) }
+      it { is_expected.to include("keyword_tesim" => ["Bird"]) }
     end
   end
 end

--- a/spec/presenters/work_show_presenter_spec.rb
+++ b/spec/presenters/work_show_presenter_spec.rb
@@ -55,4 +55,10 @@ describe WorkShowPresenter do
       it { is_expected.not_to be_uploading }
     end
   end
+
+  describe "#facet_mapping" do
+    let(:work) { build(:work, creator: ["JOE SMITH"]) }
+    subject { presenter.facet_mapping(:creator) }
+    it { is_expected.to eq("JOE SMITH" => "Joe Smith") }
+  end
 end

--- a/spec/renderers/translated_facet_attribute_renderer_spec.rb
+++ b/spec/renderers/translated_facet_attribute_renderer_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe TranslatedFacetAttributeRenderer do
+  let(:field)   { :name }
+  let(:mapping) { { "BOB" => "Bob", "JESSICA" => "Jessica" } }
+
+  describe "#attribute_to_html" do
+    subject { Nokogiri::HTML(renderer.render) }
+    let(:expected) { Nokogiri::HTML(tr_content) }
+
+    context "with explicit facet values" do
+      let(:renderer) { described_class.new(field, ['BOB', 'JESSICA'], mapping: mapping) }
+
+      let(:tr_content) {%(
+        <tr><th>Name</th>
+        <td><ul class='tabular'>
+        <li class="attribute name"><a href="/catalog?f%5Bname_sim%5D%5B%5D=Bob">BOB</a></li>
+        <li class="attribute name"><a href="/catalog?f%5Bname_sim%5D%5B%5D=Jessica">JESSICA</a></li>
+        </ul></td></tr>
+      )}
+
+      it { expect(renderer).not_to be_microdata(field) }
+      it { expect(subject).to be_equivalent_to(expected) }
+    end
+
+    context "without facet values" do
+      let(:renderer) { described_class.new(field, ['BOB', 'JESSICA']) }
+
+      let(:tr_content) {%(
+        <tr><th>Name</th>
+        <td><ul class='tabular'>
+        <li class="attribute name"><a href="/catalog?f%5Bname_sim%5D%5B%5D=BOB">BOB</a></li>
+        <li class="attribute name"><a href="/catalog?f%5Bname_sim%5D%5B%5D=JESSICA">JESSICA</a></li>
+        </ul></td></tr>
+      )}
+
+      it { expect(renderer).not_to be_microdata(field) }
+      it { expect(subject).to be_equivalent_to(expected) }
+    end
+  end
+end

--- a/spec/services/field_configurator_spec.rb
+++ b/spec/services/field_configurator_spec.rb
@@ -53,6 +53,21 @@ describe FieldConfigurator do
                                        :file_format,
                                        :collection,
                                        :has_model) }
+
+    describe "creator facet" do
+      subject { described_class.facet_fields.fetch(:creator) }
+      its(:opts) { is_expected.to include(facet_cleaners: [:titleize]) }
+    end
+
+    describe "publisher facet" do
+      subject { described_class.facet_fields.fetch(:publisher) }
+      its(:opts) { is_expected.to include(facet_cleaners: [:titleize]) }
+    end
+
+    describe "keyword facet" do
+      subject { described_class.facet_fields.fetch(:keyword) }
+      its(:opts) { is_expected.to include(facet_cleaners: [:downcase]) }
+    end
   end
 
   describe "::search_fields" do

--- a/spec/services/solr_document_groomer_spec.rb
+++ b/spec/services/solr_document_groomer_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe SolrDocumentGroomer do
+  let(:work)     { create(:work, creator: ["I AM LEGEND", "Will I. Am,"], keyword: ["CAPITAL", "Title."]) }
+  let(:document) { SolrDocument.new(work.to_solr) }
+
+  describe "#groom" do
+    before { described_class.call(document) }
+
+    context "with normalized fields" do
+      subject { document.fetch("creator_sim") }
+      it { is_expected.to contain_exactly("I Am Legend", "Will I Am") }
+    end
+
+    context "with downcased fields" do
+      subject { document.fetch("keyword_sim") }
+      it { is_expected.to contain_exactly("capital", "title") }
+    end
+  end
+end


### PR DESCRIPTION
This is a solution to #632. I'm not too keen on it.

The initial solution is simple: cleanup facet terms before sending them to solr such that _ADAM WEAD_ becomes _Adam Wead_. However, it gets complicated because we have linked facets, urls that map to catalog searches with a given faceted search. Because we've changed the facet but not the actual value the user entered, the links don't work.

The solution then is to modify the links so that they display the original user's entered text, but link to the modified facet term.

This is kind of icky because we're essentially modifying twice: first on the way in (to Solr) and then on the way out again when we display. The solution below could be made more efficient, perhaps. But it strikes me that the _ideal_ solution might be to modify the user input in the first place, normalizing values upfront.

Thoughts? @cam156 @olendorf ?