### PR TITLE
Validate all our configuration files prior to deploying, ref #644

### DIFF
--- a/config/application.yml
+++ b/config/application.yml
@@ -1,10 +1,9 @@
 # Figaro configuration file
 # For further instructions see: http://sites.psu.edu/dltdocs/?p=3521
+# Each key under production is checked in Scholarsphere::Config to ensure that files on servers
+# are correct. Add or removing any keys here must include a corresponding change to
+# Scholarsphere::Config::REQUIREMENTS otherwise, the cap deploy will fail.
 #
-# Example:
-# ---
-# production:
-#   TMPDIR:
 development:
   ffmpeg_path: "ffmpeg"
   service_instance: "localhost"
@@ -16,4 +15,11 @@ test:
   virtual_host: "http://test.com/"
   stats_email: "Test email"
   google_analytics_id: "test-id"
-
+production:
+  TMPDIR: "/tmp"
+  ffmpeg_path: "ffmpeg-test"
+  service_instance: "example-prod"
+  virtual_host: "http://test.com/"
+  stats_email: "Test email"
+  google_analytics_id: "test-id"
+  derivatives_path: "path"

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -100,6 +100,16 @@ namespace :apache do
 end
 
 namespace :deploy do
+  desc "Verify yaml configuration files are present and contain the correct keys"
+  task :check_configs do
+    on roles(:all) do
+      within release_path do
+        execute :rake, "scholarsphere:config:check", "RAILS_ENV=production"
+      end
+    end
+  end
+  after :updated, :check_configs
+
   desc "Restart resque-pool"
   task :resquepoolrestart do
     on roles(:job) do

--- a/lib/scholarsphere/config.rb
+++ b/lib/scholarsphere/config.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+class Scholarsphere::Config
+  def self.check
+    config_files = Dir.glob(File.join(Rails.root, "config", "*.yml")).map { |f| ConfigFile.new(f) }
+    config_files.map(&:validate)
+  end
+
+  class ConfigFile
+    attr_reader :file
+
+    REQUIREMENTS = {
+      "application.yml" => [
+        "TMPDIR",
+        "ffmpeg_path",
+        "service_instance",
+        "virtual_host",
+        "stats_email",
+        "google_analytics_id",
+        "derivatives_path"
+      ]
+    }.freeze
+
+    def initialize(file)
+      @file = file
+    end
+
+    def keys
+      YAML.load(File.open(file)).fetch("production", {}).keys
+    end
+
+    def validate
+      return true if required_keys.empty? || required_keys.uniq.sort == keys.uniq.sort
+      raise Error, "Config file #{File.basename(file)} requires #{required_keys} but has #{keys}"
+    end
+
+    private
+
+      def required_keys
+        REQUIREMENTS.fetch(File.basename(file), [])
+      end
+  end
+
+  class Error < StandardError; end
+end

--- a/lib/tasks/scholarsphere/config.rake
+++ b/lib/tasks/scholarsphere/config.rake
@@ -1,0 +1,10 @@
+namespace :scholarsphere do
+  namespace :config do
+
+    desc "Check configuration files for completeness"
+    task check: :environment do
+      Scholarsphere::Config.check
+    end
+
+  end
+end

--- a/spec/fixtures/application.yml
+++ b/spec/fixtures/application.yml
@@ -1,0 +1,2 @@
+production:
+  missing_a_key:

--- a/spec/lib/scholarsphere/config_spec.rb
+++ b/spec/lib/scholarsphere/config_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe Scholarsphere::Config do
+  describe "::check" do
+    context "with our current configuration files" do
+      it "checks the contents of our production configuration files" do
+        expect { described_class.check }.not_to raise_error(Scholarsphere::Config::Error)
+      end
+    end
+
+    context "with a sample config file" do
+      before { allow(Dir).to receive(:glob).and_return([File.join(fixture_path, "application.yml")]) }
+
+      it "raises an error" do
+        expect { described_class.check }.to raise_error(Scholarsphere::Config::Error, start_with("Config file"))
+      end
+    end
+  end
+end

--- a/spec/rake/scholarsphere/config_spec.rb
+++ b/spec/rake/scholarsphere/config_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+require 'rails_helper'
+require 'rake'
+
+describe "scholarsphere:config" do
+  before do
+    load_rake_environment ["#{Rails.root}/lib/tasks/scholarsphere/config.rake"]
+  end
+
+  describe ":check" do
+    it "checks the validity of our production yaml files" do
+      run_task('scholarsphere:config:check')
+    end
+  end
+end


### PR DESCRIPTION
@cam156 here's a suggestion avoid future problems with our configuration files on the servers. This will check for the presence of keys in our `application.yml` on the server during the Capistrano deploy process and if the keys don't matchup, the deploy aborts.

Currently, it's only checking the one yaml file, but it could be expanded to check others. The required keys are defined in `lib/scholarsphere/config.rb` which might not be the best place.