### PR TITLE
return batches with only one item since there are no relations to be made

### DIFF
--- a/lib/scholarsphere/import/batch_translator.rb
+++ b/lib/scholarsphere/import/batch_translator.rb
@@ -6,10 +6,10 @@ module Import
 
       def build_from_json(json)
         work_ids = json['generic_file_ids']
+        return if work_ids.length < 2 # skip anything that doesn't have at least two works
         works = work_ids.map { |id| GenericWork.find(id) }
         works.each do |work|
           work.related_objects = works - [work]
-          work.save
         end
       end
 

--- a/spec/fixtures/import/batch_zg64tkabc.json
+++ b/spec/fixtures/import/batch_zg64tkabc.json
@@ -1,0 +1,9 @@
+{
+  "id": "zg64tkabc",
+  "status": [
+    "Complete"
+  ],
+  "generic_file_ids": [
+    "x920fw89s"
+  ]
+}


### PR DESCRIPTION
Additionally the save is not needed, the tests pas with or without it.

This is an effort to make the batch processing faster.  It may or may not make larger batches faster.