### PR TITLE
Adds aria-hidden=true to table header and adds scope attribute.

### DIFF
--- a/app/views/curation_concerns/base/_items.html.erb
+++ b/app/views/curation_concerns/base/_items.html.erb
@@ -6,11 +6,11 @@
   <table class="table table-striped related-files">
     <thead>
       <tr>
-        <th><%= t('.thumbnail') %></th>
-        <th><%= t('.title') %></th>
-        <th><%= t('.date_uploaded') %></th>
-        <th><%= t('.visibility') %></th>
-        <th><%= t('.actions') %></th>
+        <th scope="col" aria-hidden="true"><%= t('.thumbnail') %></th>
+        <th scope="col"><%= t('.title') %></th>
+        <th scope="col"><%= t('.date_uploaded') %></th>
+        <th scope="col"><%= t('.visibility') %></th>
+        <th scope="col"><%= t('.actions') %></th>
       </tr>
     </thead>
     <tbody>


### PR DESCRIPTION
First attempt at solving the column mismatch problem with JAWS screen reader by making the column header for thumbnails hidden just like the actual thumbnail.