### PR TITLE
Updating to the latest hydra-works to pick up a change to utilize less memory

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'active-fedora', '~> 10.3.0.rc2'
 gem 'sufia', github: 'projecthydra/sufia', branch: '7.2-migration'
 gem 'flipflop', git: 'https://github.com/jcoyne/flipflop.git', branch: 'hydra'
 gem 'curation_concerns', github: 'projecthydra/curation_concerns', ref: 'b073550'
-gem 'hydra-works', github: 'projecthydra/hydra-works', ref: 'd0e87d0'
+gem 'hydra-works', github: 'projecthydra/hydra-works', ref: 'f948eb0'
 
 # Other components
 gem 'clamav' unless ENV['TRAVIS'] == 'true'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,8 +29,8 @@ GIT
 
 GIT
   remote: git://github.com/projecthydra/hydra-works.git
-  revision: d0e87d017c20ffbecbaeda8c09b376747b9cdebc
-  ref: d0e87d0
+  revision: f948eb0fa59221fef23a9564d6c07153015c5bea
+  ref: f948eb0
   specs:
     hydra-works (0.15.0)
       hydra-derivatives (~> 3.0)
@@ -466,7 +466,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mimemagic (0.3.2)
-    mini_magick (4.6.0)
+    mini_magick (4.6.1)
     mini_portile2 (2.1.0)
     minitest (5.10.1)
     mono_logger (1.1.0)


### PR DESCRIPTION
This update to hydra-works does not read the entire file contents into memory before passing it on to fits.

I tested it out on qa by making the modification inline and it allowed a 15GB file to be characterized.

This may fix #451 in addition to #563