### PR TITLE
Update Relationships and Descriptions on Work Show to use Description List

### DIFF
--- a/app/assets/stylesheets/scholarsphere/work_show.scss
+++ b/app/assets/stylesheets/scholarsphere/work_show.scss
@@ -1,0 +1,18 @@
+.attribute-term,
+dd.attribute {
+  float: left;
+}
+
+.attribute-term {
+  clear: left;
+  width: 8em;
+}
+
+dd.attribute + dd.attribute::before {
+  content: ", ";
+}
+
+.border-bottom-1px {
+  border-bottom: 1px solid #999;
+  text-shadow: 1px 2px #fff;
+}

--- a/app/renderers/curation_concerns/renderers/attribute_renderer.rb
+++ b/app/renderers/curation_concerns/renderers/attribute_renderer.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: false
+# Overrides default renderer to replace tables with description lists for accessibility
+require "rails_autolink/helpers"
+
+module CurationConcerns
+  module Renderers
+    class AttributeRenderer
+      include ActionView::Helpers::UrlHelper
+      include ActionView::Helpers::TranslationHelper
+      include ActionView::Helpers::TextHelper
+      include ConfiguredMicrodata
+
+      attr_reader :field, :values, :options
+
+      # @param [Symbol] field
+      # @param [Array] values
+      # @param [Hash] options
+      def initialize(field, values, options = {})
+        @field = field
+        @values = values
+        @options = options
+      end
+
+      # Create definition terms and descriptions for the attribute
+      def render
+        markup = ''
+
+        return markup if !values.present? && !options[:include_empty]
+        markup << %(<dt class="attribute-term">#{label}</dt>)
+        attributes = microdata_object_attributes(field).merge(class: "attribute #{field}")
+        Array(values).each do |value|
+          markup << "<dd#{html_attributes(attributes)}>#{attribute_value_to_html(value.to_s)}</dd>"
+        end
+        # markup << %(</dd>)
+        markup.html_safe
+      end
+
+      # @return The human-readable label for this field.
+      # @note This is a central location for determining the label of a field
+      #   name. Can be overridden if more complicated logic is needed.
+      def label
+        translate(
+          :"blacklight.search.fields.show.#{field}",
+          default: [:"blacklight.search.fields.#{field}", options.fetch(:label, field.to_s.humanize)])
+      end
+
+      private
+
+        def attribute_value_to_html(value)
+          if microdata_value_attributes(field).present?
+            "<span#{html_attributes(microdata_value_attributes(field))}>#{li_value(value)}</span>"
+          else
+            li_value(value)
+          end
+        end
+
+        def html_attributes(attributes)
+          buffer = ""
+          attributes.each do |k, v|
+            buffer << " #{k}"
+            buffer << %(="#{v}") unless v.blank?
+          end
+          buffer
+        end
+
+        def li_value(value)
+          auto_link(ERB::Util.h(value))
+        end
+    end
+  end
+end

--- a/app/views/curation_concerns/base/_metadata.html.erb
+++ b/app/views/curation_concerns/base/_metadata.html.erb
@@ -1,0 +1,10 @@
+<%# Overrides the layout for mobile and small screens %>
+<div class="col-xs-12 col-sm-7">
+  <h2 class="border-bottom-1px"><%= t('.header') %></h2>
+  <dl class="<%= dom_class(presenter) %> attributes" <%= presenter.microdata_type_to_html %>>
+    <%= render 'attribute_rows', presenter: presenter %>
+    <%= presenter.attribute_to_html(:embargo_release_date, render_as: :date) %>
+    <%= presenter.attribute_to_html(:lease_expiration_date, render_as: :date) %>
+    <%= presenter.attribute_to_html(:rights, render_as: :rights) %>
+  </dl>
+</div>

--- a/app/views/curation_concerns/base/_relationships.html.erb
+++ b/app/views/curation_concerns/base/_relationships.html.erb
@@ -1,0 +1,4 @@
+<div class="col-xs-12 col-sm-5">
+  <h2 class="border-bottom-1px"><%= t('.header') %></h2>
+  <%= render 'relationships_parent_rows', presenter: presenter %>
+</div>

--- a/app/views/curation_concerns/base/_relationships_parent_row.html.erb
+++ b/app/views/curation_concerns/base/_relationships_parent_row.html.erb
@@ -1,0 +1,13 @@
+<%# Removes table code for better accessibility %>
+<h3><%= t(".label", type: type.humanize) %></h3>
+    <% if items.blank? %>
+        <p><%= t('.empty', type: type.humanize) %></p>
+    <% else %>
+        <ul class="tabular">
+          <% items.each do |item| %>
+              <li class='attribute title'>
+                <%= link_to item.title.first, [main_app, item] %>
+              </li>
+          <% end %>
+        </ul>
+    <% end %>

--- a/app/views/curation_concerns/base/_relationships_parent_row_empty.html.erb
+++ b/app/views/curation_concerns/base/_relationships_parent_row_empty.html.erb
@@ -1,0 +1,3 @@
+<%# Removes table code for better accessibility %>
+<h3><%= t(".label", type: type.humanize) %></h3>
+  <p><%= t(".empty", type: type.humanize) %></p>

--- a/app/views/curation_concerns/base/show.html.erb
+++ b/app/views/curation_concerns/base/show.html.erb
@@ -1,0 +1,32 @@
+<%# Overrides Sufia to swap the order of relationships and descriptions partials %>
+<% provide :page_title, @presenter.page_title %>
+<div itemscope itemtype="http://schema.org/CreativeWork" class="row">
+  <div class="col-xs-12">
+    <header>
+      <%= render 'work_title', presenter: @presenter %>
+    </header>
+  </div>
+  <div class="col-sm-8">
+    <%= render 'work_description', presenter: @presenter %>
+    <div class="row">
+      <%= render 'metadata', presenter: @presenter %>
+      <%= render 'relationships', presenter: @presenter %>
+    </div>
+  </div>
+  <div class="col-sm-4">
+    <%= render "show_actions", presenter: @presenter %>
+    Last modified: <%= @presenter.date_modified %>
+    <%= render 'representative_media', presenter: @presenter %>
+    <%= render 'social_media' %>
+    <%= render 'citations', presenter: @presenter %>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-sm-12">
+    <%= render 'items', presenter: @presenter %>
+    <%# TODO: we may consider adding these partials in the future %>
+    <%#= render 'sharing_with', presenter: @presenter %>
+    <%#= render 'user_activity', presenter: @presenter %>
+  </div>
+</div>

--- a/spec/features/generic_work/view_and_download_spec.rb
+++ b/spec/features/generic_work/view_and_download_spec.rb
@@ -38,7 +38,7 @@ describe GenericWork, type: :feature do
           expect(page).to have_link 'http://example.org/TheDescriptionLink/'
         end
 
-        within("table.generic_work") do
+        within("dl.generic_work") do
           expect(page).to have_link work1.related_url.first
           expect(page).to have_link work1.creator.first
           expect(page).to have_link work1.contributor.first
@@ -51,7 +51,7 @@ describe GenericWork, type: :feature do
           expect(page).to have_link work1.related_url.first
           expect(page).to have_link("Attribution 3.0 United States")
           expect(page).to have_content("1 Byte")
-          within("li.total_items") do
+          within("dd.total_items") do
             expect(page).to have_content("1")
           end
           expect(page).to have_content("Published Date")

--- a/spec/features/generic_work/work_with_many_files_spec.rb
+++ b/spec/features/generic_work/work_with_many_files_spec.rb
@@ -42,8 +42,8 @@ describe GenericWork, type: :feature do
     end
 
     it "displays the work page with all the files" do
-      within("table.attributes") do
-        expect(page).to have_selector('li.total_items', text: "100")
+      within("dl.attributes") do
+        expect(page).to have_selector('dd.total_items', text: "100")
       end
       within("table.related-files") do
         (1..100).each do |id|

--- a/spec/renderers/translated_facet_attribute_renderer_spec.rb
+++ b/spec/renderers/translated_facet_attribute_renderer_spec.rb
@@ -7,17 +7,15 @@ describe TranslatedFacetAttributeRenderer do
 
   describe "#attribute_to_html" do
     subject { Nokogiri::HTML(renderer.render) }
-    let(:expected) { Nokogiri::HTML(tr_content) }
+    let(:expected) { Nokogiri::HTML(dl_content) }
 
     context "with explicit facet values" do
       let(:renderer) { described_class.new(field, ['BOB', 'JESSICA'], mapping: mapping) }
 
-      let(:tr_content) {%(
-        <tr><th>Name</th>
-        <td><ul class='tabular'>
-        <li class="attribute name"><a href="/catalog?f%5Bname_sim%5D%5B%5D=Bob">BOB</a></li>
-        <li class="attribute name"><a href="/catalog?f%5Bname_sim%5D%5B%5D=Jessica">JESSICA</a></li>
-        </ul></td></tr>
+      let(:dl_content) {%(
+        <dt class="attribute-term">Name</dt>
+        <dd class="attribute name"><a href="/catalog?f%5Bname_sim%5D%5B%5D=Bob">BOB</a></dd>
+        <dd class="attribute name"><a href="/catalog?f%5Bname_sim%5D%5B%5D=Jessica">JESSICA</a></dd>
       )}
 
       it { expect(renderer).not_to be_microdata(field) }
@@ -27,12 +25,10 @@ describe TranslatedFacetAttributeRenderer do
     context "without facet values" do
       let(:renderer) { described_class.new(field, ['BOB', 'JESSICA']) }
 
-      let(:tr_content) {%(
-        <tr><th>Name</th>
-        <td><ul class='tabular'>
-        <li class="attribute name"><a href="/catalog?f%5Bname_sim%5D%5B%5D=BOB">BOB</a></li>
-        <li class="attribute name"><a href="/catalog?f%5Bname_sim%5D%5B%5D=JESSICA">JESSICA</a></li>
-        </ul></td></tr>
+      let(:dl_content) {%(
+        <dt class="attribute-term">Name</dt>
+        <dd class="attribute name"><a href="/catalog?f%5Bname_sim%5D%5B%5D=BOB">BOB</a></dd>
+        <dd class="attribute name"><a href="/catalog?f%5Bname_sim%5D%5B%5D=JESSICA">JESSICA</a></dd>
       )}
 
       it { expect(renderer).not_to be_microdata(field) }


### PR DESCRIPTION
Grabs the relationships partials so that we can start to override the tables with lists for relationships and descriptions.

Overrides the attribute renderer and metadata partial and swaps out table for definition lists. Fixes spec tests for by swapping out table-related code with dl.

Add Bootstrap row and columns for relationships and descriptions, adds CSS to add comma and space between inline metadata.

Swaps the columns of relationships and descriptions, adds classes for dt and dd to align them inline.