### PR TITLE
Page Titles for Works and File Sets and File Set Titles in Work Show

### DIFF
--- a/app/presenters/file_set_presenter.rb
+++ b/app/presenters/file_set_presenter.rb
@@ -13,10 +13,6 @@ class FileSetPresenter < Sufia::FileSetPresenter
     number_to_human_size(super)
   end
 
-  def page_title
-    "File | #{title.first} | File ID: #{solr_document.id} | ScholarSphere"
-  end
-
   def display_download_link?
     CurationConcerns.config.display_media_download_link
   end

--- a/app/presenters/work_show_presenter.rb
+++ b/app/presenters/work_show_presenter.rb
@@ -23,10 +23,6 @@ class WorkShowPresenter < Sufia::WorkShowPresenter
     QueuedFile.where(work_id: id).present?
   end
 
-  def page_title
-    "Work | #{title.first} | Work ID: #{solr_document.id} | ScholarSphere"
-  end
-
   # Check for member presenters before rendering the representative in CurationConcerns::WorkShowPresenter
   # @ return [FileSetPresenter, NullRepresentativePresenter]
   def representative_presenter

--- a/app/views/curation_concerns/base/show.html.erb
+++ b/app/views/curation_concerns/base/show.html.erb
@@ -1,5 +1,8 @@
-<%# Overrides Sufia to swap the order of relationships and descriptions partials %>
-<% provide :page_title, @presenter.page_title %>
+<%#
+    Overrides the CC title helper in Sufia and hard code string with interpolated values.
+    Overrides Sufia to swap the order of relationships and descriptions partials
+%>
+<% provide :page_title, "Work | #{@presenter.title.first} | Work ID: #{@presenter.id} | ScholarSphere" %>
 <div itemscope itemtype="http://schema.org/CreativeWork" class="row">
   <div class="col-xs-12">
     <header>

--- a/app/views/curation_concerns/file_sets/edit.html.erb
+++ b/app/views/curation_concerns/file_sets/edit.html.erb
@@ -1,6 +1,6 @@
 <%
   # Overrides Sufia app > views > curation_concerns > file_sets > edit.html.erb
-  # provide :page_title, curation_concern_page_title(curation_concern)
+  # hard code string with interpolated values to skip title helper from CC
 %>
 <% provide :page_title, "Edit File | #{curation_concern} | File ID: #{curation_concern.to_param} | ScholarSphere" %>
 <% provide :page_header do %>

--- a/app/views/curation_concerns/file_sets/show.html.erb
+++ b/app/views/curation_concerns/file_sets/show.html.erb
@@ -1,5 +1,5 @@
-<%# Overrides the CC title helper in Sufia and provides the wanted page title %>
-<% provide :page_title, @presenter.page_title %>
+<%# Overrides the CC title helper in Sufia and hard code string with interpolated values %>
+<% provide :page_title, "File | #{@presenter.title.first} | File ID: #{@presenter.id} | ScholarSphere" %>
 <%= render 'shared/citations' %>
 
 <div class="container-fluid">


### PR DESCRIPTION
Removes the page_title method from the file set presenter and updates the show page for the file set. Removes the page_title method from the work show presenter and adds the page title to the CC show page.