### PR TITLE
Update rubyzip to 1.2.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -662,7 +662,7 @@ GEM
       mime-types
       nokogiri
       rest-client
-    rubyzip (1.2.0)
+    rubyzip (1.2.1)
     rufus-scheduler (3.2.0)
     safe_yaml (1.0.4)
     sass (3.4.22)
@@ -846,4 +846,4 @@ DEPENDENCIES
   yaml_db
 
 BUNDLED WITH
-   1.11.2
+   1.14.5


### PR DESCRIPTION
Patches vulnerability due to https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2017-5946