### PR TITLE
Update rubyzip to 1.2.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -697,7 +697,7 @@ GEM
       multipart-post
       oauth2
     ruby-progressbar (1.8.1)
-    rubyzip (1.2.0)
+    rubyzip (1.2.1)
     rufus-scheduler (3.2.2)
     safe_yaml (1.0.4)
     sass (3.4.23)


### PR DESCRIPTION
Patches due to https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2017-5946

Note: Duplicates 536529a because a hotfix merge was not possible.