### PR TITLE
Addresses Accessibility for Label and Fieldset on Viz Widget

### DIFF
--- a/app/assets/stylesheets/scholarsphere/form.scss
+++ b/app/assets/stylesheets/scholarsphere/form.scss
@@ -1,3 +1,8 @@
 .progress-bar-complete {
   width: 100%;
 }
+
+/* Needs to be overly specific to override Bootstrap styles coming from 3 gems */
+html > body .form-progress .radio input[type="radio"] {
+  margin-left: 0;
+}

--- a/app/views/curation_concerns/base/_form_permission_under_embargo.html.erb
+++ b/app/views/curation_concerns/base/_form_permission_under_embargo.html.erb
@@ -1,0 +1,10 @@
+<fieldset>
+  <legend class="legend-save-work"><%= t('curation_concerns.visibility.legend') %></legend>
+    <p>
+      <strong>This work is under embargo.</strong> You can change the settings of the embargo here, or you can visit the <%= link_to 'Embargo Management Page', main_app.edit_embargo_path(f.object) %> to deactivate it.
+    </p>
+  <div class="form-group">
+    <input type="hidden" name="<%= f.object_name %>[visibility]" value="<%= Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO %>" />
+    <%= render "form_permission_embargo", f: f %>
+  </div>
+</fieldset>

--- a/app/views/curation_concerns/base/_form_permission_under_lease.html.erb
+++ b/app/views/curation_concerns/base/_form_permission_under_lease.html.erb
@@ -1,0 +1,10 @@
+<fieldset>
+  <legend class="legend-save-work"><%= t('curation_concerns.visibility.legend') %></legend>
+    <p>
+      <strong>This work is under lease.</strong>  You can change the settings of the lease here, or you can visit the <%= link_to 'Lease Management Page', main_app.edit_lease_path(f.object) %> to deactivate it.
+    </p>
+  <div class="form-group">
+    <input type="hidden" name="<%= f.object_name %>[visibility]" value="<%= Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LEASE %>" />
+    <%= render "form_permission_lease", f: f %>
+  </div>
+</fieldset>

--- a/app/views/curation_concerns/base/_form_visibility_component.html.erb
+++ b/app/views/curation_concerns/base/_form_visibility_component.html.erb
@@ -4,16 +4,18 @@
     <%= render 'form_permission_under_lease', f: f %>
 <% else %>
     <fieldset>
-      <legend class="legend-save-work">Visibility</legend>
-      <ul class="visibility">
+      <legend id="choose_visibility" class="legend-save-work"><%= t('curation_concerns.visibility.legend') %></legend>
+        <p class="help-block">Who should be able to view or download this content?</p>
+      <ul class="visibility" role="radiogroup" aria-labelledby="choose_visibility">
         <li class="radio">
-          <label>
-            <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, data: { 'target': '#collapsePublic' }  %>
+          <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, data: { 'target': '#collapsePublic' }  %>
+          <label for="generic_work_visibility_open">
             <%= t('curation_concerns.visibility.open.label_html') %>
+          </label>
             <div class="collapse" id="collapsePublic">
               <p>
-                <strong>Please note</strong>, making something visible to the world (i.e.
-                marking this as <%= t('curation_concerns.visibility.open.label_html') %>) may be
+                <strong>Please note</strong>,
+                marking this as <%= t('curation_concerns.visibility.open.label_html') %> may be
                 viewed as publishing which could impact your ability to:
               </p>
               <ul>
@@ -25,17 +27,16 @@
                 information about publisher copyright policies.
               </p>
             </div>
-          </label>
         </li>
         <li class="radio">
-          <label>
-            <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED %>
+          <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED %>
+          <label for="generic_work_visibility_authenticated">
             <%= t('curation_concerns.visibility.authenticated.label_html', institution: t('curation_concerns.institution.name')) %>
           </label>
         </li>
         <li class="radio">
-          <label>
-            <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO, data: { 'target': '#collapseEmbargo' } %>
+          <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO, data: { 'target': '#collapseEmbargo' } %>
+          <label for="generic_work_visibility_embargo">
             <%= t('curation_concerns.visibility.embargo.label_html') %>
           </label>
             <div class="collapse" id="collapseEmbargo">
@@ -48,8 +49,8 @@
             </div>
         </li>
         <li class="radio">
-          <label>
-            <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LEASE, data: { 'target': '#collapseLease' } %>
+          <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LEASE, data: { 'target': '#collapseLease' } %>
+          <label for="generic_work_visibility_lease">
             <%= t('curation_concerns.visibility.lease.label_html') %>
           </label>
             <div class="collapse" id="collapseLease">
@@ -62,8 +63,8 @@
             </div>
         </li>
         <li class="radio">
-          <label>
-            <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE %>
+          <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE %>
+          <label for="generic_work_visibility_restricted">
             <%= t('curation_concerns.visibility.private.label_html') %>
           </label>
         </li>

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -66,6 +66,8 @@ en:
         google: 'Share on Google+'
       form_files:
         external_upload: 'Add Files from the Cloud (E.g. Box, Dropbox)'
+    visibility:
+      legend: 'Choose Visibility'
   blacklight:
     search:
       fields:


### PR DESCRIPTION
Puts the visibility legend in locale and moves radio button out of label element. Adds some aria attributes to the viz widget and removes html and classes that aren't needed in the embargo and lease options.