### PR TITLE
Links Required Metadata and Files in Viz Widget to Tabs

### DIFF
--- a/app/views/curation_concerns/base/_form_progress.html.erb
+++ b/app/views/curation_concerns/base/_form_progress.html.erb
@@ -5,11 +5,15 @@
   <div class="list-group">
     <div class="list-group-item">
       <fieldset>
-        <legend class="legend-save-work">Requirements</legend>
+        <legend class="legend-save-work"><%= t("curation_concerns.base.form_progress.legend_required") %></legend>
         <ul class="requirements">
-          <li class="incomplete" id="required-metadata">Enter required metadata</li>
+          <li class="incomplete" id="required-metadata">
+            <a href="#metadata"><%= t("curation_concerns.base.form_progress.metadata_required") %></a>
+          </li>
           <% if Sufia.config.work_requires_files %>
-            <li class="incomplete" id="required-files">Add files</li>
+            <li class="incomplete" id="required-files">
+              <a href="#files"><%= t("curation_concerns.base.form_progress.files_required") %></a>
+            </li>
           <% end %>
         </ul>
       </fieldset>

--- a/app/views/curation_concerns/file_sets/edit.html.erb
+++ b/app/views/curation_concerns/file_sets/edit.html.erb
@@ -14,13 +14,13 @@
   <div class="col-xs-12 col-sm-8">
     <ul class="nav nav-tabs" role="tablist">
       <li id="edit_descriptions_link" class="active">
-        <a href="#descriptions_display" data-toggle="tab"><span class="fa fa-tags" aria-hidden="true"></span> Descriptions</a>
+        <a href="#descriptions_display" data-toggle="tab">Descriptions</a>
       </li>
       <li id="edit_versioning_link">
-        <a href="#versioning_display" data-toggle="tab"><span class="fa fa-sitemap" aria-hidden="true"></span> Versions</a>
+        <a href="#versioning_display" data-toggle="tab">Versions</a>
       </li>
       <li id="edit_permissions_link">
-        <a href="#permissions_display" data-toggle="tab"><span class="fa fa-key" aria-hidden="true"></span> Permissions</a>
+        <a href="#permissions_display" data-toggle="tab">Permissions</a>
       </li>
     </ul>
     <div class="tab-content">

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -64,6 +64,10 @@ en:
         twitter: 'Share on Twitter'
         tumblr: 'Share on Tumblr'
         google: 'Share on Google+'
+      form_progress:
+        legend_required: 'Requirements'
+        metadata_required: 'Enter required metadata'
+        files_required: 'Add files'
       form_files:
         external_upload: 'Add Files from the Cloud (E.g. Box, Dropbox)'
     visibility:

--- a/spec/features/generic_work/upload_and_delete_spec.rb
+++ b/spec/features/generic_work/upload_and_delete_spec.rb
@@ -64,6 +64,8 @@ describe 'Generic File uploading and deletion:', type: :feature do
         expect(page).to have_no_css("#generic_work_contributor")
 
         within("#savewidget") do
+          expect(page).to have_selector("a[href='#metadata']")
+          expect(page).to have_selector("a[href='#files']")
           expect(page).to have_content("Visibility")
           expect(page).to have_content("Public")
           expect(page).to have_content("Embargo")


### PR DESCRIPTION
Moves text into locale for translation, removes icons from tabs, and links the requirements to the correct section of the tabs.