### PR TITLE
Enable changing text for requirements, ref #640

### DIFF
--- a/app/assets/javascripts/scholarsphere/fileupload.js
+++ b/app/assets/javascripts/scholarsphere/fileupload.js
@@ -9,4 +9,24 @@ Blacklight.onLoad(function() {
   $("#new_generic_work, #new_batch_upload_item, .edit_generic_work").on('submit', function(event) {
     $(".panel-footer").toggleClass("hidden");
   });
+
+  // Using Bootstrap's tab links won't work if they're outside of the tabs they're controlling.
+  // Here we do it "manually"
+  $('.tabfaker').on('click', function(event) {
+    var metadata_tab = $("ul.nav-tabs li")[0];
+    var files_tab = $("ul.nav-tabs li")[1];
+
+    $("ul.nav-tabs li").removeClass("active");
+    $("div.tab-content div").removeClass("active");
+
+    if ($(this).attr("href") == "#metadata") {
+      $(metadata_tab).addClass("active");
+      $("div#metadata").addClass("active");
+    }
+
+    if ($(this).attr("href") == "#files"){
+      $(files_tab).addClass("active");
+      $("div#files").addClass("active");
+    }
+  });
 });

--- a/app/assets/javascripts/sufia/save_work/checklist_item.es6
+++ b/app/assets/javascripts/sufia/save_work/checklist_item.es6
@@ -1,0 +1,19 @@
+// Overrides Sufia checklist_item.es6 to add text for screen readers when metadata requirements are complete.
+
+export class ChecklistItem {
+  constructor(element) {
+    this.element = element
+  }
+
+  check() {
+    this.element.removeClass('incomplete')
+    this.element.addClass('complete')
+    this.element.children('a').text(this.element.data("complete"))
+  }
+
+  uncheck() {
+    this.element.removeClass('complete')
+    this.element.addClass('incomplete')
+    this.element.children('a').text(this.element.data("incomplete"))
+  }
+}

--- a/app/views/curation_concerns/base/_form_progress.html.erb
+++ b/app/views/curation_concerns/base/_form_progress.html.erb
@@ -6,14 +6,26 @@
     <div class="list-group-item">
       <fieldset>
         <legend class="legend-save-work"><%= t("curation_concerns.base.form_progress.legend_required") %></legend>
-        <ul class="requirements">
-          <li class="incomplete" id="required-metadata">
-            <a href="#metadata"><%= t("curation_concerns.base.form_progress.metadata_required") %></a>
-          </li>
+        <ul class="requirements" role="group">
+          <%= content_tag :li, id: "required-metadata", role: "listitem", class: "incomplete", data: {
+                complete: t("curation_concerns.base.form_progress.metadata_required_complete"),
+                incomplete: t("curation_concerns.base.form_progress.metadata_required")
+              } do
+          %>
+            <a href="#metadata" class="tabfaker" aria-controls="metadata" role="tab" data-toggle="tab">
+              <%= t("curation_concerns.base.form_progress.metadata_required") %>
+            </a>
+          <% end %>
           <% if Sufia.config.work_requires_files %>
-            <li class="incomplete" id="required-files">
-              <a href="#files"><%= t("curation_concerns.base.form_progress.files_required") %></a>
-            </li>
+            <%= content_tag :li, id: "required-files", role: "listitem", class: "incomplete", data: {
+                  complete: t("curation_concerns.base.form_progress.files_required_complete"),
+                  incomplete: t("curation_concerns.base.form_progress.files_required")
+                } do
+            %>
+              <a href="#files" class="tabfaker" aria-controls="files" role="tab" data-toggle="tab">
+                <%= t("curation_concerns.base.form_progress.files_required") %>
+              </a>
+            <% end %>
           <% end %>
         </ul>
       </fieldset>

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -2,7 +2,7 @@ en:
   sufia:
     institution_name: "Penn State"
     institution_name_full: "Penn State University"
-    deposit_agreement:  "the deposit agreement"
+    deposit_agreement:  "deposit agreement"
     upload_tooltip:     "Please accept the deposit agreement before you upload."
     bread_crumb:
       file_list: "Files"
@@ -67,7 +67,9 @@ en:
       form_progress:
         legend_required: 'Requirements'
         metadata_required: 'Enter required metadata'
+        metadata_required_complete: 'Required metadata complete'
         files_required: 'Add files'
+        files_required_complete: 'Required files complete'
       form_files:
         external_upload: 'Add Files from the Cloud (E.g. Box, Dropbox)'
     visibility:


### PR DESCRIPTION
Changes the text of the requirements links so that at screen reader informs the user as to whether the requirements are met.

Additionally, the links themselves need some Javascript reworking so they would active the tabs when clicked.