### PR TITLE
Use inline styles for progress bar, ref #643

### DIFF
--- a/app/assets/stylesheets/scholarsphere/form.scss
+++ b/app/assets/stylesheets/scholarsphere/form.scss
@@ -1,7 +1,3 @@
-.progress-bar-complete {
-  width: 100%;
-}
-
 /* Needs to be overly specific to override Bootstrap styles coming from 3 gems */
 html > body .form-progress .radio input[type="radio"] {
   margin-left: 0;

--- a/app/views/curation_concerns/base/_form_progress.html.erb
+++ b/app/views/curation_concerns/base/_form_progress.html.erb
@@ -66,8 +66,10 @@
   <%# Override Sufia: Provide immediate feedback after the form is submitted while the subsequent page is loading %>
   <div class="panel-footer hidden">
     <div class="progress">
-      <div class="progress-bar progress-bar-striped progress-bar-complete active">
-        <span id="form-feedback" aria-live="assertive">Saving your work. This may take a few moments</span>
+      <div class="progress-bar progress-bar-striped active" style="width: 100%">
+        <span id="form-feedback" aria-live="assertive">
+          <%= t("scholarsphere.upload.progress") %>
+        </span>
       </div>
     </div>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -50,6 +50,7 @@ en:
     upload:
       restrictions_html: "<h3>Maximum Upload Restrictions</h3><ul><li>Individual File Size: 500 MB</li><li>Up to 100 files and totaling less than 1GB in size</li></ul><p><a href='/contact'>Need to upload a larger file? Contact us for support.</a></p>"
       content_policy_html: "<h3>Content Policy</h3><p class='content-policy'>Please review <a href='/about#Content_Policy'>ScholarSphere’s Content Policy</a> to make sure you are not depositing materials that are sensitive.</p>"
+      progress: "Saving your work. This may take a few moments"
   statistic:
     report:
       subject: "ScholarSphere - Statistic Report"


### PR DESCRIPTION
@mtribone For whatever reason, Bootstrap needs inline styes here in order for the progress bar to show.

![progress](https://cloud.githubusercontent.com/assets/312085/23860538/a54a2964-07dd-11e7-9386-0022c8588a64.png)
