### PR TITLE
Rename Labels on Work Tabs and File Set Edit

### DIFF
--- a/app/views/batch_edits/edit.html.erb
+++ b/app/views/batch_edits/edit.html.erb
@@ -12,10 +12,10 @@
     <!-- Nav tabs -->
     <ul class="nav nav-tabs" role="tablist">
       <li id="edit_descriptions_link" class="active">
-        <a href="#descriptions_display" data-toggle="tab"><span class="fa icon-metadata" aria-hidden="true"></span> Descriptions</a>
+        <a href="#descriptions_display" data-toggle="tab"><%= t("sufia.works.edit.tab.metadata") %></a>
       </li>
       <li id="edit_permissions_link">
-        <a href="#share" data-toggle="tab"><span class="fa icon-share" aria-hidden="true"></span> Share</a>
+        <a href="#share" data-toggle="tab"><%= t("sufia.works.edit.tab.share") %></a>
       </li>
     </ul>
 

--- a/app/views/curation_concerns/base/_guts4form.html.erb
+++ b/app/views/curation_concerns/base/_guts4form.html.erb
@@ -1,0 +1,47 @@
+<% # we will yield to content_for for each tab, e.g. :files_tab %>
+<% tabs ||= %w[metadata files relationships share] # default tab order %>
+<div class="row">
+  <div class="col-xs-12 col-sm-8" role="main">
+
+    <!-- Nav tabs -->
+    <ul class="nav nav-tabs" role="tablist">
+      <% tabs.each_with_index do | tab, i | %>
+          <% if i == 0 %>
+              <li role="presentation" class="active">
+          <% else %>
+              <li role="presentation">
+          <% end %>
+          <a href="#<%= tab %>" aria-controls="<%= tab %>" role="tab" data-toggle="tab">
+            <%= t("sufia.works.edit.tab.#{tab}") %>
+          </a>
+          </li>
+      <% end %>
+    </ul>
+
+    <!-- Tab panes -->
+    <div class="tab-content">
+      <% (tabs - ['share']).each_with_index do | tab, i | %>
+          <% if i == 0 %>
+              <div role="tabpanel" class="tab-pane active" id="<%= tab %>">
+          <% else %>
+              <div role="tabpanel" class="tab-pane" id="<%= tab %>">
+          <% end %>
+          <div class="form-tab-content">
+            <%= yield "#{tab}_tab".to_sym if content_for? "#{tab}_tab".to_sym %>
+            <%= render "form_#{tab}", f: f %>
+          </div>
+          </div>
+      <% end %>
+
+      <div role="tabpanel" class="tab-pane" id="share" data-param-key="<%= f.object.model_name.param_key %>">
+        <div class="form-tab-content">
+          <%= render "form_share", f: f %>
+        </div>
+      </div>
+      </div>
+    </div>
+
+    <div id="savewidget" class="col-xs-12 col-sm-4 fixedsticky" role="complementary">
+      <%= render 'form_progress', f: f %>
+    </div>
+  </div>

--- a/app/views/curation_concerns/file_sets/edit.html.erb
+++ b/app/views/curation_concerns/file_sets/edit.html.erb
@@ -14,7 +14,7 @@
   <div class="col-xs-12 col-sm-8">
     <ul class="nav nav-tabs" role="tablist">
       <li id="edit_descriptions_link" class="active">
-        <a href="#descriptions_display" data-toggle="tab">Descriptions</a>
+        <a href="#descriptions_display" data-toggle="tab"><%= t("sufia.works.edit.tab.metadata") %></a>
       </li>
       <li id="edit_versioning_link">
         <a href="#versioning_display" data-toggle="tab">Versions</a>

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -37,6 +37,11 @@ en:
     user_profile:
       tab_user_info: "User Info"
     works:
+      edit:
+        tab:
+          metadata: "Metadata"
+          relationships: "Collections"
+          share: "Collaborators"
       new:
         after_create_html: "Your files are being processed by %{application_name} in the background. Your files will be displayed below as they are processed. You may need to refresh this page to see these updates."
   simple_form:

--- a/spec/features/collection/create_spec.rb
+++ b/spec/features/collection/create_spec.rb
@@ -67,7 +67,7 @@ describe Collection, type: :feature do
         click_button "Create Collection and Upload Works"
         expect(page).to have_content("Collection was successfully created.")
         expect(page).to have_content("Add Multiple New Works")
-        click_link("Relationships")
+        within("ul.nav-tabs") { click_link("Collections") }
         expect(page).to have_select("batch_upload_item_collection_ids", selected: title)
       end
     end

--- a/spec/features/collection/edit_spec.rb
+++ b/spec/features/collection/edit_spec.rb
@@ -113,7 +113,7 @@ describe Collection, type: :feature do
       specify do
         click_link("Add new works")
         expect(page).to have_content("Add Multiple New Works")
-        click_link("Relationships")
+        within("ul.nav-tabs") { click_link("Collections") }
         expect(page).to have_select("batch_upload_item_collection_ids", selected: collection.title.first)
       end
     end

--- a/spec/features/collection/view_and_search_spec.rb
+++ b/spec/features/collection/view_and_search_spec.rb
@@ -78,7 +78,7 @@ describe Collection, type: :feature do
       specify do
         click_link("Add new works")
         expect(page).to have_content("Add Multiple New Works")
-        click_link("Relationships")
+        within("ul.nav-tabs") { click_link("Collections") }
         expect(page).to have_select("batch_upload_item_collection_ids", selected: collection.title.first)
       end
     end

--- a/spec/features/generic_work/upload_and_delete_spec.rb
+++ b/spec/features/generic_work/upload_and_delete_spec.rb
@@ -38,7 +38,7 @@ describe 'Generic File uploading and deletion:', type: :feature do
         check 'agreement'
 
         # Enter required metadata
-        click_link("Descriptions")
+        click_link("Metadata")
         fill_in 'generic_work_title', with: 'Upload test'
         fill_in 'generic_work_keyword', with: 'keyword'
         fill_in 'generic_work_creator', with: 'creator'
@@ -60,7 +60,7 @@ describe 'Generic File uploading and deletion:', type: :feature do
 
         # Test sharing tab
         expect(User).to receive(:query_ldap_by_name_or_id).and_return([{ id: other_user.user_key, text: "#{other_user.display_name} (#{other_user.user_key})" }])
-        click_link('Share')
+        click_link("Collaborators")
         expect(page).to have_css('a.select2-choice')
         first('a.select2-choice').click
         find(".select2-input").set(other_user.user_key)
@@ -116,7 +116,7 @@ describe 'Generic File uploading and deletion:', type: :feature do
             expect(page).to have_content "Markdown Test.txt"
           end
           check 'agreement'
-          click_on 'Descriptions'
+          click_on 'Metadata'
           fill_in 'generic_work_title', with: 'Markdown Test'
           fill_in 'generic_work_keyword', with: 'keyword'
           fill_in 'generic_work_creator', with: 'creator'

--- a/spec/support/helpers/generic_works.rb
+++ b/spec/support/helpers/generic_works.rb
@@ -12,7 +12,7 @@ module GenericWorksHelper
     check 'agreement'
     click_on 'Files'
     attach_file('files[]', test_file_path(filename), visible: false)
-    click_on 'Descriptions'
+    click_on 'Metadata'
     fill_in 'generic_work_title', with: filename + '_title'
     fill_in 'generic_work_keyword', with: filename + '_keyword'
     fill_in 'generic_work_creator', with: filename + '_creator'


### PR DESCRIPTION
Adds content for tabs to sufia.en.yml and updates text. Changes views to use translation. Remove icons from tabs. Update tests to reflect name changes.

Changes based on user testing and accessibility testing with Christian and Michele. 