### PR TITLE
Add Optional Steps to Save Viz Widget

### DIFF
--- a/app/assets/javascripts/scholarsphere/fileupload.js
+++ b/app/assets/javascripts/scholarsphere/fileupload.js
@@ -15,6 +15,8 @@ Blacklight.onLoad(function() {
   $('.tabfaker').on('click', function(event) {
     var metadata_tab = $("ul.nav-tabs li")[0];
     var files_tab = $("ul.nav-tabs li")[1];
+    var relationships_tab = $("ul.nav-tabs li")[2];
+    var share_tab = $("ul.nav-tabs li")[3];
 
     $("ul.nav-tabs li").removeClass("active");
     $("div.tab-content div").removeClass("active");
@@ -27,6 +29,16 @@ Blacklight.onLoad(function() {
     if ($(this).attr("href") == "#files"){
       $(files_tab).addClass("active");
       $("div#files").addClass("active");
+    }
+
+    if ($(this).attr("href") == "#relationships"){
+        $(relationships_tab).addClass("active");
+        $("div#relationships").addClass("active");
+    }
+
+    if ($(this).attr("href") == "#share"){
+        $(share_tab).addClass("active");
+        $("div#share").addClass("active");
     }
   });
 });

--- a/app/assets/stylesheets/scholarsphere/form.scss
+++ b/app/assets/stylesheets/scholarsphere/form.scss
@@ -6,3 +6,8 @@ html > body .form-progress .radio input[type="radio"] {
 .switch-upload-type {
   padding: 0.5em 0;
 }
+
+.optional-list {
+  list-style-type: circle;
+  padding-left: 2.2em;
+}

--- a/app/views/curation_concerns/base/_form_progress.html.erb
+++ b/app/views/curation_concerns/base/_form_progress.html.erb
@@ -29,6 +29,15 @@
           <% end %>
         </ul>
       </fieldset>
+      <fieldset>
+        <legend class="legend-save-work">Optional</legend>
+        <ul class="optional-list" role="group">
+          <li role="listitem"><a href="#relationships" class="tabfaker" aria-controls="relationships" role="tab" data-toggle="tab">
+            <%= t("sufia.works.edit.tab.relationships") %></a></li>
+          <li role="listitem"><a href="#share" class="tabfaker" aria-controls="share" role="tab" data-toggle="tab">
+            <%= t("sufia.works.edit.tab.share") %></a></li>
+        </ul>
+      </fieldset>
     </div>
 
     <div class="set-access-controls list-group-item">

--- a/spec/features/generic_work/upload_and_delete_spec.rb
+++ b/spec/features/generic_work/upload_and_delete_spec.rb
@@ -58,9 +58,13 @@ describe 'Generic File uploading and deletion:', type: :feature do
         click_link("Additional fields")
         expect(page).to have_no_css("#generic_work_contributor")
 
+        # Check for optional metadata
+        within("#form-progress") { click_link("Collections") }
+        within("#form-progress") { click_link("Collaborators") }
+
         # Test sharing tab
         expect(User).to receive(:query_ldap_by_name_or_id).and_return([{ id: other_user.user_key, text: "#{other_user.display_name} (#{other_user.user_key})" }])
-        click_link("Collaborators")
+        within("ul.nav-tabs") { click_link("Collaborators") }
         expect(page).to have_css('a.select2-choice')
         first('a.select2-choice').click
         find(".select2-input").set(other_user.user_key)


### PR DESCRIPTION
Adds optional metadata links to save widget, adds tab names to JS file, and adds css for better spacing.

![screen shot 2017-03-20 at 2 51 27 pm](https://cloud.githubusercontent.com/assets/4163828/24116358/ed97b35e-0d7c-11e7-8f07-7fbc1a129545.png)