### PR TITLE
Adding resolrize job that runs through all ids once and then send the…

### DIFF
--- a/app/jobs/resolrize_job.rb
+++ b/app/jobs/resolrize_job.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+class ResolrizeJob < ActiveJob::Base
+  queue_as :resolrize
+
+  def perform
+    resource = Ldp::Resource::RdfSource.new(ActiveFedora.fedora.connection, ActiveFedora.fedora.host + ActiveFedora.fedora.base_path)
+    # GET could be slow if it's a big resource, we're using HEAD to avoid this problem,
+    # but this causes more requests to Fedora.
+    return [] unless resource.head.rdf_source?
+
+    descendant_uris = ActiveFedora::Base.descendant_uris(ActiveFedora.fedora.base_uri)
+
+    # map uri to id to make filtering types easier
+    descendant_ids = descendant_uris.map { |uri| ActiveFedora::Base.uri_to_id(uri) }.compact
+
+    # models have the 10 digit ids fron AF Noid so remove the longer ones
+    model_ids = descendant_ids.reject { |id| id.length > model_id_length }
+
+    # permissions have the longer ids
+    permission_ids = descendant_ids.reject { |id| id.length <= model_id_length }
+
+    # run the permission ids first so that solr has the permissions before the index is updated for the model
+    update_group(permission_ids)
+
+    # run the models
+    update_group(model_ids)
+
+    # run the models a second time to make sure any relationships between the models get assigned correctly
+    update_group(model_ids)
+  end
+
+  private
+
+    def model_id_length
+      10
+    end
+
+    def update_group(ids)
+      ids.each do |id|
+        logger.debug "Re-index everything ... #{id}"
+        begin
+          ActiveFedora::Base.find(id).update_index
+        rescue
+          logger.error "error processing #{id}"
+        end
+      end
+    end
+end

--- a/spec/jobs/resolrize_job_spec.rb
+++ b/spec/jobs/resolrize_job_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe ResolrizeJob, :clean do
+  let(:user) { create(:jill) }
+  let!(:file_set) { create(:file_set, :with_png, id: "abc#{(Random.rand * 10_000).to_i}", depositor: user.login) }
+  let(:job) { described_class.new }
+
+  describe "#perform" do
+    it "Updates the index for all parts of the records" do
+      expect(ActiveFedora::Base).to receive(:find).with(file_set.access_control_id).and_return(file_set.access_control).ordered
+      expect(file_set.access_control).to receive(:update_index)
+      file_set.permissions.each do |perm|
+        expect(ActiveFedora::Base).to receive(:find).with(perm.id).and_return(perm)
+        expect(perm).to receive(:update_index).ordered
+      end
+      expect(ActiveFedora::Base).to receive(:find).twice.with(file_set.id).and_return(file_set).ordered
+      expect(file_set).to receive(:update_index).twice
+      job.perform_now
+    end
+  end
+end


### PR DESCRIPTION
… models back again to make sure relationships are solrized


One thing to note we now need all descendents to capture the permissions.  Before with sufia 6 we just needed the top level descendents.