### PR TITLE
Removes the delete work link from the drop down.

### DIFF
--- a/app/views/collections/_work_action_menu.html.erb
+++ b/app/views/collections/_work_action_menu.html.erb
@@ -1,0 +1,35 @@
+<!-- Removes the delete work option from the dropdown -->
+<div class="btn-group">
+
+  <button class="btn btn-sm dropdown-toggle" data-toggle="dropdown" type="button" id="dropdownMenu_<%= document.id %>" aria-haspopup="true">
+    <span class="sr-only">Press to </span>
+    Select an action
+    <span class="caret" aria-hidden="true"></span>
+  </button>
+
+  <ul role="menu" class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenu_<%= document.id %>">
+
+    <li role="menuitem" tabindex="-1">
+      <%= button_for_remove_from_collection(@collection, document, 'Remove from Collection') %>
+    </li>
+
+    <li role="menuitem" tabindex="-1">
+      <%= link_to [:edit, document] do %>
+          <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
+          <span> Edit Work </span>
+      <% end %>
+    </li>
+
+    <li role="menuitem" tabindex="-1">
+      <%= display_trophy_link @user, document.id do |text| %>
+          <span class='glyphicon glyphicon-star'></span> <%= text %>
+      <% end %>
+    </li>
+    <li role="menuitem" tabindex="-1">
+      <%= link_to(sufia.new_work_transfer_path(document.id), class: 'itemicon itemtransfer', title: 'Transfer Ownership of Work') do %>
+          <span aria-hidden="true" class='glyphicon glyphicon-transfer'></span>
+          <span> Transfer Ownership of Work </span>
+      <% end %>
+    </li>
+  </ul>
+</div>


### PR DESCRIPTION
This change removes the ability to delete a work from the edit page of a collection.

![screen shot 2017-03-28 at 9 46 47 am](https://cloud.githubusercontent.com/assets/4163828/24408394/a32b9aae-139b-11e7-96ec-56f549bfad7e.png)
