### PR TITLE
Update Nokogiri to 1.7.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,7 +158,7 @@ GEM
       activemodel (= 4.2.7.1)
       activesupport (= 4.2.7.1)
       arel (~> 6.0)
-    activerecord-import (0.16.2)
+    activerecord-import (0.17.2)
       activerecord (>= 3.2)
     activesupport (4.2.7.1)
       i18n (~> 0.7)
@@ -496,7 +496,7 @@ GEM
     net-ssh (4.1.0)
     newrelic_rpm (3.17.1.326)
     noid (0.9.0)
-    nokogiri (1.6.8.1)
+    nokogiri (1.7.1)
       mini_portile2 (~> 2.1.0)
     nom-xml (0.6.0)
       activesupport (>= 3.2.18)
@@ -529,11 +529,11 @@ GEM
     posix-spawn (0.3.12)
     powerpack (0.1.1)
     public_suffix (2.0.5)
-    qa (0.10.2)
+    qa (0.11.1)
       activerecord-import
       deprecation
       faraday
-      nokogiri (~> 1.6.0)
+      nokogiri (~> 1.6)
       rails (>= 4.2.0, < 6.0)
     rack (1.6.5)
     rack-maintenance (2.0.1)
@@ -788,7 +788,7 @@ GEM
       actionpack (>= 3.1)
       jquery-rails
       railties (>= 3.1)
-    tzinfo (1.2.2)
+    tzinfo (1.2.3)
       thread_safe (~> 0.1)
     uber (0.1.0)
     uglifier (3.0.3)


### PR DESCRIPTION
Patches a security flaw in libxml2 and also includes an update to QA, which was limiting Nokogiri to 1.6.x only.