### PR TITLE
Update Work Show for Consistent Headings and Collection Relationships

### DIFF
--- a/app/views/curation_concerns/base/_relationships.html.erb
+++ b/app/views/curation_concerns/base/_relationships.html.erb
@@ -1,4 +1,19 @@
 <div class="col-xs-12 col-sm-5">
   <h2 class="border-bottom-1px"><%= t('.header') %></h2>
-  <%= render 'relationships_parent_rows', presenter: presenter %>
+  <%#= render 'relationships_parent_rows', presenter: presenter %>
+  <%#= Uses an earlier version before the nested works and keeps
+       the relationships_parent_rows intact by displaying code here
+  %>
+  <% collection_presenters = presenter.collection_presenters %>
+  <% if collection_presenters.blank? %>
+      <p><%= t('.empty', type: presenter.human_readable_type) %></p>
+  <% else %>
+      <% collection_presenters.each do |collection| %>
+          <ul class="tabular list-unstyled">
+            <li class='attribute title'>
+              <%= link_to collection.to_s, main_app.collection_path(collection) %>
+            </li>
+          </ul>
+      <% end %>
+  <% end %>
 </div>

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -80,6 +80,10 @@ en:
         files_required_complete: 'Required files complete'
       form_files:
         external_upload: 'Add Files from the Cloud (E.g. Box, Dropbox)'
+      metadata:
+        header: 'Metadata'
+      relationships:
+        header: 'Collections'
     visibility:
       legend: 'Choose Visibility'
   blacklight:

--- a/spec/features/generic_work/featured_work_spec.rb
+++ b/spec/features/generic_work/featured_work_spec.rb
@@ -11,7 +11,7 @@ describe "Showing the Generic File", type: :feature do
     click_link "Recent Additions"
     expect(page).to have_content(gf.title.first)
     click_link gf.title.first
-    expect(page).to have_content("Descriptions")
+    expect(page).to have_content("Metadata")
     expect(page).to have_link "Feature"
     click_link "Feature"
     visit "/concern/generic_works/#{gf.id}" # force a page refresh


### PR DESCRIPTION
Grabbed some earlier code from Sufia before nested works was introduced. Replaces relationships_parent_rows with an unordered list that just grabs the collections and updates the header in the yml file. Updates text for heading change and adds comments.