### PR TITLE
ErrorPresenter for customized error messages, ref #607

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -3,3 +3,7 @@ require: rubocop-rspec
 RSpec/AnyInstance:
   Exclude:
     - 'spec/**/*'
+
+Style/RaiseArgs:
+  Exclude:
+    - 'spec/controllers/application_controller_spec.rb'

--- a/app/presenters/error_presenter.rb
+++ b/app/presenters/error_presenter.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+class ErrorPresenter
+  attr_reader :exception, :error
+
+  def initialize(exception = Scholarsphere::Error)
+    @exception = exception
+    log_missing_key if key_missing?
+  end
+
+  def status
+    I18n.t("errors.#{error}.status", default: 500)
+  end
+
+  def title
+    I18n.t("errors.#{error}.title", default: "Error")
+  end
+
+  def message
+    I18n.t("errors.#{error}.message", default: "There was an error with your request")
+  end
+
+  def log_exception
+    Rails.logger.error("Rendering #{status} page due to exception: #{exception.inspect} - #{exception.backtrace if exception.respond_to? :backtrace}")
+  end
+
+  def log_missing_key
+    Rails.logger.warn("Error key #{error} is not present in the i18n file. You may want to add it.")
+  end
+
+  private
+
+    def error
+      exception_class.to_s.underscore.gsub(/\//, "_")
+    end
+
+    def exception_class
+      if exception.class == Class
+        exception
+      else
+        exception.class
+      end
+    end
+
+    def key_missing?
+      !I18n.exists?("errors.#{error}", :en)
+    end
+end

--- a/app/views/error.html.erb
+++ b/app/views/error.html.erb
@@ -1,0 +1,8 @@
+<h1><%= @presenter.title %></h1>
+
+<p><%= @presenter.message %></p>
+
+<p>
+  If this error continues please use the <a href="/contact/">the contact form</a>
+  for assistance uploading your content"
+</p>

--- a/app/views/errors/404.html.erb
+++ b/app/views/errors/404.html.erb
@@ -1,8 +1,0 @@
-<h1>Not found</h1>
-<p>
-  <%= application_name %> could not locate the requested resource.  We
-  apologize for the inconvenience. You might be interested in using
-  <a href="/contact/">the contact form</a> to report the
-  error, or <a href="/help/">the help page</a> for looking up
-  solutions.
-</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -56,3 +56,32 @@ en:
       subject: "ScholarSphere - Statistic Report"
       csv:
         file_name: "scholarsphere-stats_%{date_str}.csv"
+
+  # Error messages used in conjunction with ErrorPresenter. The key for each error is derived as follows:
+  #   StandardError => standard_error
+  #   MyModule::SpecialError => my_module_special_error
+  #
+  # If no key is present for an exception, a default message and 500 status is returned.
+  errors:
+    active_fedora_object_not_found_error:
+      title: "Not Found"
+      message: "This item is not available"
+      status: 404
+    abstract_controller_action_not_found:
+      title: "Not Found"
+      message: "This item is not available"
+      status: 404
+    action_controller_routing_error:
+      title: "Not Found"
+      message: "This item is not available"
+      status: 404
+    active_record_record_not_found:
+      title: "Not Found"
+      message: "This item is not available"
+      status: 404
+    ldp_bad_request:
+      message: "We cannot process the metadata as entered. This usually occurs when unexpected characters are copied from another source. Try typing your metadata by hand."
+    scholarsphere_error:
+      title: "Not Found"
+      message: "This item is not available"
+      status: 404

--- a/lib/scholarsphere.rb
+++ b/lib/scholarsphere.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+module Scholarsphere
+  class Error < StandardError; end
+end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,189 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe ApplicationController do
+  subject { response }
+
+  context "with ActiveFedora::ObjectNotFoundError" do
+    controller do
+      def index
+        raise ActiveFedora::ObjectNotFoundError
+      end
+    end
+    before { get :index }
+    its(:status) { is_expected.to be(404) }
+  end
+
+  context "with AbstractController::ActionNotFound" do
+    controller do
+      def index
+        raise AbstractController::ActionNotFound
+      end
+    end
+    before { get :index }
+    its(:status) { is_expected.to be(404) }
+  end
+
+  context "with ActionController::RoutingError" do
+    controller do
+      def index
+        raise ActionController::RoutingError.new("message")
+      end
+    end
+    before { get :index }
+    its(:status) { is_expected.to be(404) }
+  end
+
+  context "with ActionDispatch::Cookies::CookieOverflow" do
+    controller do
+      def index
+        raise ActionDispatch::Cookies::CookieOverflow
+      end
+    end
+    before { get :index }
+    its(:status) { is_expected.to be(500) }
+  end
+
+  context "with ActionView::Template::Error" do
+    controller do
+      def index
+        raise ActionView::Template::Error.new(nil, nil)
+      end
+    end
+    before { get :index }
+    its(:status) { is_expected.to be(500) }
+  end
+
+  context "with ActiveRecord::RecordNotFound" do
+    controller do
+      def index
+        raise ActiveRecord::RecordNotFound
+      end
+    end
+    before { get :index }
+    its(:status) { is_expected.to be(404) }
+  end
+
+  context "with ActiveRecord::StatementInvalid" do
+    controller do
+      def index
+        raise ActiveRecord::StatementInvalid.new(nil)
+      end
+    end
+    before { get :index }
+    its(:status) { is_expected.to be(500) }
+  end
+
+  context "with Blacklight::Exceptions::ECONNREFUSED" do
+    controller do
+      def index
+        raise Blacklight::Exceptions::ECONNREFUSED
+      end
+    end
+    before { get :index }
+    its(:status) { is_expected.to be(500) }
+  end
+
+  context "with Blacklight::Exceptions::InvalidSolrID" do
+    controller do
+      def index
+        raise Blacklight::Exceptions::InvalidSolrID
+      end
+    end
+    before { get :index }
+    it "returns a 404" do
+      pending "Returning 500 instead of 404"
+      expect(response.status).to be(404)
+    end
+  end
+
+  context "with Errno::ECONNREFUSED" do
+    controller do
+      def index
+        raise Errno::ECONNREFUSED
+      end
+    end
+    before { get :index }
+    its(:status) { is_expected.to be(500) }
+  end
+
+  context "with NameError" do
+    controller do
+      def index
+        raise NameError
+      end
+    end
+    before { get :index }
+    its(:status) { is_expected.to be(500) }
+  end
+
+  context "with Net::LDAP::LdapError" do
+    controller do
+      def index
+        raise Net::LDAP::LdapError
+      end
+    end
+    before { get :index }
+    its(:status) { is_expected.to be(500) }
+  end
+
+  context "with Redis::CannotConnectError" do
+    controller do
+      def index
+        raise Redis::CannotConnectError
+      end
+    end
+    before { get :index }
+    its(:status) { is_expected.to be(500) }
+  end
+
+  context "with RSolr::Error::Http" do
+    controller do
+      def index
+        raise RSolr::Error::Http.new({ uri: "uri" }, nil)
+      end
+    end
+    before { get :index }
+    its(:status) { is_expected.to be(500) }
+  end
+
+  context "with Ldp::BadRequest" do
+    controller do
+      def index
+        raise Ldp::BadRequest
+      end
+    end
+    before { get :index }
+    its(:status) { is_expected.to be(500) }
+  end
+
+  context "with RuntimeError" do
+    controller do
+      def index
+        raise RuntimeError
+      end
+    end
+    before { get :index }
+    its(:status) { is_expected.to be(500) }
+  end
+
+  context "with StandardError" do
+    controller do
+      def index
+        raise StandardError
+      end
+    end
+    before { get :index }
+    its(:status) { is_expected.to be(500) }
+  end
+
+  describe "#render_404" do
+    controller do
+      def index
+        render_404
+      end
+    end
+    before { get :index }
+    its(:status) { is_expected.to be(404) }
+  end
+end

--- a/spec/lib/errors_spec.rb
+++ b/spec/lib/errors_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe Scholarsphere do
+  describe Scholarsphere::Error do
+    it { is_expected.to be_kind_of(StandardError) }
+  end
+end

--- a/spec/presenters/error_presenter_spec.rb
+++ b/spec/presenters/error_presenter_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe ErrorPresenter do
+  context "with an class exception" do
+    subject { described_class.new(ActiveFedora::ObjectNotFoundError) }
+    its(:status)  { is_expected.to eq(404) }
+    its(:title)   { is_expected.to eq("Not Found") }
+    its(:message) { is_expected.to eq("This item is not available") }
+
+    it "logs the error" do
+      expect(Rails.logger).to receive(:error)
+      subject.log_exception
+    end
+  end
+
+  context "with an instance exception" do
+    subject { described_class.new(ActionController::RoutingError.new(nil)) }
+    its(:status)  { is_expected.to eq(404) }
+    its(:title)   { is_expected.to eq("Not Found") }
+    its(:message) { is_expected.to eq("This item is not available") }
+
+    it "logs the error" do
+      expect(Rails.logger).to receive(:error)
+      subject.log_exception
+    end
+  end
+
+  context "with no exception" do
+    subject { described_class.new }
+    its(:status)  { is_expected.to eq(404) }
+    its(:title)   { is_expected.to eq("Not Found") }
+    its(:message) { is_expected.to eq("This item is not available") }
+
+    it "logs the error use Scholarsphere::Error" do
+      expect(Rails.logger).to receive(:error).with("Rendering 404 page due to exception: Scholarsphere::Error - ")
+      subject.log_exception
+    end
+  end
+
+  context "when the i18n key is missing" do
+    subject { described_class.new(Fixnum) }
+
+    its(:status)  { is_expected.to eq(500) }
+    its(:title)   { is_expected.to eq("Error") }
+    its(:message) { is_expected.to eq("There was an error with your request") }
+
+    it "logs that the key isn't there" do
+      expect(Rails.logger).to receive(:warn).with("Error key fixnum is not present in the i18n file. You may want to add it.")
+      described_class.new(Fixnum)
+    end
+  end
+end

--- a/spec/views/error.html.erb_spec.rb
+++ b/spec/views/error.html.erb_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe 'error.html.erb' do
+  before do
+    assign(:presenter, presenter)
+    render
+  end
+
+  context "with no exception" do
+    let(:presenter) { ErrorPresenter.new }
+
+    it "displays the page" do
+      expect(rendered).to include("This item is not available")
+    end
+  end
+
+  context "with an exception" do
+    let(:presenter) { ErrorPresenter.new(ActiveFedora::ObjectNotFoundError) }
+
+    it "displays the page" do
+      expect(rendered).to include("This item is not available")
+    end
+  end
+end


### PR DESCRIPTION
Returns a customized error page based on the class of exception raised.

We'll need an additional update of the i18n config file with the specific message desired for each exception.