### PR TITLE
Display recent items according to date uploaded, ref #670

### DIFF
--- a/app/controllers/sufia/homepage_controller.rb
+++ b/app/controllers/sufia/homepage_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+class Sufia::HomepageController < ApplicationController
+  include Sufia::HomepageControllerBehavior
+
+  protected
+
+    def sort_field
+      "#{Solrizer.solr_name('date_uploaded', :stored_sortable, type: :date)} desc"
+    end
+end

--- a/spec/controllers/sufia/homepage_controller_spec.rb
+++ b/spec/controllers/sufia/homepage_controller_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe Sufia::HomepageController do
+  subject { described_class.new }
+
+  its(:sort_field) { is_expected.to eq("date_uploaded_dtsi desc") }
+end

--- a/spec/features/generic_work/view_and_download_spec.rb
+++ b/spec/features/generic_work/view_and_download_spec.rb
@@ -15,13 +15,20 @@ describe GenericWork, type: :feature do
     end
     let!(:work2) { create(:private_work, depositor: current_user.login) }
 
-    before do
-      sign_in_with_js(current_user)
-      visit(main_app.polymorphic_path(work1))
-    end
+    before { sign_in_with_js(current_user) }
 
     context 'When viewing a file' do
       specify "I see all the correct information" do
+        visit(root_path)
+
+        # Work is listed under Recently Uploaded
+        click_link("Recent Additions")
+        within("#recent_docs") do
+          expect(page).to have_link(work1.keyword.first)
+          click_link(work1.title.first)
+        end
+
+        # View the work's show page
         expect(page).to have_content work1.title.first
         expect(page).not_to have_link "Feature"
         within("h1 span") do


### PR DESCRIPTION
This avoids display of migrated items, which would be sorted according to the system's creation date. Instead we use date uploaded, which is assigned by Sufia at the time the original work or file was created.