### PR TITLE
separating the config directories for qa and qa-new

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -47,25 +47,25 @@ set :format_options, command_output: false
 # Example link: ln -s /opt/heracles/deploy/scholarsphere/shared/config/redis.yml /opt/heracles/deploy/scholarsphere/current/config/redis.yml
 set :linked_files, fetch(:linked_files, []).push(
   'config/analytics.yml',
-  # 'config/application.yml',
-  'config/arkivo-new.yml',
-  #  'config/blacklight.yml',
+  'config/application.yml',
+  'config/arkivo.yml',
+  'config/blacklight.yml',
   'config/browse_everything_providers.yml',
   'config/database.yml',
   'config/devise.yml',
-  #  'config/fedora.yml',
-  #  'config/fedora3.yml',
+  'config/fedora.yml',
+  'config/fedora3.yml',
   'config/ga-privatekey.p12',
   'config/hydra-ldap.yml',
   'config/initializers/arkivo_constraint.rb',
   'config/initializers/qa.rb',
   'config/initializers/sufia6.rb',
-  #  'config/newrelic.yml',
-  #  'config/redis-new.yml',
-  # 'config/scholarsphere.yml',
+  'config/newrelic.yml',
+  'config/redis.yml',
+  'config/scholarsphere.yml',
   'config/secrets.yml',
   'config/share_notify.yml',
-  #  'config/solr.yml',
+  'config/solr.yml',
   'config/zotero.yml',
   'public/robots.txt',
   'public/sitemap.xml'
@@ -191,26 +191,6 @@ namespace :deploy do
     end
   end
   after :published, "passenger:config_update"
-end
-
-# Temporary Task while moving from old servers to new, some files need kept the same
-namespace :movefiles do
-  desc "Clean up old rbenv versions"
-  task :link_special_files do
-    on roles(:web, :job) do
-      execute "ln -fs /opt/heracles/deploy/scholarsphere/shared/config/redis-new.yml #{release_path}/config/redis.yml"
-      execute "ln -fs /opt/heracles/deploy/scholarsphere/shared/config/arkivo-new.yml #{release_path}/config/arkivo.yml"
-      execute "ln -fs /opt/heracles/deploy/scholarsphere/shared/config/blacklight-new.yml #{release_path}/config/blacklight.yml"
-      execute "ln -fs /opt/heracles/deploy/scholarsphere/shared/config/fedora-new.yml #{release_path}/config/fedora.yml"
-      execute "ln -fs /opt/heracles/deploy/scholarsphere/shared/config/solr-new.yml #{release_path}/config/solr.yml"
-      execute "ln -fs /opt/heracles/deploy/scholarsphere/shared/config/scholarsphere-new.yml #{release_path}/config/scholarsphere.yml"
-      execute "ln -fs /opt/heracles/deploy/scholarsphere/shared/config/application-new.yml #{release_path}/config/application.yml"
-      execute "ln -fs /opt/heracles/deploy/scholarsphere/shared/config/newrelic-new.yml #{release_path}/config/newrelic.yml"
-    end
-  end
-  after "deploy:updated", "movefiles:link_special_files"
-  # after :updated, :link_special_files
-  # after :updated, :check_configs
 end
 
 # Used to keep x-1 instances of ruby on a machine.  Ex +4 leaves 3 versions on a machine.  +3 leaves 2 versions


### PR DESCRIPTION
The old way  config_qa_new was a symbolic link to config_qa and all of the config files that changed between new qa and old qa were named with an "-new"

The new way the directories are separate:  config_qa and config_qa_new  and the file names remain the same.

This makes it easier to change the files in the config directory, but I just realized this does not document which files have been changed on qa-new server. @jrpatterson @informaticianme based on the lack of documentation I am not sure if this is a good or a bad change...
