### PR TITLE
Only allow edit actions for shared items, ref #741

### DIFF
--- a/app/views/my/_index_partials/_list_works.html.erb
+++ b/app/views/my/_index_partials/_list_works.html.erb
@@ -36,7 +36,13 @@
   <td class='text-center'><%= render_visibility_link document %></td>
 
   <td class='text-center'>
-    <%= render 'work_action_menu', document: document %>
+    <%# Override Sufia to only display edit button for works shared with current user %>
+    <% if controller_name == "shares" %>
+      <%= link_to t("sufia.dashboard.my.action.edit_work"), edit_polymorphic_path([main_app, document]),
+          class: 'btn btn-default btn-sm' %>
+    <% else %>
+      <%= render 'work_action_menu', document: document %>
+    <% end %>
   </td>
 </tr>
 <tr id="detail_<%= document.id %>">

--- a/spec/features/dashboard/dashboard_shares_spec.rb
+++ b/spec/features/dashboard/dashboard_shares_spec.rb
@@ -7,41 +7,30 @@ describe 'Dashboard Shares', type: :feature do
   let(:current_user) { create(:user) }
   let(:jill)         { create(:jill) }
 
-  context "the default" do
-    before do
-      sign_in_with_js(current_user)
-      go_to_dashboard_shares
-    end
+  let!(:collection) { create(:collection, depositor: current_user.user_key) }
+  let!(:gf)         { create(:public_file, title: ["Public, unshared file"], depositor: jill.user_key) }
 
-    it 'displays tab title and buttons' do
-      expect(page).to have_content("Works Shared with Me")
-      expect(page).to have_link("New Work", visible: false)
-      expect(page).to have_link("New Collection", visible: false)
-      expect(page).not_to have_selector(".batch-toggle input[value='Delete Selected']")
-    end
+  let!(:gf2) do
+    create(:private_file, title: ["Private, shared filed"],
+                          depositor: jill.user_key,
+                          edit_users: [current_user.user_key])
   end
 
-  context 'when user has a collection' do
-    let!(:collection) { create(:collection, depositor: current_user.user_key) }
-    let!(:gf) { create(:public_file, title: ["Public, unshared file"], depositor: jill.user_key) }
+  before do
+    sign_in_with_js(current_user)
+    go_to_dashboard_shares
+  end
 
-    let!(:gf2) do
-      create(:private_file,
-             title: ["Private, shared filed"],
-             depositor: jill.user_key,
-             edit_users: [current_user.user_key]
-            )
-    end
-
-    before do
-      sign_in_with_js(current_user)
-      go_to_dashboard_shares
-    end
-
-    it "does not display collections and others' files" do
-      expect(page).not_to have_content(collection.title)
-      expect(page).not_to have_content(gf.title.first)
-      expect(page).to have_content(gf2.title.first)
+  it "displays only shared files" do
+    expect(page).to have_content("Works Shared with Me")
+    expect(page).to have_link("New Work", visible: false)
+    expect(page).to have_link("New Collection", visible: false)
+    expect(page).not_to have_selector(".batch-toggle input[value='Delete Selected']")
+    expect(page).not_to have_content(collection.title)
+    expect(page).not_to have_content(gf.title.first)
+    expect(page).to have_content(gf2.title.first)
+    within("tr#document_#{gf2.id}") do
+      expect(page).to have_link("Edit Work")
     end
   end
 end


### PR DESCRIPTION
Includes a small refactoring of the dashboard shares feature test, combining the original two tests into one, saving a few seconds on the test suite.