### PR TITLE
Move the directory linking to before the check of linked directories …

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -120,7 +120,7 @@ namespace :deploy do
       execute "ln -sf /#{fetch(:application)}/config_#{fetch(:stage)}/scholarsphere/ /opt/heracles/deploy/scholarsphere/shared/config"
     end
   end
-  before 'deploy:symlink:shared', :symlink_shared_directories
+  before 'deploy:check:linked_dirs', :symlink_shared_directories
 
   desc "Restart resque-pool"
   task :resquepoolrestart do


### PR DESCRIPTION
…since it will fail if the directory does not exist

Realized doing it before the sym linking does it after the check that those directories and files exists.  Doing it on a new machine or a machine where the sym link does not exist in the first place causes the check to fail unless symlink_shared_directories is prior to deploy:check:linked_dirs