### PR TITLE
Sanitize remote file names, ref #727

### DIFF
--- a/spec/jobs/import_url_job_spec.rb
+++ b/spec/jobs/import_url_job_spec.rb
@@ -6,6 +6,7 @@ describe ImportUrlJob do
   let(:file_set)       { create(:file_set, user: user, import_url: "import_url") }
   let(:log)            { double }
   let(:mock_retriever) { double }
+  let(:file_name)      { "Development Team Projects and Milestones (not downloaded).xlsx" }
 
   before do
     allow(log).to receive(:performing!)
@@ -14,9 +15,10 @@ describe ImportUrlJob do
     allow(Hydra::Works::VirusCheckerService).to receive(:file_has_virus?).and_return(false)
   end
 
-  it "uses the file's original filename" do
+  it "sanitizes the file name" do
     expect(CurationConcerns.config.callback).to receive(:run).with(:after_import_url_success, file_set, user)
     expect(log).to receive(:success!)
-    described_class.perform_now(file_set, "file_name", log)
+    described_class.perform_now(file_set, file_name, log)
+    expect(file_set.label).to eq("Development_Team_Projects_and_Milestones__not_downloaded_.xlsx")
   end
 end


### PR DESCRIPTION
This problem was introduced in 8094bfb9d5fe4d1daf18f212d4778923786d72ba

Remotely-uploaded files from BrowseEverything were failing to process because of non-alphanumeric characters in their filenames, such as
spaces and parentheses.

CarrierWave, which is responsible for uploading local files for ingest, already has a process for sanitizing filenames by removing these
unsupported characters. We can fix the remote file problem by using CarrierWave::SanitizedFile to clean remote filenames the same way
we are cleaning the local ones.

This increases our dependency on CarrierWave, but we're already using it, so this bring both file upload processes closer inline with
one another.