### PR TITLE
Enable errors in development mode

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,7 +30,7 @@ class ApplicationController < ActionController::Base
               RSolr::Error::Http,
               Ldp::BadRequest,
               StandardError,
-              RuntimeError, with: :render_error_page
+              RuntimeError, with: :render_error_page unless Rails.env.development?
 
   # Mysql2 isn't loaded in Travis, so we'll skip testing it
   rescue_from Mysql2::Error, with: :render_error_page unless Rails.env.test?


### PR DESCRIPTION
This reverts one of the changes in 9cd3e4c4b31baca363c3cee66955a0dc193eb007 so we can see the actual error in development mode.

It also allows the better_errors console to render.