### PR TITLE
Update Solr to 6.4.1

### DIFF
--- a/.solr_wrapper
+++ b/.solr_wrapper
@@ -1,9 +1,9 @@
-# Place any default configuration for solr_wrapper here
-# port: 8983
-version: 6.4.0
+# .solr_wrapper
+version: 6.4.1
+port: 8983
 instance_dir: tmp/solr-development
 download_dir: tmp
 collection:
   persist: true
-  dir: solr/config/
+  dir: solr/config
   name: hydra-development

--- a/config/solr_wrapper_test.yml
+++ b/config/solr_wrapper_test.yml
@@ -1,9 +1,9 @@
-#config/solr_wrapper_test.yml
-version: 6.4.0
+# config/solr_wrapper_test.yml
+version: 6.4.1
 port: 8985
 instance_dir: tmp/solr-test
 download_dir: tmp
 collection:
-    persist: false
-    dir: solr/config
-    name: hydra-test
+  persist: false
+  dir: solr/config
+  name: hydra-test

--- a/config/travis/solr_wrapper_test.yml
+++ b/config/travis/solr_wrapper_test.yml
@@ -1,9 +1,9 @@
 #config/solr_wrapper_test.yml
-version: 5.5.2
+version: 6.4.1
 port: 8985
 instance_dir: solr-test
 download_dir: dep_cache
 collection:
-    persist: false
-    dir: solr/config
-    name: hydra-test
+  persist: false
+  dir: solr/config
+  name: hydra-test


### PR DESCRIPTION
This gets us to the current Solr version used in production and also gets all our solr configs in similar state.