### PR TITLE
Making the single-use links more accessible, ref #738

### DIFF
--- a/app/views/curation_concerns/file_sets/_show_actions.html.erb
+++ b/app/views/curation_concerns/file_sets/_show_actions.html.erb
@@ -1,0 +1,19 @@
+<div class="form-actions">
+  <% if Sufia.config.analytics %>
+    <%= link_to "Analytics", @presenter.stats_path, id: 'stats', class: 'btn btn-default' %>
+  <% end %>
+  <% if Sufia.config.citations %>
+    <%= link_to "Citations", sufia.citations_work_path(@presenter), id: 'citations', class: 'btn btn-default' %>
+  <% end %>
+  <% if @presenter.editor? %>
+      <%= link_to "Edit This #{@presenter.human_readable_type}", edit_polymorphic_path([main_app, @presenter]),
+                  class: 'btn btn-default' %>
+      <%= link_to "Delete This #{@presenter.human_readable_type}", [main_app, @presenter],
+                  class: 'btn btn-danger', data: { confirm: "Delete this #{@presenter.human_readable_type}?" },
+                  method: :delete %>
+      <%# Overrides Sufia to remove single-use links button %>
+  <% end %>
+
+  <%= render 'social_media' %>
+</div>
+

--- a/app/views/curation_concerns/file_sets/_single_use_link_rows.html.erb
+++ b/app/views/curation_concerns/file_sets/_single_use_link_rows.html.erb
@@ -1,0 +1,22 @@
+<%# Overrides Sufia to provide better accessibility %>
+<% single_use_links.each do |presenter| %>
+  <tr scope="row">
+    <td>
+      <%= t('sufia.single_use_links.expiration_message', link: presenter.short_key,
+                                                         time: presenter.human_readable_expiration) %>
+
+      <button class="btn btn-xs btn-default copy-single-use-link"
+              data-clipboard-text="<%= curation_concerns.send(presenter.url_helper, presenter.downloadKey) %>"
+              data-toggle="tooltip" data-placement="bottom"
+              title="<%= t('curation_concerns.single_use_links.copy.tooltip') %>"
+              aria-label="<%= t('sufia.single_use_links.accessibility.copy', link: presenter.short_key) %>">
+        <%= t('curation_concerns.single_use_links.copy.button', link: presenter.short_key) %>
+      </button>
+
+      <%= link_to t('curation_concerns.single_use_links.delete'),
+                  curation_concerns.delete_single_use_link_path(params[:id], presenter),
+                  class: 'btn btn-xs btn-danger delete-single-use-link',
+                  aria: { label: t('sufia.single_use_links.accessibility.delete', link: presenter.short_key) } %>
+    </td>
+  </tr>
+<% end %>

--- a/app/views/curation_concerns/file_sets/_single_use_links.html.erb
+++ b/app/views/curation_concerns/file_sets/_single_use_links.html.erb
@@ -1,0 +1,23 @@
+<%# Overrides Sufia to provide better accessibility %>
+<h3><%= t('curation_concerns.single_use_links.title') %></h3>
+
+<table class="table table-striped table-condensed <%= dom_class(presenter) %> single-use-links" aria-live="assertive">
+  <caption>
+    Listing of current single-use links to this file
+  </caption>
+  <tbody data-url="<%= curation_concerns.generated_single_use_links_path(presenter) %>">
+    <% if presenter.single_use_links.present? %>
+      <%= render 'single_use_link_rows', single_use_links: presenter.single_use_links %>
+    <% else %>
+      <tr class="sr-only" scope="row">
+        <td><%= t('sufia.single_use_links.accessibility.no_links') %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<div class="form_actions">
+  <%= link_to t('sufia.single_use_links.button'),
+              curation_concerns.generate_download_single_use_link_path(presenter),
+              class: 'btn btn-default generate-single-use-link' %>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,6 +21,14 @@ en:
         add_new_works:
           label: "Add new works"
           desc: "Add new works to this Collection"
+    single_use_links:
+      button: "Create Single-Use Link"
+      expiration_message: "Link id %{link} expires %{time}"
+      accessibility:
+        no_links: "No links present. To create a new link, click Create Single-Use Link"
+        copy: "Copy link id %{link} to clipboard"
+        delete: "Delete link id %{link}"
+
 
   hydra:
     metadata_help:

--- a/spec/factories/single_use_links.rb
+++ b/spec/factories/single_use_links.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+FactoryGirl.define do
+  factory :single_use_link do
+    itemId 'fs-id'
+    path '/downloads/1234'
+  end
+end

--- a/spec/views/curations_concerns/file_sets/_single_use_links.html.erb_spec.rb
+++ b/spec/views/curations_concerns/file_sets/_single_use_links.html.erb_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe "curation_concerns/file_sets/_single_use_links.html.erb" do
+  let(:user)      { create(:user) }
+  let(:solr_doc)  { SolrDocument.new(build(:file_set, id: "1234").to_solr) }
+  let(:ability)   { Ability.new(user) }
+  let(:presenter) { FileSetPresenter.new(solr_doc, ability) }
+
+  context "when no links are present" do
+    before { render "curation_concerns/file_sets/single_use_links", presenter: presenter }
+    it "renders accessible text" do
+      expect(rendered).to have_content("No links present. To create a new link, click Create Single-Use Link")
+    end
+  end
+
+  context "when links are present" do
+    let(:sul_presenter) { CurationConcerns::SingleUseLinkPresenter.new(create(:single_use_link)) }
+    let(:page) { Capybara::Node::Simple.new(rendered) }
+    let(:copy_button) { page.find('button.copy-single-use-link')['aria-label'] }
+    let(:delete_link) { page.find('a.delete-single-use-link')['aria-label'] }
+
+    before do
+      controller.params = { id: "fs-id" }
+      allow(presenter).to receive(:single_use_links).and_return([sul_presenter])
+      render "curation_concerns/file_sets/single_use_links", presenter: presenter
+    end
+
+    it "renders accessible actions" do
+      expect(page).to have_content("Link id #{sul_presenter.short_key} expires in 23 hours")
+      expect(copy_button).to eq("Copy link id #{sul_presenter.short_key} to clipboard")
+      expect(delete_link).to eq("Delete link id #{sul_presenter.short_key}")
+    end
+  end
+end


### PR DESCRIPTION
Clicking the button to create a new single-use link wasn't making an obvious change.

The button was moved down under the table to which the links were being added, enabling the user to see the result more easily.
Additionally, aria labels and more informative text was added so that visually impaired links could more readily understand
what was occurring and what the links and buttons do.

The actions still aren't ideal. A better solution will be to not use tables and update the Javascript to include responses with
better accessibility functions.