### PR TITLE
Redirect to user's collections dashboard upon delete, ref #740

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -34,6 +34,24 @@ class CollectionsController < ApplicationController
     end
   end
 
+  # Overrides CurationConcerns::CollectionsControllerBehavior
+  # Redirects to the user's collections dashboard page
+  def after_destroy(id)
+    respond_to do |format|
+      format.html { redirect_to sufia.dashboard_collections_path, notice: 'Collection was successfully deleted.' }
+      format.json { render json: { id: id }, status: :destroyed, location: @collection }
+    end
+  end
+
+  # Overrides CurationConcerns::CollectionsControllerBehavior
+  # Redirects to the user's collections dashboard page
+  def after_destroy_error(id)
+    respond_to do |format|
+      format.html { redirect_to sufia.dashboard_collections_path, notice: 'Collection could not be deleted.' }
+      format.json { render json: { id: id }, status: :destroy_error, location: @collection }
+    end
+  end
+
   protected
 
     # Override CurationConcerns::CollectionsControllerBehavior to build a form with ability and request

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -27,4 +27,28 @@ describe CollectionsController, type: :controller do
     subject { described_class }
     its(:form_class) { is_expected.to be(CollectionForm) }
   end
+
+  describe "#delete" do
+    let(:user) { create(:user) }
+    let(:collection) { create(:collection, depositor: user.login) }
+
+    before do
+      allow_any_instance_of(Devise::Strategies::HttpHeaderAuthenticatable).to receive(:remote_user).and_return(user.login)
+      allow_any_instance_of(User).to receive(:groups).and_return([])
+    end
+
+    context "when the collection is successfully deleted" do
+      before { delete :destroy, id: collection }
+      it { is_expected.to redirect_to("/dashboard/collections") }
+    end
+
+    context "when the collection is not successfully deleted" do
+      before do
+        controller.instance_variable_set(:@collection, collection)
+        allow(collection).to receive(:destroy).and_return(false)
+        delete :destroy, id: collection
+      end
+      it { is_expected.to redirect_to("/dashboard/collections") }
+    end
+  end
 end

--- a/spec/features/collection/delete_spec.rb
+++ b/spec/features/collection/delete_spec.rb
@@ -17,8 +17,12 @@ describe Collection, type: :feature do
       db_item_actions_toggle(collection).click
       click_link 'Delete Collection'
       expect(page).to have_content 'Collection was successfully deleted'
-      expect(page).to have_css '#documents'
-      expect(page).not_to have_content title
+      within("#my_nav") do
+        expect(page).to have_content("My Collections")
+      end
+      within("#documents") do
+        expect(page).not_to have_content title
+      end
     end
   end
 end


### PR DESCRIPTION
When deleting your collection, the application was redirecting back to the catalog page. This was not consistent with other delete behaviors that redirected back to the appropriate dashboard page.

When a collection is deleted, whether successfully or not, it redirect back to the collections dashboard page with the appropriate message.