### PR TITLE
Provide separate step for uploading all files, ref #453

### DIFF
--- a/app/assets/javascripts/sufia/uploader.js
+++ b/app/assets/javascripts/sufia/uploader.js
@@ -1,4 +1,9 @@
-// This is overriding Sufia's uploader.js so we can change the value of limitConcurrentUploads
+// Overrides Sufia's uploader.js
+// Injects new UI behavior where auto-uploading is disabled and a new button is provided to
+// being uploading all the files after their records are individually added to the DOM.
+// Although this does add on additional step to the workflow, it avoids the problems
+// we were seeing in #453, while at the same time enables non-sequential, concurrent
+// uploading for increased performance.
 
 //= require fileupload/tmpl
 //= require fileupload/jquery.iframe-transport
@@ -24,22 +29,23 @@
   $.fn.extend({
     sufiaUploader: function( options ) {
       // Initialize our jQuery File Upload widget.
-      // TODO: get these values from configuration.
       this.fileupload($.extend({
-        // xhrFields: {withCredentials: true},              // to send cross-domain cookies
-        // acceptFileTypes: /(\.|\/)(png|mov|jpe?g|pdf)$/i, // not a strong check, just a regex on the filename
-        // limitMultiFileUploadSize: 500000000, // bytes
-        // limit to one file at a time (see #453)
-        limitConcurrentUploads: 1,
+        sequentialUploads: false,
+        limitConcurrentUploads: 6,
         maxNumberOfFiles: 100,
         maxFileSize: 500000000, // bytes, i.e. 500 MB
-        autoUpload: true,
+        autoUpload: false,
         url: '/uploads/',
         type: 'POST',
         dropZone: $(this).find('.dropzone')
       }, options))
       .bind('fileuploadadded', function (e, data) {
         $(e.currentTarget).find('button.cancel').removeClass('hidden');
+        $(e.currentTarget).find('button.all').removeClass('disabled');
+      })
+      .bind('fileuploadcompleted', function (e, data) {
+        if ($('button.start').length == 0)
+          $(e.currentTarget).find('button.all').addClass('disabled');
       });
 
       $(document).bind('dragover', function(e) {
@@ -68,6 +74,11 @@
             window.dropZoneTimeout = null;
             dropZone.removeClass('in hover');
         }, 100);
+      });
+
+      $('button.all').on('click', function(event) {
+        event.preventDefault();
+        $('button.start').click();
       });
     }
   });

--- a/app/views/curation_concerns/base/_browse_everything.html.erb
+++ b/app/views/curation_concerns/base/_browse_everything.html.erb
@@ -1,4 +1,4 @@
 <!-- overriding patial so I could remove the help text and put it in _form_files -->
-<%= button_tag(t('sufia.upload.browse_everything.browse_files_button'), type: 'button', class: 'btn btn-lg btn-success', id: "browse-btn",
+<%= button_tag(t('sufia.upload.browse_everything.browse_files_button'), type: 'button', class: 'btn btn-success', id: "browse-btn",
                'data-toggle' => 'browse-everything', 'data-route' => browse_everything_engine.root_path,
                'data-target' => "##{f.object.persisted? ? 'edit' : 'new'}_#{f.object.model.model_name.param_key}" ) %>

--- a/app/views/curation_concerns/base/_form_files.html.erb
+++ b/app/views/curation_concerns/base/_form_files.html.erb
@@ -1,36 +1,47 @@
-<!-- Overridden to:
+<%# Overridden to:
         make span an label
-        Add arria-hidden to empty spans
-        Put help text above the file list -->
+        Add aria-hidden to empty spans
+        Put help text above the file list
+#%>
 <div id="fileupload">
   <div class="alert alert-success">
     <%= t("sufia.upload.cloud_timeout_message_html", contact_href: link_to(t("sufia.upload.alert.contact_href_text"), sufia.contact_form_index_path)) %>
   </div>
 
-  <!-- Redirect browsers with JavaScript disabled to the origin page -->
-  <noscript><input type="hidden" name="redirect" value="<%= main_app.root_path %>"></noscript>
-  <!-- The table listing the files available for upload/download -->
-  <table role="presentation" class="table table-striped"><tbody class="files"></tbody></table>
-
+  <!-- The fileupload-buttonbar contains buttons to add/delete files -->
   <h2><%= t('curation_concerns.base.form_files.local_upload') %></h2>
-  <!-- The fileupload-buttonbar contains buttons to add/delete files and start/cancel the upload -->
   <div class="row fileupload-buttonbar">
-    <div class="col-xs-7">
+    <div class="col-xs-4">
         <input type="file" name="files[]" id="inputfiles" class="inputfile" multiple />
         <label for="inputfiles"> Add files</label>
       <% if browser_supports_directory_upload? %>
           <input type="file" name="files[]" id="inputfolder" class="inputfile" multiple directory webkitdirectory>
           <label for="inputfolder"> Add folder</label>
       <% end %>
-      <button type="reset" class="btn btn-warning cancel hidden">
-        <span class="glyphicon glyphicon-ban-circle" aria-hidden="true"></span>
-        <span>Cancel upload</span>
+    </div>
+    <div class="col-xs-8">
+      <div class="dropzone">
+        <%= t('curation_concerns.base.form_files.dropzone') %>
+      </div>
+    </div>
+  </div>
+
+  <h2><%= t('curation_concerns.base.form_files.external_upload') %></h2>
+  <%= render 'browse_everything', f: f %>
+
+  <!-- The table listing the files available for upload/download -->
+  <h2><%= t('scholarsphere.upload.available') %></h2>
+  <div class="row">
+    <div class="col-xs-4">
+      <button class="btn btn-info all disabled" aria-label="Upload all local files from the listing of files">
+        <span class="glyphicon glyphicon-circle-arrow-up" aria-hidden="true"></span>
+        <span>Upload all local files</span>
       </button>
       <!-- The global file processing state -->
       <span class="fileupload-process"></span>
     </div>
     <!-- The global progress state -->
-    <div class="col-xs-5 fileupload-progress fade">
+    <div class="col-xs-8 fileupload-progress fade">
       <!-- The global progress bar -->
       <div class="progress progress-striped active" role="progressbar" aria-valuemin="0" aria-valuemax="100">
         <div class="progress-bar progress-bar-success" style="width:0%;"></div>
@@ -39,13 +50,20 @@
       <div class="progress-extended">&nbsp;</div>
     </div>
   </div>
-  <div class="dropzone">
-    <%= t('curation_concerns.base.form_files.dropzone') %>
-  </div>
+  <table class="table table-striped" aria-live="assertive">
+    <caption>Listing of files ready to be uploaded</caption>
+    <tbody class="files">
+      <tr>
+        <th scope="col">File</th>
+        <th scope="col">Size</th>
+        <th scope="col">Actions</th>
+      </tr>
+    </tbody>
+  </table>
 </div>
 
+<!-- Redirect browsers with JavaScript disabled to the origin page -->
+<noscript><input type="hidden" name="redirect" value="<%= main_app.root_path %>"></noscript>
+
 <%= render 'sufia/uploads/js_templates' %>
-<% if Sufia.config.browse_everything %>
-    <h2><%= t('curation_concerns.base.form_files.external_upload') %></h2>
-    <%= render 'browse_everything', f: f %>
-<% end %>
+

--- a/app/views/sufia/uploads/_js_templates.html.erb
+++ b/app/views/sufia/uploads/_js_templates.html.erb
@@ -1,0 +1,122 @@
+<%# Overrides Sufia to use more accessible table elements in uploaded files #%>
+<!-- The template to display files available for upload -->
+<script id="template-upload" type="text/x-tmpl">
+{% for (var i=0, file; file=o.files[i]; i++) { %}
+    <tr class="template-upload fade">
+        <td>
+            <p class="name">{%=file.name%}</p>
+            <strong class="error text-danger"></strong>
+        </td>
+        <td>
+            <p class="size">Processing...</p>
+            <div class="progress progress-striped active" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0"><div class="progress-bar progress-bar-success" style="width:0%;"></div></div>
+        </td>
+        <td>
+            {% if (!i && !o.options.autoUpload) { %}
+                <button class="btn btn-primary start" aria-label="Click to begin uploading selected file" disabled>
+                    <i class="glyphicon glyphicon-upload"></i>
+                    <span>Start</span>
+                </button>
+            {% } %}
+            {% if (!i) { %}
+                <button class="btn btn-warning cancel" aria-label="Click to cancel uploading">
+                    <i class="glyphicon glyphicon-ban-circle"></i>
+                    <span>Cancel</span>
+                </button>
+            {% } %}
+        </td>
+    </tr>
+{% } %}
+</script>
+
+<!-- function used by the following template -->
+<script type="text/javascript">
+  function setAllResourceTypes() {
+    var firstResourceType = $(".resource_type_dropdown")[0].value;
+    $(".resource_type_dropdown").each(function(index, element) {
+      element.value = firstResourceType;
+    });
+  }
+</script>
+
+<!-- The template to display files available for download -->
+<script id="batch-template-download" type="text/x-tmpl">
+{% for (var i=0, file; file=o.files[i]; i++) { %}
+    <tr class="template-download fade">
+        <td>
+          <div class="row">
+            <div class="col-sm-6 name">
+                <span>{%=file.name%}</span>
+                <input type="hidden" name="uploaded_files[]" value="{%=file.id%}">
+            </div>
+            <div class="col-sm-6">
+              {% if (file.error) { %}
+                  <div><span class="label label-danger">Error</span> {%=file.error%}</div>
+              {% } %}
+              <span class="size">{%=o.formatFileSize(file.size)%}</span>
+              <button class="btn btn-danger delete pull-right" data-type="{%=file.deleteType%}" data-url="{%=file.deleteUrl%}"{% if (file.deleteWithCredentials) { %} data-xhr-fields='{"withCredentials":true}'{% } %}>
+                  <i class="glyphicon glyphicon-trash"></i>
+                  <span>Delete</span>
+              </button>
+            </div>
+          </div>
+          <div class="row">
+            <div class="col-sm-12 form-horizontal">
+              <div class="form-group">
+                <label for="title_{%=file.id%}" class="col-sm-5 control-label">Display label</label>
+                <div class="col-sm-7">
+                  <input type="text" class="form-control" name="title[{%=file.id%}]" id="title_{%=file.id%}" value="{%=file.name%}">
+                </div>
+                <label for="resource_type_{%=file.id%}" class="col-sm-5 control-label">Resource Type</label>
+                <div class="col-sm-7">
+                  <select class="form-control resource_type_dropdown" name="resource_type[{%=file.id%}]" id="resource_type_{%=file.id%}" value="{%=file.name%}">
+                    <% ResourceTypesService.select_options.each do |type| %>
+                      <option value="<%= type[0] %>"><%= type[1] %></option>
+                    <% end %>
+                  </select>
+                  <!-- TODO: Why is the button drawn for all files? -->
+                  {% if (i == 0) { %}
+                    <button class="btn pull-right resource_type_button" onClick="setAllResourceTypes(); return false;">Set all to this Resource Type</button>
+                  {% } %}
+                </div>
+              </div>
+            </div>
+          </div>
+        </td>
+    </tr>
+{% } %}
+</script>
+
+<!-- Simpler display of files available for download. Originally from curation_concerns/base/_form_files -->
+<!-- TODO: further consolidate with template-download above -->
+<script id="template-download" type="text/x-tmpl">
+{% for (var i=0, file; file=o.files[i]; i++) { %}
+    <tr class="template-download fade">
+        <td>
+            <p class="name">
+                {% if (file.url) { %}
+                    <a href="{%=file.url%}" title="{%=file.name%}" download="{%=file.name%}" {%=file.thumbnailUrl?'data-gallery':''%}>{%=file.name%}</a>
+                {% } else { %}
+                    <span>{%=file.name%}</span>
+                {% } %}
+                <input type="hidden" name="uploaded_files[]" value="{%=file.id%}">
+            </p>
+            {% if (file.error) { %}
+                <div><span class="label label-danger">Error</span> {%=file.error%}</div>
+            {% } %}
+        </td>
+        <td>
+            <span class="size">{%=o.formatFileSize(file.size)%}</span>
+        </td>
+        <td>
+            <button class="btn btn-danger delete" aria-label="Delete file from uploads"
+                    data-type="{%=file.deleteType%}"
+                    data-url="{%=file.deleteUrl%}"{% if (file.deleteWithCredentials) { %}
+                    data-xhr-fields='{"withCredentials":true}'{% } %}>
+                <i class="glyphicon glyphicon-trash"></i>
+                <span>Delete</span>
+            </button>
+        </td>
+    </tr>
+{% } %}
+</script>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -59,6 +59,7 @@ en:
       restrictions_html: "<h3>Maximum Upload Restrictions</h3><ul><li>Individual File Size: 500 MB</li><li>Up to 100 files and totaling less than 1GB in size</li></ul><p><a href='/contact'>Need to upload a larger file? Contact us for support.</a></p>"
       content_policy_html: "<h3>Content Policy</h3><p class='content-policy'>Please review <a href='/about#Content_Policy'>ScholarSphere’s Content Policy</a> to make sure you are not depositing materials that are sensitive.</p>"
       progress: "Saving your work. This may take a few moments"
+      available: "Files Available for Upload"
   statistic:
     report:
       subject: "ScholarSphere - Statistic Report"

--- a/spec/features/generic_work/upload_and_delete_spec.rb
+++ b/spec/features/generic_work/upload_and_delete_spec.rb
@@ -153,6 +153,7 @@ describe 'Generic File uploading and deletion:', type: :feature do
           visit '/concern/generic_works/new'
           click_on 'Files'
           attach_file('files[]', test_file_path(filename), visible: false)
+          click_on 'Start'
           click_on 'Metadata'
           fill_in 'generic_work_title', with: filename + '_title'
           fill_in 'generic_work_keyword', with: filename + '_keyword'


### PR DESCRIPTION
Note: I'm not completely enamored with this solution because it basically side-steps the problem with a hack. However, I'm not really sure how else to fix the underlying problem because I think it lies with the jbuilder templating system and not with jQuery fileupload plugin. It also has a few hidden benefits, maybe? Uploads are actually occurring faster now, and there's a little more flexibility where the user can add files in multiple batches and only hit "Upload all" once.

This solution injects a new UI behavior where auto-uploading is disabled and a new button is provided to being uploading all the files after their records are individually added to the DOM. (see the circled button)

Although this does add an additional step to the workflow, it fixes the problem and also enables non-sequential, concurrent uploading for increased performance.
![upload](https://cloud.githubusercontent.com/assets/312085/25145355/f314a340-243e-11e7-8fa6-ca4fc3e0abf5.png)

ping @cam156 @mtribone @olendorf 
