### PR TITLE
Use CopyPermissionsJob in CurationConcerns::PermissionsController

### DIFF
--- a/app/controllers/curation_concerns/permissions_controller.rb
+++ b/app/controllers/curation_concerns/permissions_controller.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+class CurationConcerns::PermissionsController < ApplicationController
+  include CurationConcerns::PermissionsControllerBehavior
+
+  def confirm_access
+    # intentional noop to display default rails view
+  end
+
+  # Overrides Sufia to use our own CopyPermissionsJob which does the same things as VisibilityCopyJob
+  # and InheritPermissionsJob, but in one job instead of two.
+  # Fixes https://github.com/psu-stewardship/scholarsphere/issues/758
+  # Remove once we've upgraded to Hyrax
+  def copy_access
+    authorize! :edit, curation_concern
+    CopyPermissionsJob.perform_later(curation_concern)
+    redirect_to [main_app, curation_concern], notice: I18n.t("sufia.upload.change_access_flash_message")
+  end
+end

--- a/app/jobs/copy_permissions_job.rb
+++ b/app/jobs/copy_permissions_job.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+# Combines VisibilityCopyJob from CurationConcerns and InheritPermissionsJob from Sufia into one job.
+class CopyPermissionsJob < ActiveJob::Base
+  def perform(work)
+    work.file_sets.each do |file|
+      # Copy visibility and any leases or embargoes from the work to the file.
+      # Visibility must come first because it can clear an embargo/lease.
+      file.visibility = work.visibility
+      if work.lease
+        file.build_lease unless file.lease
+        file.lease.attributes = work.lease.attributes.except('id')
+        file.lease.save
+      end
+      if work.embargo
+        file.build_embargo unless file.embargo
+        file.embargo.attributes = work.embargo.attributes.except('id')
+        file.embargo.save
+      end
+
+      # Obtain the permission attributes from the work
+      attribute_map = work.permissions.map(&:to_hash)
+
+      # Mark any attributes deleted if they are not present in the work
+      file.permissions.map(&:to_hash).each do |perm|
+        unless attribute_map.include?(perm)
+          perm[:_destroy] = true
+          attribute_map << perm
+        end
+      end
+
+      # Apply the new and deleted attributes to the file
+      file.permissions_attributes = attribute_map
+      file.save!
+    end
+  end
+end

--- a/spec/controllers/curation_concerns/permissions_controller_spec.rb
+++ b/spec/controllers/curation_concerns/permissions_controller_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe CurationConcerns::PermissionsController do
+  let(:curation_concern) { build(:work, id: "1234") }
+
+  describe "#copy_access" do
+    before do
+      allow(controller).to receive(:curation_concern).and_return(curation_concern)
+      allow(controller).to receive(:authorize!).with(:edit, curation_concern).and_return(true)
+    end
+
+    it "calls CopyPermissionsJob" do
+      expect(CopyPermissionsJob).to receive(:perform_later).with(curation_concern)
+      expect(controller).to receive(:redirect_to)
+      controller.copy_access
+    end
+  end
+end

--- a/spec/jobs/copy_permissions_job_spec.rb
+++ b/spec/jobs/copy_permissions_job_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe CopyPermissionsJob do
+  context "when changing visibility" do
+    let(:work)     { create(:public_work, edit_users: ["user1"]) }
+    let(:file_set) { create(:file_set) }
+
+    subject { file_set }
+
+    before do
+      work.ordered_members = [file_set]
+      work.save
+      described_class.perform_now(work)
+    end
+
+    its(:visibility) { is_expected.to eq("open") }
+  end
+
+  # This duplicates Sufia's InheritPermissionsJob spec tests
+  context "when changing permissions" do
+    let(:user) { create(:user, login: "user") }
+    let(:work) { create(:work, :with_one_file, user: user) }
+
+    before do
+      work.permissions.build(name: name, type: type, access: access)
+      work.save
+    end
+
+    context "when edit people change" do
+      let(:name) { 'abc@123.com' }
+      let(:type) { 'person' }
+      let(:access) { 'edit' }
+
+      it 'copies permissions to its contained files' do
+        # files have the depositor as the edit user to begin with
+        expect(work.file_sets.first.edit_users).to eq [user.to_s]
+
+        described_class.perform_now(work)
+        work.reload.file_sets.each do |file|
+          expect(file.edit_users).to match_array [user.to_s, "abc@123.com"]
+        end
+      end
+
+      context "when people should be removed" do
+        before do
+          file_set = work.file_sets.first
+          file_set.permissions.build(name: "remove_me", type: type, access: access)
+          file_set.save
+        end
+
+        it 'copies permissions to its contained files' do
+          # files have the depositor as the edit user to begin with
+          expect(work.file_sets.first.edit_users).to eq [user.to_s, "remove_me"]
+
+          described_class.perform_now(work)
+          work.reload.file_sets.each do |file|
+            expect(file.edit_users).to match_array [user.to_s, "abc@123.com"]
+          end
+        end
+      end
+    end
+
+    context "when read people change" do
+      let(:name) { 'abc@123.com' }
+      let(:type) { 'person' }
+      let(:access) { 'read' }
+
+      it 'copies permissions to its contained files' do
+        # files have the depositor as the edit user to begin with
+        expect(work.file_sets.first.read_users).to eq []
+
+        described_class.perform_now(work)
+        work.reload.file_sets.each do |file|
+          expect(file.read_users).to match_array ["abc@123.com"]
+          expect(file.edit_users).to match_array [user.to_s]
+        end
+      end
+    end
+
+    context "when read groups change" do
+      let(:name) { 'my_read_group' }
+      let(:type) { 'group' }
+      let(:access) { 'read' }
+
+      it 'copies permissions to its contained files' do
+        # files have the depositor as the edit user to begin with
+        expect(work.file_sets.first.read_groups).to eq []
+
+        described_class.perform_now(work)
+        work.reload.file_sets.each do |file|
+          expect(file.read_groups).to match_array ["my_read_group"]
+          expect(file.edit_users).to match_array [user.to_s]
+        end
+      end
+    end
+
+    context "when edit groups change" do
+      let(:name) { 'my_edit_group' }
+      let(:type) { 'group' }
+      let(:access) { 'edit' }
+
+      it 'copies permissions to its contained files' do
+        # files have the depositor as the edit user to begin with
+        expect(work.file_sets.first.read_groups).to eq []
+
+        described_class.perform_now(work)
+        work.reload.file_sets.each do |file|
+          expect(file.edit_groups).to match_array ["my_edit_group"]
+          expect(file.edit_users).to match_array [user.to_s]
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Addresses #758

Changing visibility to private was resulting in Ldp::Gone errors due to bug in HydraHead.

This provides a patch until we can upgrade to a new version of HydraHead by using a custom job that combines visibility and permissions changes into one job.