### PR TITLE
My Collections and My Works have Same Metadata as Collection Items

### DIFF
--- a/app/views/my/_index_partials/_list_collections.html.erb
+++ b/app/views/my/_index_partials/_list_collections.html.erb
@@ -1,0 +1,46 @@
+<% id = document.id %>
+<tr id="document_<%= id %>">
+  <td></td>
+  <td>
+    <div class="media">
+      <span class="fa fa-cubes collection-icon-small pull-left"></span>
+      <div class="media-body">
+        <div class="media-heading">
+          <%= link_to document, id: "src_copy_link#{id}" do %>
+              <span class="sr-only"><%= t("sufia.dashboard.my.sr.show_label") %> </span>
+              <%= document.title_or_label %>
+          <% end %>
+          <a href="#" class="small" title="Click for more details">
+            <span id="expand_<%= id %>" class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
+            <span class="sr-only"> <%= "#{t("sufia.dashboard.my.sr.detail_label")} #{document.title_or_label}" %></span>
+          </a>
+        </div>
+      </div>
+    </div>
+  </td>
+  <td class="text-center"><%= document.create_date %> </td>
+  <td class="text-center">
+    <%= render_visibility_link(document) %>
+  </td>
+  <td class="text-center">
+    <%= render 'collection_action_menu', id: id %>
+  </td>
+</tr>
+<tr id="detail_<%= id %>"> <!--  collection detail"> -->
+  <td colspan="6">
+    <dl class="expanded-details row">
+      <dt class="col-xs-3 col-lg-2">Creator:</dt>
+        <dd class="col-xs-9 col-lg-10"><%= document.creator.to_a.to_sentence %></dd>
+      <dt class="col-xs-3 col-lg-2">Depositor:</dt>
+        <dd class="col-xs-9 col-lg-10"><%= link_to_profile document.depositor %></dd>
+      <dt class="col-xs-3 col-lg-2"><%= t("sufia.dashboard.my.collection_list.edit_access") %></dt>
+        <dd class="col-xs-9 col-lg-10">
+          <% if document.edit_groups.present? %>
+            <%= t("sufia.dashboard.my.collection_list.groups") %> <%= document.edit_groups.join(', ') %>
+            <br/>
+          <% end %>
+          <%= t("sufia.dashboard.my.collection_list.users") %> <%= document.edit_people.join(', ') %>
+        </dd>
+    </dl>
+  </td>
+</tr>

--- a/app/views/my/_index_partials/_list_works.html.erb
+++ b/app/views/my/_index_partials/_list_works.html.erb
@@ -48,8 +48,18 @@
 <tr id="detail_<%= document.id %>">
   <td colspan="6">
     <dl class="expanded-details row">
-      <dt class="col-xs-3 col-lg-2">File Format:</dt>
-      <dd class="col-xs-9 col-lg-10"><%= document.file_format %></dd>
+      <dt class="col-xs-3 col-lg-2">Creator:</dt>
+      <dd class="col-xs-9 col-lg-10"><%= document.creator.to_a.to_sentence %></dd>
+      <dt class="col-xs-3 col-lg-2">Depositor:</dt>
+      <dd class="col-xs-9 col-lg-10"><%= link_to_profile document.depositor %></dd>
+      <dt class="col-xs-3 col-lg-2"><%= t("sufia.dashboard.my.collection_list.edit_access") %></dt>
+      <dd class="col-xs-9 col-lg-10">
+        <% if document.edit_groups.present? %>
+            <%= t("sufia.dashboard.my.collection_list.groups") %> <%= document.edit_groups.join(', ') %>
+            <br/>
+        <% end %>
+        <%= t("sufia.dashboard.my.collection_list.users") %> <%= document.edit_people.join(', ') %>
+      </dd>
     </dl>
   </td>
 </tr>

--- a/spec/features/dashboard/dashboard_collections_spec.rb
+++ b/spec/features/dashboard/dashboard_collections_spec.rb
@@ -28,13 +28,17 @@ describe 'Dashboard Collections:', type: :feature do
   end
 
   specify 'toggle displays additional information' do
-    first('i.glyphicon-chevron-right').click
-    expect(page).to have_content(collection.description.first)
+    first('span.glyphicon-chevron-right').click
+    expect(page).to have_content(collection.creator.first)
+    expect(page).to have_content(collection.depositor)
+    expect(page).to have_content "Edit Access"
     expect(page).to have_content(current_user)
   end
 
   specify 'additional information is hidden' do
-    expect(page).not_to have_content(collection.description)
+    expect(page).not_to have_content(collection.creator.first)
+    expect(page).not_to have_content(collection.depositor)
+    expect(page).not_to have_content "Edit Access"
     expect(page).not_to have_content(current_user)
   end
 

--- a/spec/features/dashboard/dashboard_works_spec.rb
+++ b/spec/features/dashboard/dashboard_works_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'feature_spec_helper'
+
 include Selectors::Dashboard
 
 describe 'Dashboard Works', type: :feature do
@@ -39,16 +40,11 @@ describe 'Dashboard Works', type: :feature do
 
       # A return controller is specified
       expect(page).to have_css("input#return_controller", visible: false)
-
-      # TODO: This part of the test won't pass until this Sufia
-      #       ticket has been taken care of: https://github.com/projecthydra/sufia/issues/2054
-      #
-      # Clicking + displays additional metadata about that file
-      # within("#documents") do
-      #   first('i.glyphicon-chevron-right').click
-      # end
-      # expect(page).to have_content file.creator.first
-      # expect(page).to have_content "Edit Access"
+      # Displays additional metadata about that file
+      first('span.glyphicon-chevron-right').click
+      expect(page).to have_content file.creator.first
+      expect(page).to have_content file.depositor
+      expect(page).to have_content "Edit Access"
 
       db_item_actions_toggle(file).click
       click_link 'Edit Work'


### PR DESCRIPTION
Adds description list from collection show to expose additional details for creator, depositor, edit access. Keeps consistency throughout. Tests for creator and depositor instead of description.