### PR TITLE
Adds help text to the proxy part of the form progress widget.

### DIFF
--- a/app/views/curation_concerns/base/_form_progress.html.erb
+++ b/app/views/curation_concerns/base/_form_progress.html.erb
@@ -45,7 +45,9 @@
     </div>
     <% unless current_user.can_make_deposits_for.empty? %>
         <div class="list-group-item">
-          <%= f.input :on_behalf_of, collection: current_user.can_make_deposits_for.map(&:user_key), prompt: "Yourself" %>
+          <label for="generic_work_on_behalf_of"><%= t('curation_concerns.base.form_progress.on_behalf_of') %></label>
+          <p class="help-block"><%= t('curation_concerns.base.form_progress.on_behalf_of_help') %></p>
+          <%= f.input :on_behalf_of, label: false, collection: current_user.can_make_deposits_for.map(&:user_key), prompt: "Yourself" %>
         </div>
     <% end %>
   </div>

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -87,6 +87,8 @@ en:
         metadata_required_complete: 'Required metadata complete'
         files_required: 'Add files'
         files_required_complete: 'Required files complete'
+        on_behalf_of: 'On behalf of'
+        on_behalf_of_help: 'Remember to correct the creator field if you are depositing on behalf of someone else.'
       form_files:
         external_upload: 'Add Files from the Cloud (E.g. Box, Dropbox)'
       metadata:


### PR DESCRIPTION
Adds `label: false` to `f.input` and popped in my own label and help text in the yml file.


![screen shot 2017-04-20 at 3 25 12 pm](https://cloud.githubusercontent.com/assets/4163828/25248847/b636b562-25dd-11e7-8930-203dc67c7a5f.png)
