### PR TITLE
Collections should default to open access, ref #729

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -4,6 +4,16 @@ class Collection < ActiveFedora::Base
   include CurationConcerns::BasicMetadata
   self.indexer = CollectionIndexer
 
+  def private_access?
+    super unless new_record?
+    false
+  end
+
+  def open_access?
+    super unless new_record?
+    true
+  end
+
   private
 
     # Field name to look up when locating the size of each file in Solr.

--- a/spec/features/collection/create_spec.rb
+++ b/spec/features/collection/create_spec.rb
@@ -20,7 +20,7 @@ describe Collection, type: :feature do
         expect(page).to have_selector("label", class: "required", text: "Keyword")
       end
       within("div.collection_form_visibility") do
-        expect(find("input#visibility_restricted")).to be_checked
+        expect(find("input#visibility_open")).to be_checked
       end
     end
   end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -25,4 +25,11 @@ describe Collection do
     let(:collection) { described_class }
     its(:indexer) { is_expected.to eq(CollectionIndexer) }
   end
+
+  context "with a new collection" do
+    let(:collection) { build(:collection) }
+
+    it { is_expected.not_to be_private_access }
+    it { is_expected.to be_open_access }
+  end
 end


### PR DESCRIPTION
Currently, only works were defaulting to open or public visibility. This applies the same change to collections.

The collection form is coming from Curation Concerns, and as such, is using the model as the edit record instead of the form. There should be another ticket later to remove these changes once the collection is fully utilizing the form.

See #780