### PR TITLE
New resque restart command for the new servers

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -112,7 +112,12 @@ namespace :deploy do
   desc "Restart resque-pool"
   task :resquepoolrestart do
     on roles(:job) do
-      execute "sudo /sbin/service resque_pool restart"
+      # You can remove this logic once we're all on the new servers
+      if host.hostname =~ /new/
+        execute "sudo /sbin/service resque restart"
+      else
+        execute "sudo /sbin/service resque_pool restart"
+      end
     end
   end
   after :published, :resquepoolrestart


### PR DESCRIPTION
The current servers you "resque_pool restart" whereas the new servers use "resque restart" but we need to support both for now.