### PR TITLE
Remove private visibility option, #779

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ cache:
   bundler: true
   directories:
     - "dep_cache"
+    - "travis_phantomjs"
 bundler_args: --without development debug
 sudo: false
 rvm:
@@ -18,7 +19,18 @@ env:
     - TEST_SUITE=unit
     - TEST_SUITE=rubocop
 before_install:
-  - export PATH="$PATH:$(pwd)/fits"
+  - "which phantomjs"
+  - "phantomjs --version"
+  - "export PATH=$PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH"
+  - "which phantomjs"
+  - "phantomjs --version"
+  - "if [ $(phantomjs --version) != '2.1.1' ]; then rm -rf $PWD/travis_phantomjs; mkdir -p $PWD/travis_phantomjs; fi"
+  - "if [ $(phantomjs --version) != '2.1.1' ]; then wget https://assets.membergetmember.co/software/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2; fi"
+  - "if [ $(phantomjs --version) != '2.1.1' ]; then tar -xvf $PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis_phantomjs; fi"
+  - "which phantomjs"
+  - "phantomjs --version"
+  - export PATH="$PATH:$PWD/fits"
+  - "which fits"
   - "mkdir -p dep_cache"
   - "pwd"
   - "ls -l dep_cache"

--- a/app/views/collections/_form_permission.html.erb
+++ b/app/views/collections/_form_permission.html.erb
@@ -1,0 +1,20 @@
+<%# Overrides CurationConcerns to remove the private visibility option from collections %>
+<div class="set-access-controls">
+  <fieldset>
+    <legend>
+      Visibility
+      <small>Who should be able to view your collection?</small>
+    </legend>
+
+    <div class="form-group">
+      <label class="radio">
+        <input type="radio" id="visibility_open" name="<%= f.object_name %>[visibility]" value="<%= Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC %>" <% if @collection.open_access? %> checked="true"<% end %>/>
+        <%= t('curation_concerns.visibility.open.label_html', type: 'content') %>
+      </label>
+      <label class="radio">
+        <input type="radio" id="visibility_registered" name="<%= f.object_name %>[visibility]" value="<%= Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED %>" <% if @collection.authenticated_only_access? %> checked="true"<% end %> />
+        <%= t('curation_concerns.visibility.authenticated.label_html', institution: t('curation_concerns.institution.name')) %>
+      </label>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/curation_concerns/base/_form_permission.html.erb
+++ b/app/views/curation_concerns/base/_form_permission.html.erb
@@ -1,0 +1,36 @@
+<%#
+  Overrides CurationConcerns to remove the private visibility option in permissions
+  tab of the fileset edit view.
+%>
+
+<% if f.object.embargo_release_date %>
+  <%= render 'form_permission_under_embargo', f: f %>
+<% elsif f.object.lease_expiration_date %>
+  <%= render 'form_permission_under_lease', f: f %>
+<% else %>
+  <fieldset class="set-access-controls">
+    <legend>
+      Visibility
+      <small>Who should be able to view or download this content?</small>
+    </legend>
+
+    <div class="form-group">
+      <label class="radio">
+        <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC %>
+        <%= t('curation_concerns.visibility.open.label_html', type: 'work') %>
+      </label>
+      <label class="radio">
+        <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED %>
+        <%= t('curation_concerns.visibility.authenticated.label_html', institution: t('curation_concerns.institution.name')) %>
+      </label>
+      <label class="radio">
+        <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO %>
+        <%= render "form_permission_embargo", f: f %>
+      </label>
+      <label class="radio">
+        <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LEASE %>
+        <%= render "form_permission_lease", f: f %>
+      </label>
+    </div>
+  </fieldset>
+<% end %>

--- a/app/views/curation_concerns/base/_form_visibility_component.html.erb
+++ b/app/views/curation_concerns/base/_form_visibility_component.html.erb
@@ -62,12 +62,6 @@
               </div>
             </div>
         </li>
-        <li class="radio">
-          <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE %>
-          <label for="generic_work_visibility_restricted">
-            <%= t('curation_concerns.visibility.private.label_html') %>
-          </label>
-        </li>
       </ul>
     </fieldset>
 <% end %>

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -1,22 +1,17 @@
 # frozen_string_literal: true
 FactoryGirl.define do
-  factory :collection do
+  factory :collection, aliases: [:public_collection] do
     transient do
       user { FactoryGirl.create(:user) }
     end
-    sequence(:title) { |n| ["Title #{n}"] }
+
+    sequence(:title)       { |n| ["Title #{n}"] }
     sequence(:description) { |n| ["Description #{n}"] }
-    sequence(:creator) { |n| ["Creator #{n}"] }
+    sequence(:creator)     { |n| ["Creator #{n}"] }
+    visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+
     after(:build) do |collection, attrs|
       collection.apply_depositor_metadata((attrs.depositor || attrs.user.user_key))
-    end
-
-    factory :public_collection do
-      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
-    end
-
-    factory :private_collection do
-      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
     end
 
     factory :my_collection do

--- a/spec/features/batch_edit_spec.rb
+++ b/spec/features/batch_edit_spec.rb
@@ -41,6 +41,7 @@ describe "Batch management of works", type: :feature do
       expect(page).to have_css "input#batch_edit_item_publisher[value*='publisherpublisher']"
       expect(page).to have_css "input#batch_edit_item_subject[value*='subjectsubject']"
       expect(page).to have_css "input#batch_edit_item_related_url[value*='http://example.org/TheRelatedURLLink/']"
+      expect(page).to have_no_checked_field("Private")
     end
   end
 

--- a/spec/features/collection/edit_spec.rb
+++ b/spec/features/collection/edit_spec.rb
@@ -80,6 +80,8 @@ describe Collection, type: :feature do
       within("div.collection_date_created") do
         expect(page).to have_content("Published Date")
       end
+      expect(page).to have_checked_field("Public")
+      expect(page).to have_no_checked_field("Private")
       fill_in 'Title', with: updated_title
       fill_in 'Description', with: updated_description
       fill_in 'Creator', with: updated_creators.first

--- a/spec/features/generic_work/upload_and_delete_spec.rb
+++ b/spec/features/generic_work/upload_and_delete_spec.rb
@@ -13,7 +13,7 @@ describe 'Generic File uploading and deletion:', type: :feature do
     let(:file)                  { work }
     let(:work)                  { find_work_by_title "little_file.txt_title" }
 
-    before { sign_in_with_js(current_user) }
+    before { sign_in_with_named_js(:upload_and_delete, current_user, disable_animations: true) }
 
     describe "Sufia's default user agreement" do
       before { visit new_generic_work_path }
@@ -166,6 +166,7 @@ describe 'Generic File uploading and deletion:', type: :feature do
             choose 'generic_work_visibility_authenticated'
           end
           check 'agreement'
+          sleep(1.second)
           click_on 'Save'
           expect(page).to have_css('h1', filename + '_title')
           click_link "My Dashboard"

--- a/spec/features/generic_work/upload_and_delete_spec.rb
+++ b/spec/features/generic_work/upload_and_delete_spec.rb
@@ -42,12 +42,12 @@ describe 'Generic File uploading and deletion:', type: :feature do
           expect(page).to have_content("Visibility")
           expect(page).to have_content("Public")
           expect(page).to have_content("Embargo")
-          expect(page).to have_content("Private")
+          expect(page).not_to have_content("Private")
           expect(page).to have_content("Penn State")
           expect(page).to have_checked_field("Public")
           expect(page).to have_content("marking this as Public")
           sleep(1.second)
-          choose 'generic_work_visibility_restricted'
+          choose 'generic_work_visibility_authenticated'
           expect(page).not_to have_content("marking this as Public")
         end
 
@@ -125,7 +125,7 @@ describe 'Generic File uploading and deletion:', type: :feature do
             expect(page).to have_content "Markdown Test.txt"
           end
           within("#savewidget") do
-            choose 'generic_work_visibility_restricted'
+            choose 'generic_work_visibility_authenticated'
           end
           sleep(1.second)
           check 'agreement'
@@ -163,7 +163,7 @@ describe 'Generic File uploading and deletion:', type: :feature do
           select 'Audio', from: 'generic_work_resource_type'
           select 'Attribution-NonCommercial-NoDerivatives 4.0 International', from: 'generic_work_rights'
           within("#savewidget") do
-            choose 'generic_work_visibility_restricted'
+            choose 'generic_work_visibility_authenticated'
           end
           check 'agreement'
           click_on 'Save'

--- a/spec/views/collections/_form_permission.html.erb_spec.rb
+++ b/spec/views/collections/_form_permission.html.erb_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe "collections/_form_permission.html.erb" do
+  let(:collection) { build(:collection) }
+  let(:form) { CollectionForm.new(collection, Ability.new(nil), double) }
+
+  let(:page) do
+    view.simple_form_for form do |f|
+      render 'collections/form_permission.html.erb', f: f
+    end
+    Capybara::Node::Simple.new(rendered)
+  end
+
+  before { assign(:collection, collection) }
+
+  it "omits the private visibility option" do
+    expect(page).to have_no_checked_field("Private")
+  end
+end

--- a/spec/views/curations_concerns/base/_form_permission.html.erb_spec.rb
+++ b/spec/views/curations_concerns/base/_form_permission.html.erb_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe "curation_concerns/base/_form_permission.html.erb" do
+  let(:work) { build(:work) }
+  let(:form) { CurationConcerns::GenericWorkForm.new(work, Ability.new(nil)) }
+
+  let(:page) {
+    view.simple_form_for(form) do |f|
+      render 'curation_concerns/base/form_permission.html.erb', f: f
+    end
+    Capybara::Node::Simple.new(rendered)
+  }
+
+  it "omits the private visibility option" do
+    expect(page).to have_no_checked_field("Private")
+  end
+end

--- a/spec/views/curations_concerns/base/_form_visibility_component.html.erb_spec.rb
+++ b/spec/views/curations_concerns/base/_form_visibility_component.html.erb_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe "curation_concerns/base/_form_visibility_component.html.erb" do
+  let(:work) { build(:work) }
+  let(:form) { CurationConcerns::GenericWorkForm.new(work, Ability.new(nil)) }
+
+  let(:page) do
+    view.simple_form_for(form) do |f|
+      render 'curation_concerns/base/form_visibility_component.html.erb', f: f
+    end
+    Capybara::Node::Simple.new(rendered)
+  end
+
+  it "omits the private visibility option" do
+    expect(page).to have_no_checked_field("Private")
+  end
+end


### PR DESCRIPTION
Holding works in a private status will no longer be an option. Therefore, the option must be removed.

Existing private works will remain private and editing them will continue to allow them to be private even though the option is no longer explicitly present. New works can be embargoed, and collections will have no private option at all.

Note: I've tested this with existing works that are private. When editing them, there is no selected visibility, since it's private. However, if I save the work without selecting any visibility at all, it remains private. I would expect the form not to save at all since I hadn't selected a visibility. Maybe this is a bug that should be ticketed elsewhere.