### PR TITLE
Sticky Widget No MOAR!!!

### DIFF
--- a/app/assets/stylesheets/scholarsphere/fixedsticky.scss
+++ b/app/assets/stylesheets/scholarsphere/fixedsticky.scss
@@ -1,0 +1,28 @@
+@media (min-width: 768px) {
+  .fixedsticky {
+    position: -webkit-sticky;
+    position: -moz-sticky;
+    position: -ms-sticky;
+    position: -o-sticky;
+    position: static;
+  }
+
+  /* When position: sticky is supported but native behavior is ignored */
+  .fixedsticky-withoutfixedfixed .fixedsticky-off,
+  .fixed-supported .fixedsticky-off {
+    position: static;
+  }
+
+  .fixedsticky-withoutfixedfixed .fixedsticky-on,
+  .fixed-supported .fixedsticky-on {
+    position: static !important;
+  }
+
+  .fixedsticky-dummy {
+    display: none;
+  }
+
+  .fixedsticky-on + .fixedsticky-dummy {
+    display: none;
+  }
+}

--- a/app/assets/stylesheets/scholarsphere/typography.scss
+++ b/app/assets/stylesheets/scholarsphere/typography.scss
@@ -39,3 +39,5 @@ html > body .label-info,
 html > body .btn-info { background-color: #2c76c7; }
 html > body .label-warning,
 html > body .btn-warning { background-color: #F0AD1B; }
+
+.anchor { text-decoration: none; }

--- a/app/views/curation_concerns/base/_form_metadata.html.erb
+++ b/app/views/curation_concerns/base/_form_metadata.html.erb
@@ -11,9 +11,11 @@
             role: "button",
             'aria-expanded'=> "false",
             'aria-controls'=> "extended-terms" %>
+<p class="hidden-xs"><a href="#savework" target="_self"><%= t('curation_concerns.base.back_to_top') %></a></p>
 <div id="extended-terms" class='collapse'>
   <%= render 'form_media', f: f %>
   <% f.object.secondary_terms.each do |term| %>
       <%= render_edit_field_partial(term, f: f) %>
   <% end %>
+  <p class="hidden-xs"><a href="#savework" target="_self"><%= t('curation_concerns.base.back_to_top') %></a></p>
 </div>

--- a/app/views/curation_concerns/base/_form_progress.html.erb
+++ b/app/views/curation_concerns/base/_form_progress.html.erb
@@ -1,6 +1,8 @@
 <aside id="form-progress" class="form-progress panel panel-default">
   <div class="panel-heading">
-    <h3 class="panel-title"><%= t("sufia.works.progress.header") %></h3>
+    <a name="savework" class="anchor">
+      <h3 class="panel-title"><%= t("sufia.works.progress.header") %></h3>
+    </a>
   </div>
   <div class="list-group">
     <div class="list-group-item">

--- a/app/views/curation_concerns/base/_guts4form.html.erb
+++ b/app/views/curation_concerns/base/_guts4form.html.erb
@@ -41,7 +41,7 @@
       </div>
     </div>
 
-    <div id="savewidget" class="col-xs-12 col-sm-4 fixedsticky" role="complementary">
+    <div id="savewidget" class="col-xs-12 col-sm-4" role="complementary">
       <%= render 'form_progress', f: f %>
     </div>
   </div>

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -23,6 +23,8 @@ en:
       greeting: "Hello"
       user_notifications: "User Notifications"
       transfer_files_link: "Select files to transfer"
+      my:
+        shares: 'Shared with Me'
     homepage:
       recently_uploaded:
         tab_label: 'Recent Additions'
@@ -80,6 +82,7 @@ en:
     institution:
       name: "Penn State"
     base:
+      back_to_top: 'Back to Top'
       social_media:
         facebook: 'Share on Facebook'
         twitter: 'Share on Twitter'

--- a/spec/features/dashboard/dashboard_shares_spec.rb
+++ b/spec/features/dashboard/dashboard_shares_spec.rb
@@ -22,7 +22,7 @@ describe 'Dashboard Shares', type: :feature do
   end
 
   it "displays only shared files" do
-    expect(page).to have_content("Works Shared with Me")
+    expect(page).to have_content("Shared with Me")
     expect(page).to have_link("New Work", visible: false)
     expect(page).to have_link("New Collection", visible: false)
     expect(page).not_to have_selector(".batch-toggle input[value='Delete Selected']")


### PR DESCRIPTION
Removes fixedsticky class from guts4form. Switches the fixed sticky on from fixed to static. Adds 1997 style back to top links. Adds text to translation file.

Moves anchor to be around the heading in the widget, adds class to remove underline for anchor, updates spec test to reflect new name of tab for shared with me. Hides back to top link from xs devices.

Fixes #777 and #778 