### PR TITLE
Changing the office processor to convert office docs into a png instead of pdf

### DIFF
--- a/lib/hydra/derivatives/processors/document.rb
+++ b/lib/hydra/derivatives/processors/document.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# Overriding this class to have soffice create png files, which we then generate a thumb for instead
+# of a PDF.  The PDF processing seems to take much more time than the PDF processing
+module Hydra::Derivatives::Processors
+  class Document < Processor
+    include ShellBasedProcessor
+
+    def self.encode(path, format, outdir)
+      execute "#{Hydra::Derivatives.libreoffice_path} --invisible --headless --convert-to #{format} --outdir #{outdir} #{path}"
+    end
+
+    # Converts the document to the format specified in the directives hash.
+    # TODO: file_suffix and options are passed from ShellBasedProcessor.process but are not needed.
+    #       A refactor could simplify this.
+    def encode_file(_file_suffix, _options = {})
+      convert_to_format
+    ensure
+      FileUtils.rm_f(converted_file)
+    end
+
+    private
+
+      # For jpeg files, a pdf is created from the original source and then passed to the Image processor class
+      # so we can get a better conversion with resizing options. Otherwise, the ::encode method is used.
+      def convert_to_format
+        if directives.fetch(:format) == "jpg"
+          Hydra::Derivatives::Processors::Image.new(converted_file, directives).process
+        else
+          output_file_service.call(File.read(converted_file), directives)
+        end
+      end
+
+      def converted_file
+        @converted_file ||= if directives.fetch(:format) == "jpg"
+                              # TODO: This is the only change from HydraDerivaties
+                              #      It would be good if we could configure this instead of overriding
+                              convert_to("png")
+                            else
+                              convert_to(directives.fetch(:format))
+                            end
+      end
+
+      def convert_to(format)
+        self.class.encode(source_path, format, Hydra::Derivatives.temp_file_base)
+        File.join(Hydra::Derivatives.temp_file_base, [File.basename(source_path, ".*"), format].join('.'))
+      end
+  end
+end

--- a/spec/lib/hydra/derivatives/document_spec.rb
+++ b/spec/lib/hydra/derivatives/document_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Hydra::Derivatives::Processors::Document do
+  let(:source_path)    { File.join(fixture_path, "test.doc") }
+  let(:output_service) { Hydra::Derivatives::PersistBasicContainedOutputFileService }
+
+  before { allow(subject).to receive(:output_file_service).and_return(output_service) }
+  before { allow(subject).to receive(:convert_to).with(convert_directive).and_return(converted_file) }
+
+  subject { described_class.new(source_path, directives) }
+
+  describe "#encode_file" do
+    context "when converting to jpg" do
+      let(:directives) { { format: "jpg" } }
+      let(:convert_directive) { "png" }
+      let(:converted_file) { "path/to/pdf/created/from/original" }
+      let(:mock_processor) { double }
+
+      before do
+        allow(Hydra::Derivatives::Processors::Image).to receive(:new).with(converted_file, directives).and_return(mock_processor)
+      end
+
+      it "creates a thumbnail of the document using a pdf created from the original" do
+        expect(mock_processor).to receive(:process)
+        expect(File).to receive(:unlink).with(converted_file)
+        subject.encode_file("jpg")
+      end
+    end
+
+    context "when converting to another format" do
+      let(:directives) { { format: "png" } }
+      let(:convert_directive) { "png" }
+      let(:converted_file) { "path/to/converted.png" }
+      let(:mock_content)   { "mocked png content" }
+
+      before { allow(File).to receive(:read).with(converted_file).and_return(mock_content) }
+      it "creates a thumbnail of the document" do
+        expect(output_service).to receive(:call).with(mock_content, directives)
+        expect(File).to receive(:unlink).with(converted_file)
+        subject.encode_file("png")
+      end
+    end
+  end
+end


### PR DESCRIPTION
then into a jpeg so that the processing is faster

soffice --convert_to pdf seems to hang for complex documents
soffice --convert_to png seems to work faster for all types of documents

We still go ahead and convert it to a jpeg again so that we create a small image.