### PR TITLE
Add fileuploaddestroyed to UploadedFiles JS, ref #775

### DIFF
--- a/app/assets/javascripts/sufia/save_work/uploaded_files.es6
+++ b/app/assets/javascripts/sufia/save_work/uploaded_files.es6
@@ -1,0 +1,28 @@
+// Overrides Sufia to add the fileuploaddestroyed callback so the form re-checks that the file requirement
+// is met. Avoids a bug where works could be created without files if the file was uploaded then deleted.
+export class UploadedFiles {
+  // Monitors the form and runs the callback if any files are added
+  // Adds a fileuploaddestroyed callback which is not present in the source code
+  // but is documented in the jQuery-File-Upload Github wiki.
+  constructor(form, callback) {
+    this.form = form
+    $('#fileupload').bind('fileuploadcompleted', callback)
+    $('#fileupload').bind('fileuploaddestroyed', callback)
+  }
+
+  get hasFileRequirement() {
+    let fileRequirement = this.form.find('li#required-files')
+    return fileRequirement.size() > 0
+  }
+
+  get hasFiles() {
+    let fileField = this.form.find('input[name="uploaded_files[]"]')
+    return fileField.size() > 0
+  }
+
+  get hasNewFiles() {
+    // In a future release hasFiles will include files already on the work plus new files,
+    // but hasNewFiles() will include only the files added in this browser window.
+    return this.hasFiles
+  }
+}

--- a/spec/features/generic_work/upload_and_delete_spec.rb
+++ b/spec/features/generic_work/upload_and_delete_spec.rb
@@ -145,46 +145,6 @@ describe 'Generic File uploading and deletion:', type: :feature do
         end
       end
     end
-
-    context 'user does not need help' do
-      context 'with a single file' do
-        before { allow(ShareNotifyDeleteJob).to receive(:perform_later) }
-
-        specify 'uploading, deleting and notifications' do
-          visit '/concern/generic_works/new'
-          click_on 'Files'
-          attach_file('files[]', test_file_path(filename), visible: false)
-          click_on 'Start'
-          click_on 'Metadata'
-          fill_in 'generic_work_title', with: filename + '_title'
-          fill_in 'generic_work_keyword', with: filename + '_keyword'
-          fill_in 'generic_work_creator', with: filename + '_creator'
-          fill_in 'generic_work_description', with: filename + '_description'
-          select 'Audio', from: 'generic_work_resource_type'
-          select 'Attribution-NonCommercial-NoDerivatives 4.0 International', from: 'generic_work_rights'
-          within("#savewidget") do
-            choose 'generic_work_visibility_authenticated'
-          end
-          check 'agreement'
-          sleep(1.second)
-          click_on 'Save'
-          expect(page).to have_css('h1', filename + '_title')
-          click_link "My Dashboard"
-          expect(page).to have_css "table#activity"
-          within("table#activity") do
-            expect(page).to have_content filename
-          end
-          within("#notifications") do
-            expect(page).to have_content "little_file.txt was successfully added"
-          end
-          go_to_dashboard_works
-          expect(page).to have_content file.title.first
-          db_item_actions_toggle(file).click
-          click_link 'Delete Work'
-          expect(page).to have_content "Deleted #{file.title.first}"
-        end
-      end
-    end
   end
 
   context 'When logged in as a non-PSU user' do

--- a/spec/features/generic_work/upload_no_help_spec.rb
+++ b/spec/features/generic_work/upload_no_help_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+require 'feature_spec_helper'
+
+include Selectors::Dashboard
+
+describe 'Generic File uploading and deletion:', type: :feature do
+  let(:new_generic_work_path) { '/concern/generic_works/new' }
+  let(:current_user)          { create(:user) }
+  let(:other_user)            { create(:user) }
+  let(:filename)              { 'little_file.txt' }
+  let(:batch)                 { ['little_file.txt', 'little_file.txt'] }
+  let(:file)                  { work }
+  let(:work)                  { find_work_by_title "little_file.txt_title" }
+
+  before { sign_in_with_named_js(:upload_no_help, current_user, disable_animations: true) }
+
+  context 'user does not need help' do
+    context 'with a single file' do
+      before { allow(ShareNotifyDeleteJob).to receive(:perform_later) }
+
+      specify 'uploading, deleting and notifications' do
+        visit '/concern/generic_works/new'
+        click_on 'Files'
+        attach_file('files[]', test_file_path(filename), visible: false)
+        click_on 'Start'
+        click_on 'Metadata'
+        fill_in 'generic_work_title', with: filename + '_title'
+        fill_in 'generic_work_keyword', with: filename + '_keyword'
+        fill_in 'generic_work_creator', with: filename + '_creator'
+        fill_in 'generic_work_description', with: filename + '_description'
+        select 'Audio', from: 'generic_work_resource_type'
+        select 'Attribution-NonCommercial-NoDerivatives 4.0 International', from: 'generic_work_rights'
+        within("#savewidget") do
+          choose 'generic_work_visibility_authenticated'
+        end
+        check 'agreement'
+        sleep(3.seconds)
+        click_on 'Save'
+        expect(page).to have_css('h1', filename + '_title')
+        click_link "My Dashboard"
+        expect(page).to have_css "table#activity"
+        within("table#activity") do
+          expect(page).to have_content filename
+        end
+        within("#notifications") do
+          expect(page).to have_content "little_file.txt was successfully added"
+        end
+        go_to_dashboard_works
+        expect(page).to have_content file.title.first
+        db_item_actions_toggle(file).click
+        click_link 'Delete Work'
+        expect(page).to have_content "Deleted #{file.title.first}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
If a file was added, then deleted, the form would not update its file requirement check and a user could proceed to created a work without a file. This overrides Sufia to add a fileuploaddestroyed callback which re-checks the forms validity if a file is deleted.

It's not the classiest fix because we're overriding an entire file to make a one-line change. However, this is ecmascript, and while it's possible (in theory) to do some class inheritance, I'm not sure how and if it would work. 