### PR TITLE
Add warning message for batch editing permissions, ref #803

### DIFF
--- a/app/views/batch_edits/edit.html.erb
+++ b/app/views/batch_edits/edit.html.erb
@@ -6,6 +6,8 @@
 <p>Changes will be applied to the following <%= @form.names.size %> works:</p>
 <%= @form.names.join(", ").html_safe %>
 
+<div class="alert alert-warning"><%= t('scholarsphere.batch_edit.permissions_warning') %></div>
+
 <div class="row">
   <div class="col-xs-12 col-sm-8" role="main">
 
@@ -36,11 +38,11 @@
             <div id="status_permissions" class="status fleft"></div>
           </div>
         <% end %>
-      </div>     
+      </div>
     </div>
 
     <!-- Ajax call to clear the batch before page uload. -->
-    <%= button_to "Clear Batch", { controller: :batch_edits, action: :clear }, 
+    <%= button_to "Clear Batch", { controller: :batch_edits, action: :clear },
         form_class: 'hidden', remote: true, id: 'clear_batch' %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -62,6 +62,8 @@ en:
       available: "Files Available for Upload"
       caption: "Listing of files ready to be uploaded"
       local: "Files must be added before they can be uploaded"
+    batch_edit:
+      permissions_warning: "Warning! Making changes to visibility or sharing permissions will remove any existing permissions on the files in this batch and replace them with the ones specified here."
   statistic:
     report:
       subject: "ScholarSphere - Statistic Report"

--- a/spec/features/batch_edit_spec.rb
+++ b/spec/features/batch_edit_spec.rb
@@ -42,6 +42,7 @@ describe "Batch management of works", type: :feature do
       expect(page).to have_css "input#batch_edit_item_subject[value*='subjectsubject']"
       expect(page).to have_css "input#batch_edit_item_related_url[value*='http://example.org/TheRelatedURLLink/']"
       expect(page).to have_no_checked_field("Private")
+      expect(page).to have_content(I18n.t('scholarsphere.batch_edit.permissions_warning'))
     end
   end
 


### PR DESCRIPTION
Inform users that batch editing permissions will overwrite any other existing permissions.