### PR TITLE
Add fileuploaddestroyed to UploadedFiles JS, ref #775

### DIFF
--- a/app/assets/javascripts/sufia/save_work/uploaded_files.es6
+++ b/app/assets/javascripts/sufia/save_work/uploaded_files.es6
@@ -1,0 +1,28 @@
+// Overrides Sufia to add the fileuploaddestroyed callback so the form re-checks that the file requirement
+// is met. Avoids a bug where works could be created without files if the file was uploaded then deleted.
+export class UploadedFiles {
+  // Monitors the form and runs the callback if any files are added
+  // Adds a fileuploaddestroyed callback which is not present in the source code
+  // but is documented in the jQuery-File-Upload Github wiki.
+  constructor(form, callback) {
+    this.form = form
+    $('#fileupload').bind('fileuploadcompleted', callback)
+    $('#fileupload').bind('fileuploaddestroyed', callback)
+  }
+
+  get hasFileRequirement() {
+    let fileRequirement = this.form.find('li#required-files')
+    return fileRequirement.size() > 0
+  }
+
+  get hasFiles() {
+    let fileField = this.form.find('input[name="uploaded_files[]"]')
+    return fileField.size() > 0
+  }
+
+  get hasNewFiles() {
+    // In a future release hasFiles will include files already on the work plus new files,
+    // but hasNewFiles() will include only the files added in this browser window.
+    return this.hasFiles
+  }
+}

--- a/spec/features/generic_work/upload_and_delete_spec.rb
+++ b/spec/features/generic_work/upload_and_delete_spec.rb
@@ -165,6 +165,7 @@ describe 'Generic File uploading and deletion:', type: :feature do
           within("#savewidget") do
             choose 'generic_work_visibility_authenticated'
           end
+          sleep(1.second)
           check 'agreement'
           sleep(1.second)
           click_on 'Save'


### PR DESCRIPTION
If a file was added, then deleted, the form would not update its file requirement check and a user could proceed to created a work without a file.

This overrides Sufia to add a fileuploaddestroyed callback which re-checks the forms validity if a file is deleted.

@cam156 I decided not to spilt out the failing test because we loose the commit history, and incorporated your change here.