### PR TITLE
Display Penn State institution label, ref #811

### DIFF
--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -79,6 +79,7 @@ en:
         rights: "Licensing and distribution information governing access to the collection. A rights statement or license ensures your collection gets used appropriately and that you get credit when your collection is used. See <a href=\"/licenses\" target=\"_blank\">Licenses</a> for more information"
         title: "A name to aid in identifying a collection. A descriptive title will make it much easier to find your collection. Avoid uninformative titles."
   curation_concerns:
+    institution_name: "Penn State"
     institution:
       name: "Penn State"
     base:

--- a/spec/factories/works.rb
+++ b/spec/factories/works.rb
@@ -41,7 +41,7 @@ FactoryGirl.define do
       end
     end
 
-    factory :registered_file do
+    factory :registered_file, aliases: [:registered_work] do
       visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
     end
 


### PR DESCRIPTION
Registered works' visibility was displaying as "Institution Name" instead of Penn State in certain views.

An updated locales file solved the problem, but refactoring some of our feature tests expanded test the test coverage.