### PR TITLE
Updating Solr to 6.4.2

### DIFF
--- a/.solr_wrapper
+++ b/.solr_wrapper
@@ -1,5 +1,5 @@
 # .solr_wrapper
-version: 6.4.1
+version: 6.4.2
 port: 8983
 instance_dir: tmp/solr-development
 download_dir: tmp

--- a/config/solr_wrapper_test.yml
+++ b/config/solr_wrapper_test.yml
@@ -1,5 +1,5 @@
 # config/solr_wrapper_test.yml
-version: 6.4.1
+version: 6.4.2
 port: 8985
 instance_dir: tmp/solr-test
 download_dir: tmp

--- a/config/travis/solr_wrapper_test.yml
+++ b/config/travis/solr_wrapper_test.yml
@@ -1,5 +1,5 @@
 #config/solr_wrapper_test.yml
-version: 6.4.1
+version: 6.4.2
 port: 8985
 instance_dir: solr-test
 download_dir: dep_cache


### PR DESCRIPTION
Our server environments were updated to use Solr 6.4.2, so our testing and local development environments should follow suit.