### PR TITLE
Relabels Open Access to Public 

### DIFF
--- a/app/presenters/collection_presenter.rb
+++ b/app/presenters/collection_presenter.rb
@@ -4,4 +4,8 @@ class CollectionPresenter < Sufia::CollectionPresenter
   def self.terms
     super + [:date_modified, :date_uploaded]
   end
+
+  def permission_badge_class
+    PublicPermissionBadge
+  end
 end

--- a/app/presenters/file_set_presenter.rb
+++ b/app/presenters/file_set_presenter.rb
@@ -16,4 +16,8 @@ class FileSetPresenter < Sufia::FileSetPresenter
   def display_download_link?
     CurationConcerns.config.display_media_download_link
   end
+
+  def permission_badge_class
+    PublicPermissionBadge
+  end
 end

--- a/app/presenters/public_permission_badge.rb
+++ b/app/presenters/public_permission_badge.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+class PublicPermissionBadge < CurationConcerns::PermissionBadge
+  private
+
+    def link_title
+      if open_access_with_embargo?
+        'Open Access with Embargo'
+      elsif open_access?
+        I18n.translate('sufia.visibility.open')
+      elsif registered?
+        I18n.translate('curation_concerns.institution_name')
+      else
+        'Private'
+      end
+    end
+end

--- a/app/presenters/work_show_presenter.rb
+++ b/app/presenters/work_show_presenter.rb
@@ -36,6 +36,10 @@ class WorkShowPresenter < Sufia::WorkShowPresenter
     send(field).zip(FacetValueCleaningService.call(send(field), config)).to_h
   end
 
+  def permission_badge_class
+    PublicPermissionBadge
+  end
+
   private
 
     # Override to add rows parameter

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -51,6 +51,8 @@ en:
         instructions: "The file structure will be flattened and all files will be uploaded to one new work. If you'd like to maintain the file structure, consider using the zip or similar format."
       new:
         after_create_html: "Your files are being processed by %{application_name} in the background. Your files will be displayed below as they are processed. You may need to refresh this page to see these updates."
+    visibility:
+      open: "Public"
     batch_uploads:
       files:
         instructions: "The file structure will be flattened and each file will be uploaded to a separate new work resulting in one work per uploaded file. If you'd like to maintain the file structure, consider using the zip or similar format."

--- a/spec/features/dashboard/dashboard_works_spec.rb
+++ b/spec/features/dashboard/dashboard_works_spec.rb
@@ -48,7 +48,7 @@ describe 'Dashboard Works', type: :feature do
 
       # Displays visibility information about my works
       within("#document_#{work1.id}") do
-        expect(page).to have_selector("span.label-success", text: "Open Access")
+        expect(page).to have_selector("span.label-success", text: "Public")
       end
       within("#document_#{work2.id}") do
         expect(page).to have_selector("span.label-info", text: "Penn State")

--- a/spec/features/generic_work/view_and_download_spec.rb
+++ b/spec/features/generic_work/view_and_download_spec.rb
@@ -31,7 +31,7 @@ describe GenericWork, type: :feature do
         expect(page).to have_content work1.title.first
         expect(page).not_to have_link "Feature"
         within("h1 span") do
-          expect(page).to have_content("Open Access")
+          expect(page).to have_content("Public")
         end
 
         within("ul.breadcrumb") do


### PR DESCRIPTION
Overrides translation from Sufia and permission badge presenter from Curation Concerns. Rubocop fixes and updates spec test to replace open access with public. This change makes labeling more consistent in the interface and is more accurate with certain rights selections.