### PR TITLE
Update audit_repository script, ref #783

### DIFF
--- a/script/audit_repository
+++ b/script/audit_repository
@@ -3,6 +3,4 @@
 
 require File.expand_path(File.join(File.dirname(__FILE__), '../config/environment.rb'))
 
-::GenericFile.find_each do |gf|
-  Sufia::GenericFileAuditService.new(gf).audit
-end
+Sufia::RepositoryAuditService.audit_everything


### PR DESCRIPTION
The previous script used a class that no longer existed.

We've updated the script to use the new Sufia service which reports errors in the same way as previous audits.

Failures are written to the ChecksumAuditLog files are only re-checked if the CurationConcerns.config.max_days_between_audits has passed since the last audit.