### PR TITLE
Create rake task for Resque assets, ref #444

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -170,6 +170,18 @@ namespace :deploy do
   end
   after :migrate, :roleassets
 
+  desc "Create a symlink to assets used by Resque"
+  task :symlink_resque_assets do
+    on roles(:web) do
+      within release_path do
+        with rails_env: fetch(:rails_env) do
+          execute :rake, "resque:assets"
+        end
+      end
+    end
+  end
+  after :roleassets, :symlink_resque_assets
+
   # Passenger Capistrano Task
   # The passenger install task allows Chef to install Passenger now via Yum, but it allows Capistrano to maintain the file
   # as Ruby is updated on the system.  The PassengerDefaultRuby variable is set to system ruby by default from the Yum

--- a/lib/tasks/resque.rake
+++ b/lib/tasks/resque.rake
@@ -25,3 +25,11 @@ task "resque:retry-failed-jobs" => :environment do
   end
 end
 
+desc "Symlinks assets from Resque's gem to the public/admin folder"
+task "resque:assets" => :environment do
+  FileUtils.mkdir_p(File.join(Rails.root, "public/admin"))
+  resque_path = Gem::Specification.all.select { |gem| gem.name == "resque" }.first.gem_dir
+  assets = File.join(resque_path, "lib/resque/server/public")
+  target = File.join(Rails.root, "public/admin/queues")
+  FileUtils.ln_sf(assets, target)
+end


### PR DESCRIPTION
Resque's web interface isn't finding css and js assets.

Although probably fixed in later releases, for now we are just symlinking the assets from where they are in the gem to where Resque is expecting to find them, under public/admin.

This commit can be reverted once Resque is updated and/or replaced with the resque-web gem.