### PR TITLE
Use ruby 2.3.3 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
 bundler_args: --without development debug
 sudo: false
 rvm:
-  - 2.3.0
+  - 2.3.3
 jdk:
   - oraclejdk8
 env:


### PR DESCRIPTION
Travis's ruby version did not match our locally-deployed one.