### PR TITLE
Display Twitter and Google Scholar metadata, ref #335

### DIFF
--- a/app/views/curation_concerns/base/show.html.erb
+++ b/app/views/curation_concerns/base/show.html.erb
@@ -1,8 +1,19 @@
 <%#
-    Overrides the CC title helper in Sufia and hard code string with interpolated values.
-    Overrides Sufia to swap the order of relationships and descriptions partials
+    - Overrides the CC title helper in Sufia and hard code string with interpolated values.
+    - Overrides Sufia to swap the order of relationships and descriptions partials
+    - Moves Twitter and Google Scholar meta tags
 %>
+
+<% content_for(:twitter_meta) do %>
+  <%= render "shared/twitter", presenter: @presenter %>
+<% end %>
+
+<% content_for(:gscholar_meta) do %>
+  <%= render "shared/gscholar", presenter: @presenter %>
+<% end %>
+
 <% provide :page_title, "Work | #{@presenter.title.first} | Work ID: #{@presenter.id} | ScholarSphere" %>
+
 <div itemscope itemtype="http://schema.org/CreativeWork" class="row">
   <div class="col-xs-12">
     <header>

--- a/app/views/shared/_gscholar.html.erb
+++ b/app/views/shared/_gscholar.html.erb
@@ -1,0 +1,11 @@
+<meta name="citation_title" content="<%= presenter.title.first %>"/>
+
+<% presenter.creator.each do |creator| %>
+  <meta name="citation_author" content="<%= creator %>"/>
+<% end %>
+
+<meta name="citation_publication_date" content="<%= presenter.date_created.first %>"/>
+
+<% if presenter.representative_presenter.display_download_link? %>
+  <meta name="citation_pdf_url" content="<%= main_app.download_url(presenter.representative_presenter) %>"/>
+<% end %>

--- a/app/views/shared/_twitter.html.erb
+++ b/app/views/shared/_twitter.html.erb
@@ -1,0 +1,20 @@
+<meta name="twitter:card" content="product">
+<meta name="twitter:site" content="<%= t('sufia.product_twitter_handle') %>"/>
+<meta name="twitter:creator" content="<%= presenter.tweeter %>"/>
+<meta property="og:site_name" content="<%= application_name %>"/>
+<meta property="og:type" content="object"/>
+<meta property="og:title" content="<%= presenter.title.first %>"/>
+
+<% unless presenter.description.empty? %>
+  <meta property="og:description" content="<%= presenter.description.first.truncate(200) %>"/>
+<% end %>
+
+<% if presenter.representative_presenter.display_download_link? %>
+  <meta property="og:image" content="<%= main_app.download_url(presenter.representative_presenter, file: 'thumbnail') %>"/>
+<% end %>
+
+<meta property="og:url" content="<%= polymorphic_path([main_app, presenter]) %>"/>
+<meta name="twitter:data1" content="<%= presenter.keyword.join(', ') %>"/>
+<meta name="twitter:label1" content="Keywords"/>
+<meta name="twitter:data2" content="<%= presenter.rights %>"/>
+<meta name="twitter:label2" content="Rights"/>

--- a/spec/features/generic_work/view_and_download_spec.rb
+++ b/spec/features/generic_work/view_and_download_spec.rb
@@ -34,6 +34,11 @@ describe GenericWork, type: :feature do
           expect(page).to have_content("Public")
         end
 
+        # Meta tag information for Google Scholar
+        expect(page).to have_css('meta[name="citation_title"]', visible: false)
+        expect(page).to have_css('meta[name="citation_author"]', visible: false)
+        expect(page).to have_css('meta[name="citation_publication_date"]', visible: false)
+
         within("ul.breadcrumb") do
           expect(page).to have_link("My Dashboard")
           expect(page).to have_link("My Works")

--- a/spec/views/shared/_gscholar.html.erb_spec.rb
+++ b/spec/views/shared/_gscholar.html.erb_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe "shared/_gscholar.html.erb" do
+  let(:doc)       { SolrDocument.new(build(:work, id: "citation-test").to_solr) }
+  let(:presenter) { WorkShowPresenter.new(doc, Ability.new(nil)) }
+
+  subject { rendered }
+
+  context "without a representative file set" do
+    before do
+      allow(presenter).to receive(:member_presenters).and_return([])
+      render "shared/gscholar", presenter: presenter
+    end
+
+    it { is_expected.to include('<meta name="citation_title" content="Sample Title"/>') }
+  end
+
+  context "with a file set" do
+    let(:fs_doc)       { SolrDocument.new(build(:file_set, id: "citation-download").to_solr) }
+    let(:fs_presenter) { FileSetPresenter.new(fs_doc, Ability.new(nil)) }
+
+    before do
+      allow(presenter).to receive(:member_presenters).and_return([fs_presenter])
+      allow(presenter).to receive(:representative_presenter).and_return(fs_presenter)
+      render "shared/gscholar", presenter: presenter
+    end
+
+    it { is_expected.to include('<meta name="citation_pdf_url" content="http://test.host/downloads/citation-download"/>') }
+  end
+end

--- a/spec/views/shared/_twitter.html.erb_spec.rb
+++ b/spec/views/shared/_twitter.html.erb_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe "shared/_twitter.html.erb" do
+  let(:doc)       { SolrDocument.new(build(:work, id: "citation-test").to_solr) }
+  let(:presenter) { WorkShowPresenter.new(doc, Ability.new(nil)) }
+
+  subject { rendered }
+
+  context "without a representative file set" do
+    before do
+      allow(presenter).to receive(:member_presenters).and_return([])
+      render "shared/twitter", presenter: presenter
+    end
+
+    it { is_expected.to include('<meta property="og:title" content="Sample Title"/>') }
+  end
+
+  context "with a file set" do
+    let(:fs_doc)       { SolrDocument.new(build(:file_set, id: "citation-download").to_solr) }
+    let(:fs_presenter) { FileSetPresenter.new(fs_doc, Ability.new(nil)) }
+
+    before do
+      allow(presenter).to receive(:member_presenters).and_return([fs_presenter])
+      allow(presenter).to receive(:representative_presenter).and_return(fs_presenter)
+      render "shared/twitter", presenter: presenter
+    end
+
+    it { is_expected.to include('<meta property="og:image" content="http://test.host/downloads/citation-download?file=thumbnail"/>') }
+  end
+end


### PR DESCRIPTION
Google Scholar metadata was not rendering because (likely) the partial was never getting called in our code.

This changes the render to call directly in the show view, but uses separate partials to allow for easier testing and adding more tags later.