### PR TITLE
Patch Mail to fix SMTP injection vulnerability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,9 @@ gem 'curation_concerns', github: 'projecthydra/curation_concerns', ref: 'b073550
 gem 'hydra-works', github: 'projecthydra/hydra-works', ref: 'f948eb0'
 gem 'browse-everything', github: 'projecthydra/browse-everything', ref: '0e33595'
 
+# Use patched version of mail. Remove this once 2.6.6 is officially out
+gem 'mail', '= 2.6.6.rc1'
+
 # Other components
 gem 'clamav' unless ENV['TRAVIS'] == 'true'
 gem 'coffee-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -468,7 +468,7 @@ GEM
       multi_json (~> 1.10)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
-    mail (2.6.4)
+    mail (2.6.6.rc1)
       mime-types (>= 1.16, < 4)
     mailboxer (0.14.0)
       carrierwave (>= 0.5.8)
@@ -856,6 +856,7 @@ DEPENDENCIES
   kaminari_route_prefix
   launchy
   ldap_disambiguate
+  mail (= 2.6.6.rc1)
   mysql2 (~> 0.3.17)
   namae (= 0.9.3)
   nest
@@ -892,4 +893,4 @@ DEPENDENCIES
   yaml_db
 
 BUNDLED WITH
-   1.14.5
+   1.14.6


### PR DESCRIPTION
2.6.6 is still in release candidate status, so this commit should be reverted of updated once 2.6.6 is out.