### PR TITLE
Update cronjobs with current emails, ref #848

### DIFF
--- a/config/cronjobs/compare_solr.bash
+++ b/config/cronjobs/compare_solr.bash
@@ -7,7 +7,7 @@
 #  Description:  Compares number of objects in Solr with Fedora
 #                and emails the results
 #
-# V  Installed  Programmer    Description                                     
+# V  Installed  Programmer    Description
 # -- ---------- ------------  -------------------------------------------------
 # 01 2014-09-22 awead         First Edition
 #
@@ -32,7 +32,7 @@ fi
 RESULTS=`bundle exec rake scholarsphere:solr:compare`
 if [ $? -ne 0 ]; then
   MESSAGE="rake scholarsphere:solr:compare exited with a non-zero status. Last success was $DATE. $RESULTS"
-  echo $MESSAGE | mail -s "$SUBJECT" UL-DLT-HYDRA@LISTS.PSU.EDU
+  echo $MESSAGE | mail -s "$SUBJECT" umg-up.its.scholarsphere-support@groups.ucs.psu.edu
 else
   date > /tmp/last_compare_solr_run
 fi

--- a/config/cronjobs/update_user_stats.bash
+++ b/config/cronjobs/update_user_stats.bash
@@ -25,7 +25,7 @@ RESULTS=`bundle exec rake sufia:stats:user_stats 2>&1`
 if [ $? -ne 0 ]; then
   SUBJECT="`hostname` user stats task"
   MESSAGE="rake scholarsphere:stats:user_stats exited with a non-zero status.  $RESULTS"
-  echo $MESSAGE | mail -s "$SUBJECT" UL-DLT-HYDRA@LISTS.PSU.EDU
+  echo $MESSAGE | mail -s "$SUBJECT" umg-up.its.scholarsphere-support@groups.ucs.psu.edu
 fi
 
 echo $RESULTS

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -4,6 +4,9 @@
 #
 # NOTE: If you want the cronjob to run only on one machine, use :job for the roles
 #       otherwise, the :app role will run the cronjob on every server!
+
+# Create the log file, if it isn't there
+FileUtils.touch("#{path}/log/wheneveroutput.log")
 set :output, "#{path}/log/wheneveroutput.log"
 
 every :day, at: "12:00am", roles: [:app] do
@@ -29,6 +32,10 @@ end
 
 every :monday, at: "6:00 am", roles: [:job] do
   command "#{path}/config/cronjobs/send_weekly_stats.bash"
+end
+
+every :day, at: "5:00 am", roles: [:job] do
+  command "#{path}/config/cronjobs/send_daily_stats.bash"
 end
 
 every 60.minutes, roles: [:app] do


### PR DESCRIPTION
Updates the emails used in cronjobs to send failure information. Also adds the daily stats jobs to schedule.rb. It wasn't there before, so I'm not sure how it was getting run in the first place.