### PR TITLE
Update cronjobs with current emails, ref #848

### DIFF
--- a/config/cronjobs/compare_solr.bash
+++ b/config/cronjobs/compare_solr.bash
@@ -7,7 +7,7 @@
 #  Description:  Compares number of objects in Solr with Fedora
 #                and emails the results
 #
-# V  Installed  Programmer    Description                                     
+# V  Installed  Programmer    Description
 # -- ---------- ------------  -------------------------------------------------
 # 01 2014-09-22 awead         First Edition
 #
@@ -32,7 +32,7 @@ fi
 RESULTS=`bundle exec rake scholarsphere:solr:compare`
 if [ $? -ne 0 ]; then
   MESSAGE="rake scholarsphere:solr:compare exited with a non-zero status. Last success was $DATE. $RESULTS"
-  echo $MESSAGE | mail -s "$SUBJECT" UL-DLT-HYDRA@LISTS.PSU.EDU
+  echo $MESSAGE | mail -s "$SUBJECT" umg-up.its.scholarsphere-support@groups.ucs.psu.edu
 else
   date > /tmp/last_compare_solr_run
 fi

--- a/config/cronjobs/update_user_stats.bash
+++ b/config/cronjobs/update_user_stats.bash
@@ -25,7 +25,7 @@ RESULTS=`bundle exec rake sufia:stats:user_stats 2>&1`
 if [ $? -ne 0 ]; then
   SUBJECT="`hostname` user stats task"
   MESSAGE="rake scholarsphere:stats:user_stats exited with a non-zero status.  $RESULTS"
-  echo $MESSAGE | mail -s "$SUBJECT" UL-DLT-HYDRA@LISTS.PSU.EDU
+  echo $MESSAGE | mail -s "$SUBJECT" umg-up.its.scholarsphere-support@groups.ucs.psu.edu
 fi
 
 echo $RESULTS

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -33,8 +33,8 @@ set :passenger_roles, :web
 # rails settings, NOTE: Task is wired into event stack
 set :rails_env, 'production'
 
-# whenever settings, NOTE: Task is wired into event stack
-set :whenever_identifier, -> { "#{fetch(:application)}_#{fetch(:stage)}" }
+# Settings for whenever gem that updates the crontab file on the server
+# See schedule.rb for details
 set :whenever_roles, [:app, :job]
 
 set :log_level, :debug

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,9 +1,16 @@
 # frozen_string_literal: true
-
 # Use this file to easily define all of your cron jobs.
 #
-# NOTE: If you want the cronjob to run only on one machine, use :job for the roles
+# @example Running commands manually
+#   bundle exec cap whenever:clear_crontab
+#   bundle exec cap whenever:update_crontab
+#
+# @note If you want the cronjob to run only on one machine, use :job for the roles
 #       otherwise, the :app role will run the cronjob on every server!
+# @note The clear_crontab and update_crontab commands are run automatically when running cap deploy
+#
+# @see http://github.com/javan/whenever
+
 set :output, "#{path}/log/wheneveroutput.log"
 
 every :day, at: "12:00am", roles: [:app] do
@@ -31,6 +38,10 @@ every :monday, at: "6:00 am", roles: [:job] do
   command "#{path}/config/cronjobs/send_weekly_stats.bash"
 end
 
+every :day, at: "5:00 am", roles: [:job] do
+  command "#{path}/config/cronjobs/send_daily_stats.bash"
+end
+
 every 60.minutes, roles: [:app] do
   command "#{path}/config/cronjobs/temp_file_clean.bash"
 end
@@ -38,5 +49,3 @@ end
 every 10.minutes, roles: [:job] do
   command "#{path}/config/cronjobs/resque-cleanup.bash"
 end
-
-# Learn more: http://github.com/javan/whenever


### PR DESCRIPTION
Updates the emails used in cronjobs to send failure information. Also adds the daily stats jobs to schedule.rb and adjusts Capistrano's whenever settings so that crontabs are being cleared and regenerated correctly.

I'm not sure how send_daily_stats.bash was getting run unless it was managed somewhere else, so maybe that change needs to come out.

@cam156 