### PR TITLE
Fix issue with capturing and rendering Google Analytics info, ref #842

### DIFF
--- a/app/assets/javascripts/sufia/ga_events.js
+++ b/app/assets/javascripts/sufia/ga_events.js
@@ -1,0 +1,9 @@
+// Callbacks for tracking events using Google Analytics
+// This changes Sufia's implementation to use a css class instead of an id, enabling us
+// to track multiple download links in a page.
+
+$(document).on('click', '.ga-download', function(e) {
+  _gaq.push(['_trackEvent', 'Files', 'Downloaded', $(this).data('label')]);
+
+});
+

--- a/app/views/curation_concerns/base/_member.html.erb
+++ b/app/views/curation_concerns/base/_member.html.erb
@@ -10,7 +10,7 @@
     <% if can?(:edit, member.id) %>
       <%= render 'actions', member: member %>
     <% else %>
-      <%= link_to 'Download', main_app.download_path(member), class: 'btn btn-default btn-sm',
+      <%= link_to 'Download', main_app.download_path(member), class: 'btn btn-default btn-sm ga-download',
                   title: "Download #{member.to_s.inspect}", target: "_blank" %>
     <% end %>
   </td>

--- a/app/views/curation_concerns/file_sets/_actions.html.erb
+++ b/app/views/curation_concerns/file_sets/_actions.html.erb
@@ -1,0 +1,42 @@
+<%# Overrides Sufia to add class to download link to track statistics via GA %>
+<div class="btn-group">
+
+  <button class="btn btn-default dropdown-toggle" data-toggle="dropdown" type="button" id="dropdownMenu_<%= file_set.id %>" aria-haspopup="true">
+    <span class="sr-only">Press to </span>
+    Select an action
+    <span class="caret" aria-hidden="true"></span>
+  </button>
+
+  <ul role="menu" class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenu_<%= file_set.id %>">
+
+  <% if can?(:edit, file_set.id) %>
+    <li role="menuitem" tabindex="-1">
+      <%= link_to 'Edit', edit_polymorphic_path([main_app, file_set]),
+        { title: "Edit #{file_set}" } %>
+    </li>
+
+    <li role="menuitem" tabindex="-1">
+      <%= link_to 'Versions',  edit_polymorphic_path([main_app, file_set], anchor: 'versioning_display'),
+        { title: "Display previous versions" } %>
+    </li>
+  <% end %>
+
+  <% if can?(:destroy, file_set.id) %>
+    <li role="menuitem" tabindex="-1">
+      <%= link_to 'Delete', polymorphic_path([main_app, file_set]),
+        method: :delete, title: "Delete #{file_set}",
+        data: {confirm: "Deleting #{file_set} from #{application_name} is permanent. Click OK to delete this from #{application_name}, or Cancel to cancel this operation"} %>
+    </li>
+  <% end %>
+
+  <% if can?(:read, file_set.id) %>
+    <li role="menuitem" tabindex="-1">
+      <%= link_to 'Download', main_app.download_path(file_set), class: "ga-download",
+        title: "Download #{file_set.to_s.inspect}", target: "_blank" %>
+    </li>
+  <% end %>
+
+  </ul>
+</div>
+
+

--- a/app/views/curation_concerns/file_sets/media_display/_image.html.erb
+++ b/app/views/curation_concerns/file_sets/media_display/_image.html.erb
@@ -1,4 +1,5 @@
-<% if file_set.respond_to?(:display_download_link?) && file_set.display_download_link? %>
+<%# Overrides Sufia to add class to download link to track statistics via GA %>
+<% if CurationConcerns.config.display_media_download_link %>
     <div>
       <h2 class="sr-only"><%= t('curation_concerns.show.downloadable_content.heading') %></h2>
       <%= image_tag thumbnail_url(file_set),
@@ -9,7 +10,7 @@
                   target: :_blank,
                   data: { turbolinks: false },
                   class: "btn btn-default ga-download" do %>
-          <%= t('curation_concerns.show.downloadable_content.default_link') %>
+          <%= t('curation_concerns.show.downloadable_content.image_link') %>
       <% end %>
     </div>
 <% else %>

--- a/app/views/curation_concerns/file_sets/media_display/_office_document.html.erb
+++ b/app/views/curation_concerns/file_sets/media_display/_office_document.html.erb
@@ -1,4 +1,5 @@
-<% if file_set.respond_to?(:display_download_link?) && file_set.display_download_link? %>
+<%# Overrides Sufia to add class to download link to track statistics via GA %>
+<% if CurationConcerns.config.display_media_download_link %>
     <div>
       <h2 class="sr-only"><%= t('curation_concerns.show.downloadable_content.heading') %></h2>
       <%= image_tag thumbnail_url(file_set),
@@ -6,10 +7,11 @@
                     alt: "",
                     role: "presentation" %>
       <%= link_to main_app.download_path(file_set),
-                  target: :_blank,
+                  target: "_new",
                   data: { turbolinks: false },
+                  target: :_blank,
                   class: "btn btn-default ga-download" do %>
-          <%= t('curation_concerns.show.downloadable_content.default_link') %>
+          <%= t('curation_concerns.show.downloadable_content.office_link') %>
       <% end %>
     </div>
 <% else %>

--- a/app/views/curation_concerns/file_sets/media_display/_pdf.html.erb
+++ b/app/views/curation_concerns/file_sets/media_display/_pdf.html.erb
@@ -1,4 +1,5 @@
-<% if file_set.respond_to?(:display_download_link?) && file_set.display_download_link? %>
+<%# Overrides Sufia to add class to download link to track statistics via GA %>
+<% if CurationConcerns.config.display_media_download_link %>
     <div>
       <h2 class="sr-only"><%= t('curation_concerns.show.downloadable_content.heading') %></h2>
       <%= image_tag thumbnail_url(file_set),
@@ -9,7 +10,7 @@
                   target: :_blank,
                   data: { turbolinks: false },
                   class: "btn btn-default ga-download" do %>
-          <%= t('curation_concerns.show.downloadable_content.default_link') %>
+          <%= t('curation_concerns.show.downloadable_content.pdf_link') %>
       <% end %>
     </div>
 <% else %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,4 +1,10 @@
 # frozen_string_literal: true
+# In production, these are normally "eager loaded" but in development, they are not.
+# This enables the stats view pages to render.
+require 'legato'
+require 'sufia/pageview'
+require 'sufia/download'
+
 Sufia::Engine.configure do
   config.logout_url = 'https://webaccess.psu.edu/cgi-bin/logout?http://localhost:3000/'
   config.login_url = 'https://webaccess.psu.edu/?cosign-localhost&http://localhost:3000/dashboard'

--- a/lib/tasks/scholarsphere/stats.rake
+++ b/lib/tasks/scholarsphere/stats.rake
@@ -3,7 +3,14 @@ namespace :scholarsphere do
 
     desc "Cache file view & download stats for all users"
     task :user_stats => :environment do
-      require 'sufia/models/stats/user_stat_importer'
+
+      # These must be required here so that Pageview and Download classes will properly load Legato's
+      # additional methods. In a complete Rails production environment, they are eager-loaded, but
+      # for rake tasks they do not appear to be.
+      require 'legato'
+      require 'sufia/pageview'
+      require 'sufia/download'
+
       importer = Sufia::UserStatImporter.new(verbose: true, logging: true, delay_secs: 1.0, number_of_retries: 5)
       importer.import
     end


### PR DESCRIPTION
GA was not registering any file downloads because the configured dom id wasn't there. Also, the rake tasks that were caching this information were not executing.

Since download links can be in multiple places, we're opting for a class that can be applied to any link and will register that event in Google. The rake task wasn't executing because existing loading mechanisms weren't including all the correct code from the Legato gem.