### PR TITLE
Render a telephone link in user profile, ref #801

### DIFF
--- a/app/views/users/_user_info.html.erb
+++ b/app/views/users/_user_info.html.erb
@@ -34,7 +34,7 @@
 
       <% if user.telephone %>
           <dt><span class="glyphicon glyphicon-earphone" aria-hidden="true"></span> Telephone</dt>
-          <dd><%= link_to_telephone(user) %></dd>
+          <dd><%= link_to user.telephone, "tel:#{user.telephone.gsub(/\s+/, "")}" %></dd>
       <% end %>
     </dl>
   </div>

--- a/spec/views/users/show.html.erb_spec.rb
+++ b/spec/views/users/show.html.erb_spec.rb
@@ -16,6 +16,8 @@ describe 'users/show.html.erb', type: :view do
     render
   end
 
+  subject { rendered }
+
   describe "when the user doesn't have a title" do
     let(:user) { build(:user, title: nil, created_at: join_date) }
 
@@ -32,5 +34,10 @@ describe 'users/show.html.erb', type: :view do
       expect(rendered).to match(/<dt>Title<\/dt>/)
       expect(rendered).to match(/<dd>Mrs<\/dd>/)
     end
+  end
+
+  describe "when user has a phone number" do
+    let(:user) { build(:user, created_at: join_date, telephone: "+1 800 867 5309") }
+    it { is_expected.to include('<a href="tel:+18008675309">+1 800 867 5309</a>') }
   end
 end


### PR DESCRIPTION
Current links to telephone numbers were not doing anything. This allows the browser to trigger any configured applications to dial the number.