### PR TITLE
Retain provided collections when switching create pages, ref #860

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -44,4 +44,22 @@ module ApplicationHelper
   def more_facets_link_path(solr_field)
     sufia.send("dashboard_#{controller_name}_facet_path", solr_field)
   end
+
+  # @return [Array] used to render link that switches to a new work with any included collections
+  def switch_to_new_work_path
+    if params.key?(:collection_ids)
+      [:new, Sufia.primary_work_type.model_name.singular_route_key, collection_ids: params.fetch(:collection_ids)]
+    else
+      [:new, Sufia.primary_work_type.model_name.singular_route_key]
+    end
+  end
+
+  # @return [String] used to render link that switches to the batch create page with any included collections
+  def switch_to_batch_upload_path
+    if params.key?(:collection_ids)
+      sufia.new_batch_upload_path(collection_ids: params.fetch(:collection_ids))
+    else
+      sufia.new_batch_upload_path
+    end
+  end
 end

--- a/app/views/curation_concerns/base/_form.html.erb
+++ b/app/views/curation_concerns/base/_form.html.erb
@@ -10,8 +10,8 @@
     <% unless f.object.persisted? %>
         <% content_for :metadata_tab do %>
             <p class="switch-upload-type">
-              To create a separate work for each of the files, go to <%= link_to "Batch upload", sufia.new_batch_upload_path,
-                                                                                 class: 'btn btn-default' %>
+              To create a separate work for each of the files, go to
+              <%= link_to "Batch upload", switch_to_batch_upload_path, class: 'btn btn-default' %>
             </p>
             <p class="instructions"><%= t("sufia.concepts.work_collection") %></p>
             <p class="instructions"><%= t("sufia.works.files.instructions") %></p>

--- a/app/views/sufia/batch_uploads/_form.html.erb
+++ b/app/views/sufia/batch_uploads/_form.html.erb
@@ -1,7 +1,8 @@
 <%= simple_form_for [sufia, @form], html: { multipart: true } do |f| %>
     <% content_for :files_tab do %>
         <p class="switch-upload-type">
-          To create a single work for all the files, go to <%= link_to "New Work", [:new, Sufia.primary_work_type.model_name.singular_route_key], class: "btn btn-default" %></p>
+          To create a single work for all the files, go to
+          <%= link_to "New Work", switch_to_new_work_path, class: "btn btn-default" %></p>
         <p class="instructions"><%= t("sufia.concepts.work_collection") %></p>
         <p class="instructions"><%= t("sufia.batch_uploads.files.instructions") %></p>
     <% end %>

--- a/spec/views/curations_concerns/base/_form.html.erb_spec.rb
+++ b/spec/views/curations_concerns/base/_form.html.erb_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe "curation_concerns/base/_form.html.erb" do
+  include Devise::Test::ControllerHelpers
+
+  let(:form) { CurationConcerns::GenericWorkForm.new(GenericWork.new, Ability.new(nil)) }
+
+  before do
+    assign(:form, form)
+    controller.stub(:params).and_return(params)
+    stub_template "_form_files.html.erb" => ""
+    stub_template "_form_metadata.html.erb" => ""
+    stub_template "_form_relationships.html.erb" => ""
+    stub_template "_form_share.html.erb" => ""
+    stub_template "_form_progress.html.erb" => ""
+    render "curation_concerns/base/form.html.erb"
+  end
+
+  describe "rendering the link that switches to the batch create page" do
+    subject { rendered }
+
+    context "without no collection id parameters" do
+      let(:params) { {} }
+      it { is_expected.to include('href="/batch_uploads/new"') }
+    end
+
+    context "with collection ids" do
+      let(:params) { { collection_ids: ["collection-id"] } }
+      it { is_expected.to include('href="/batch_uploads/new?collection_ids%5B%5D=collection-id"') }
+    end
+  end
+end

--- a/spec/views/sufia/batch_uploads/_form.html.erb_spec.rb
+++ b/spec/views/sufia/batch_uploads/_form.html.erb_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe "sufia/batch_uploads/_form.html.erb" do
+  let(:form) { BatchUploadForm.new(BatchUploadItem.new, Ability.new(nil)) }
+
+  before do
+    assign(:form, form)
+    controller.stub(:params).and_return(params)
+    stub_template "_form_files.html.erb" => ""
+    stub_template "_form_metadata.html.erb" => ""
+    stub_template "_form_relationships.html.erb" => ""
+    stub_template "_form_share.html.erb" => ""
+    stub_template "_form_progress.html.erb" => ""
+    render "sufia/batch_uploads/form.html.erb"
+  end
+
+  describe "rendering the link that switches to the new single work page" do
+    subject { rendered }
+
+    context "without no collection id parameters" do
+      let(:params) { {} }
+      it { is_expected.to include('href="/concern/generic_works/new"') }
+    end
+
+    context "with collection ids" do
+      let(:params) { { collection_ids: ["collection-id"] } }
+      it { is_expected.to include('href="/concern/generic_works/new?collection_ids%5B%5D=collection-id"') }
+    end
+  end
+end


### PR DESCRIPTION
If you had previously selected a collection to which you were gong to add a batch of new works, the collection id is not retained if you switched to a single work creation page, and vice-versa.

This provides helper methods that keep the collection id parameter in the url when changing between batch and single work creation.