### PR TITLE
Redirect to collection when adding new works, ref #702

### DIFF
--- a/app/controllers/sufia/batch_uploads_controller.rb
+++ b/app/controllers/sufia/batch_uploads_controller.rb
@@ -46,4 +46,21 @@ class Sufia::BatchUploadsController < ApplicationController
     def uploading_on_behalf_of?
       params.fetch(hash_key_for_curation_concern).fetch(:on_behalf_of, nil).present?
     end
+
+    # Overrides Sufia to redirect to a collection's show page if needed
+    def redirect_after_update
+      if collection?
+        redirect_to collection_path(attributes_for_actor.fetch(:collection_ids).first)
+      elsif uploading_on_behalf_of?
+        redirect_to sufia.dashboard_shares_path
+      else
+        redirect_to sufia.dashboard_works_path
+      end
+    end
+
+  private
+
+    def collection?
+      attributes_for_actor.fetch(:collection_ids, []).present?
+    end
 end

--- a/spec/controllers/sufia/batch_uploads_controller_spec.rb
+++ b/spec/controllers/sufia/batch_uploads_controller_spec.rb
@@ -39,6 +39,25 @@ describe Sufia::BatchUploadsController do
         expect(flash[:notice]).to include("Your files are being processed")
       end
     end
+
+    context "when providing a collection" do
+      let(:params) do
+        ActionController::Parameters.new(
+          title: { '1' => 'foo' },
+          resource_type: { '1' => 'Article' },
+          uploaded_files: ['1'],
+          batch_upload_item: { keyword: [""], visibility: 'open', collection_ids: ["collection-id"] }
+        )
+      end
+
+      before { allow(BatchCreateJob).to receive(:perform_later) }
+
+      it "redirects to the collection show page" do
+        post :create, params
+        expect(response).to redirect_to("/collections/collection-id")
+        expect(flash[:notice]).to include("Your files are being processed")
+      end
+    end
   end
 
   describe "#uploading_on_behalf_of?" do


### PR DESCRIPTION
If the user specified a collection to add new works to, it was redirecting to the dashboard instead of the collection and it was not obvious that the new works had been added.

If a collection has been specified in the parameters hash, we redirect to the collection after the works have been successfully created.