### PR TITLE
Display events for works, ref #853

### DIFF
--- a/app/presenters/work_show_presenter.rb
+++ b/app/presenters/work_show_presenter.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class WorkShowPresenter < Sufia::WorkShowPresenter
   include ActionView::Helpers::NumberHelper
+  include Sufia::WithEvents
 
   delegate :bytes, to: :solr_document
 
@@ -38,6 +39,14 @@ class WorkShowPresenter < Sufia::WorkShowPresenter
 
   def permission_badge_class
     PublicPermissionBadge
+  end
+
+  def event_class
+    solr_document.hydra_model
+  end
+
+  def events(size = 100)
+    super(size)
   end
 
   private

--- a/app/views/curation_concerns/base/show.html.erb
+++ b/app/views/curation_concerns/base/show.html.erb
@@ -41,6 +41,6 @@
     <%= render 'items', presenter: @presenter %>
     <%# TODO: we may consider adding these partials in the future %>
     <%#= render 'sharing_with', presenter: @presenter %>
-    <%#= render 'user_activity', presenter: @presenter %>
+    <%= render 'users/activity', presenter: @presenter %>
   </div>
 </div>

--- a/spec/features/generic_work/upload_and_delete_spec.rb
+++ b/spec/features/generic_work/upload_and_delete_spec.rb
@@ -139,6 +139,9 @@ describe 'Generic File uploading and deletion:', type: :feature do
           sleep(1.second)
           click_on 'Save'
           expect(page).to have_content 'Your files are being processed'
+          within("#activity_log") do
+            expect(page).to have_content("User #{current_user.display_name} has deposited Markdown Test")
+          end
           expect(page).to have_css('h1', 'Markdown Test')
           click_on "Notifications"
           expect(page).to have_content "The file (Markdown Test.txt) was successfully imported"

--- a/spec/presenters/work_show_presenter_spec.rb
+++ b/spec/presenters/work_show_presenter_spec.rb
@@ -61,4 +61,23 @@ describe WorkShowPresenter do
     subject { presenter.facet_mapping(:creator) }
     it { is_expected.to eq("JOE SMITH" => "Joe Smith") }
   end
+
+  describe "#events" do
+    context "with no events" do
+      let(:work)   { build(:work) }
+      its(:events) { is_expected.to be_empty }
+    end
+
+    context "with events" do
+      let(:events) { double }
+      before do
+        allow(Sufia::RedisEventStore).to receive(:for).with("GenericWork:1234:event").and_return(events)
+        allow(events).to receive(:fetch).with(100).and_return(["event1", "event2"])
+      end
+
+      its(:events) { is_expected.to contain_exactly("event1", "event2") }
+    end
+  end
+
+  its(:event_class) { is_expected.to eq(GenericWork) }
 end


### PR DESCRIPTION
Sufia captures events that occur on works, but they were not being displayed in the UI.

This displays the same partial that we use for file set events, only the events are attached to the work presenter.