### PR TITLE
Inform user when derivative creation fails for files, ref #706

### DIFF
--- a/app/jobs/create_derivatives_job.rb
+++ b/app/jobs/create_derivatives_job.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+# Replaces CurationConcerns job to rescue from derivative creation failures and notify the user.
+class CreateDerivativesJob < ActiveJob::Base
+  queue_as CurationConcerns.config.ingest_queue_name
+
+  # @param [FileSet] file_set
+  # @param [String] file_id identifier for a Hydra::PCDM::File
+  # @param [String, NilClass] filepath the cached file within the CurationConcerns.config.working_path
+  def perform(file_set, file_id, filepath = nil)
+    return if file_set.video? && !CurationConcerns.config.enable_ffmpeg
+    filename = CurationConcerns::WorkingDirectory.find_or_retrieve(file_id, file_set.id, filepath)
+
+    file_set.create_derivatives(filename)
+
+    # Reload from Fedora and reindex for thumbnail and extracted text
+    file_set.reload
+    file_set.update_index
+    file_set.parent.update_index if parent_needs_reindex?(file_set)
+  rescue StandardError => e
+    notify_user(file_set)
+    raise(e)
+  end
+
+  # If this file_set is the thumbnail for the parent work,
+  # then the parent also needs to be reindexed.
+  def parent_needs_reindex?(file_set)
+    return false unless file_set.parent
+    file_set.parent.thumbnail_id == file_set.id
+  end
+
+  private
+
+    def notify_user(file_set)
+      user = User.find_by_login(file_set.depositor)
+      FileSetDerivativeFailureJob.perform_later(file_set, user)
+    end
+end

--- a/app/jobs/file_set_derivative_failure_job.rb
+++ b/app/jobs/file_set_derivative_failure_job.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class FileSetDerivativeFailureJob < FileSetAttachedEventJob
+  def action
+    "The derivative for #{link_to repo_object.title.first, polymorphic_path(repo_object)} was not successfully created"
+  end
+end

--- a/spec/jobs/create_derivatives_job_spec.rb
+++ b/spec/jobs/create_derivatives_job_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe CreateDerivativesJob do
+  let(:file_set) { build(:file_set) }
+
+  context "when the job fails" do
+    before do
+      allow(CurationConcerns::WorkingDirectory).to receive(:find_or_retrieve).and_return("filename")
+      allow(file_set).to receive(:create_derivatives).and_raise(StandardError, "failed to create derivatives")
+    end
+
+    it "sends a message to the user" do
+      expect(FileSetDerivativeFailureJob).to receive(:perform_later).with(file_set, kind_of(User))
+      expect { described_class.perform_now(file_set, "file-id") }.to raise_error(StandardError)
+    end
+  end
+end

--- a/spec/jobs/file_set_derivative_failure_job_spec.rb
+++ b/spec/jobs/file_set_derivative_failure_job_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe FileSetDerivativeFailureJob do
+  let(:user)     { create(:user) }
+  let(:file_set) { work.file_sets.first }
+
+  let!(:work)    { create(:work, :with_one_file, user: user) }
+
+  it "sends an failed derivative message on a file set" do
+    expect {
+      described_class.perform_now(file_set, user)
+    }.to change { file_set.events.length }.by(1)
+  end
+end


### PR DESCRIPTION
Not all files are supported by ImageMagick and when it is not able to create thumbnails for a file, it fails in the resque queue, but the user never sees anything.

This reports a derivative failure to the file set's activity stream so the user knows that a failure occurred.