### PR TITLE
overriding the image derivative types to not include tiff

### DIFF
--- a/config/initializers/image_derivative_types.rb
+++ b/config/initializers/image_derivative_types.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+# Override image mime types so we do not process tiff files since these are causing issues
+#   currently the tiff files in the system are geo tiffs which just hang up the derivative generation
+module Hydra::Works::MimeTypes::ClassMethods
+  def image_mime_types
+    ['image/png', 'image/jpeg', 'image/jpg', 'image/jp2', 'image/bmp', 'image/gif']
+  end
+end

--- a/spec/lib/scholarsphere/config_spec.rb
+++ b/spec/lib/scholarsphere/config_spec.rb
@@ -6,6 +6,7 @@ describe Scholarsphere::Config do
     context "with our current configuration files" do
       it "checks the contents of our production configuration files" do
         expect { described_class.check }.not_to raise_error(Scholarsphere::Config::Error)
+        expect(FileSet.image_mime_types).to eq(["image/png", "image/jpeg", "image/jpg", "image/jp2", "image/bmp", "image/gif"])
       end
     end
 


### PR DESCRIPTION
Yes I know that the test may be considered in the wrong place, but I did not want to spin up the entire rails environment to just check  the contents of an array.  I figured items in config "could" be tested in the config test.