### PR TITLE
Reset FileSet permissions when transferring works, ref #893

### DIFF
--- a/app/services/sufia/change_content_depositor_service.rb
+++ b/app/services/sufia/change_content_depositor_service.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+# Overrides Sufia to ensure file set's permissions are reset if needed.
+module Sufia
+  class ChangeContentDepositorService
+    # @param [ActiveFedora::Base] work
+    # @param [User] user
+    # @param [TrueClass, FalseClass] reset
+    def self.call(work, user, reset)
+      work.proxy_depositor = work.depositor
+      work.permissions = [] if reset
+      work.apply_depositor_metadata(user)
+      work.file_sets.each do |f|
+        f.permissions = [] if reset
+        f.apply_depositor_metadata(user)
+        f.save!
+      end
+      work.save!
+      work
+    end
+  end
+end

--- a/spec/services/sufia/change_content_depositor_service_spec.rb
+++ b/spec/services/sufia/change_content_depositor_service_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe Sufia::ChangeContentDepositorService do
+  let!(:depositor) { create(:user) }
+  let!(:receiver)  { create(:user) }
+  let!(:file)      { create(:file_set, :public, user: depositor) }
+  let!(:work)      { create(:public_work, depositor: depositor.user_key) }
+
+  before do
+    work.members << file
+    described_class.call(work, receiver, reset)
+  end
+
+  context "by default, when permissions are not reset" do
+    let(:reset) { false }
+
+    it "changes the depositor and records an original depositor" do
+      work.reload
+      expect(work.depositor).to eq receiver.user_key
+      expect(work.proxy_depositor).to eq depositor.user_key
+      expect(work.edit_users).to include(receiver.user_key, depositor.user_key)
+      expect(work.visibility).to eq("open")
+    end
+
+    it "changes the depositor of the child file sets" do
+      file.reload
+      expect(file.depositor).to eq receiver.user_key
+      expect(file.edit_users).to include(receiver.user_key, depositor.user_key)
+      expect(file.visibility).to eq("open")
+    end
+  end
+
+  context "when permissions are reset" do
+    let(:reset) { true }
+
+    it "excludes the depositor from the edit users" do
+      work.reload
+      expect(work.depositor).to eq receiver.user_key
+      expect(work.proxy_depositor).to eq depositor.user_key
+      expect(work.edit_users).to contain_exactly(receiver.user_key)
+      expect(work.visibility).to eq("restricted")
+    end
+
+    it "changes the depositor of the child file sets" do
+      file.reload
+      expect(file.depositor).to eq receiver.user_key
+      expect(file.edit_users).to contain_exactly(receiver.user_key)
+      expect(file.visibility).to eq("restricted")
+    end
+  end
+end


### PR DESCRIPTION
When transferring works, the contained file sets were not getting the permissions changed in the same way as the works. The original depositor was still retaining edit rights and the visibility was not getting changed.

Resetting the permissions on the file set, when the flag is used, fixes the issue.