### PR TITLE
Removing daily stats from the schedule.

### DIFF
--- a/config/cronjobs/send_daily_stats.bash
+++ b/config/cronjobs/send_daily_stats.bash
@@ -5,6 +5,9 @@
 #  Version:      01
 #  Description:  Sends an email daily to our subscribed users that gives system level
 #                  stats and metadata about uploaded files
+#
+# NOT CURRENTLY IN USE!!!
+#
 #============================================================
 
 

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -38,10 +38,6 @@ every :monday, at: "6:00 am", roles: [:job] do
   command "#{path}/config/cronjobs/send_weekly_stats.bash"
 end
 
-every :day, at: "5:00 am", roles: [:job] do
-  command "#{path}/config/cronjobs/send_daily_stats.bash"
-end
-
 every 60.minutes, roles: [:app] do
   command "#{path}/config/cronjobs/temp_file_clean.bash"
 end


### PR DESCRIPTION
They got added in here: https://github.com/psu-stewardship/scholarsphere/commit/e006cce5f4188743900a5aad530273cc6d375253#diff-b6de01cbd4b49ee8c835f6d988693033R41

Was this a request from @olendorf ?  Do we want a daily or a weekly email?  If we only want a weekly one we should not run the daily stats email.