### PR TITLE
Check removed permissions on works, ref #890

### DIFF
--- a/app/controllers/curation_concerns/generic_works_controller.rb
+++ b/app/controllers/curation_concerns/generic_works_controller.rb
@@ -48,4 +48,10 @@ class CurationConcerns::GenericWorksController < ApplicationController
         wants.json { render_json_response(response_type: :deleted, message: "Deleted #{curation_concern.id}") }
       end
     end
+
+    # Overrides Sufia to reload curation_concern so that removed permissions will be checked.
+    def permissions_changed?
+      curation_concern.reload
+      @saved_permissions != curation_concern.permissions.map(&:to_hash)
+    end
 end

--- a/spec/factories/works.rb
+++ b/spec/factories/works.rb
@@ -152,10 +152,12 @@ FactoryGirl.define do
     end
 
     trait :with_required_metadata do
-      title   ['a required title']
-      keyword ['required keyword']
-      creator ['required creator']
-      rights  ['http://creativecommons.org/licenses/by/3.0/us/']
+      title         ['a required title']
+      description   ['a required description']
+      keyword       ['required keyword']
+      creator       ['required creator']
+      rights        ['https://creativecommons.org/licenses/by/4.0/']
+      resource_type ['Article']
     end
   end
 end

--- a/spec/features/generic_work/edit_permissions_spec.rb
+++ b/spec/features/generic_work/edit_permissions_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+require 'feature_spec_helper'
+
+describe "Editing permissions on a work" do
+  context "when removing permissions from a work with files" do
+    let(:user1) { create(:user, display_name: "First User") }
+    let(:user2) { create(:user, display_name: "Second User") }
+
+    let(:work) do
+      create(:public_work, :with_required_metadata, depositor: user1.user_key,
+                                                    edit_users: [user1.user_key, user2.user_key])
+    end
+
+    let(:file_set) { create(:file_set, :public, user: user1, edit_users: [user1.user_key, user2.user_key]) }
+
+    before do
+      work.members << file_set
+      work.save
+      sign_in_with_js(user1)
+    end
+
+    it "copies the permissions to the file set" do
+      visit("/concern/generic_works/#{work.id}/edit")
+      within("ul.nav-tabs") do
+        click_link("Collaborators")
+      end
+      within("#share") do
+        expect(page).to have_content("First User")
+        expect(page).to have_content("Second User")
+      end
+      find(".remove_perm").click
+      click_button("Save")
+      expect(page).to have_content("Apply changes to contents?")
+      click_button("Yes please.")
+      expect(page).to have_content(work.title.first)
+      expect(work.reload.edit_users).to contain_exactly(user1.user_key)
+      expect(work.file_sets.first.edit_users).to contain_exactly(user1.user_key)
+    end
+  end
+end


### PR DESCRIPTION
When removing permissions from a work, the changes were not getting copied down to contained file sets.

Overriding Sufia's controller to check for removed permissions fixes the issue.