### PR TITLE
Re-apply the title attributes to ensure title order is preserved

### DIFF
--- a/app/actors/curation_concerns/actors/generic_work_actor.rb
+++ b/app/actors/curation_concerns/actors/generic_work_actor.rb
@@ -7,10 +7,11 @@ module CurationConcerns
       def create(attributes)
         stat = super(attributes)
 
-        # TODO: when we move to RDF 2 we will need to remove this code
-        # This code is a patch to keep order only while we are on RDF 1.9
-        # assign again to keep creator order
+        # TODO: When we move to RDF 2 we will need to remove this code.
+        # Retains order in title and creator while we are on RDF 1.9.
         curation_concern.creator = attributes[:creator]
+        curation_concern.creator = attributes[:title]
+
         stat
       end
     end


### PR DESCRIPTION
In some cases, the order in which titles are created or updated is not preserved when saving the record.

Re-applying the title order, in the same way we do with creators, fixes this problem.

Note: This is a temporary fix. Once we have updated to the RDF 2.0 gem, there will be no guarantee of order and a more permanent solution will be needed.