### PR TITLE
Adds the proxied user as the depositor in BaseActor, #895

### DIFF
--- a/app/actors/curation_concerns/actors/generic_work_actor.rb
+++ b/app/actors/curation_concerns/actors/generic_work_actor.rb
@@ -4,8 +4,13 @@
 module CurationConcerns
   module Actors
     class GenericWorkActor < CurationConcerns::Actors::BaseActor
+      # Override CurationConcerns to pass attributes to apply_creation_data_to_curation_concern
+      # and re-apply creator to ensure order is correct.
       def create(attributes)
-        stat = super(attributes)
+        @cloud_resources = attributes.delete(:cloud_resources.to_s)
+        apply_creation_data_to_curation_concern(attributes)
+        apply_save_data_to_curation_concern(attributes)
+        next_actor.create(attributes) && save && run_callbacks(:after_create_concern)
 
         # TODO: When we move to RDF 2 we will need to remove this code.
         # Retains order in title and creator while we are on RDF 1.9.
@@ -14,9 +19,25 @@ module CurationConcerns
         curation_concern.creator = attributes[:creator]
         curation_concern.save
         curation_concern.title = attributes[:title]
-
-        stat
       end
+
+      protected
+
+        def apply_creation_data_to_curation_concern(attributes)
+          apply_depositor_metadata(attributes)
+          apply_deposit_date
+        end
+
+        def apply_depositor_metadata(attributes)
+          if attributes.key?("on_behalf_of")
+            depositor = ::User.find_by_user_key(attributes.fetch("on_behalf_of"))
+            curation_concern.apply_depositor_metadata(depositor)
+            curation_concern.edit_users += [depositor, user.user_key]
+          else
+            curation_concern.apply_depositor_metadata(user.user_key)
+            curation_concern.edit_users += [user.user_key]
+          end
+        end
     end
   end
 end

--- a/spec/actors/curation_concerns/generic_work_actor_spec.rb
+++ b/spec/actors/curation_concerns/generic_work_actor_spec.rb
@@ -35,4 +35,11 @@ describe CurationConcerns::Actors::GenericWorkActor do
       expect(work.creator).to eq([])
     end
   end
+
+  context "when uploading on behalf of another user" do
+    let(:other_user) { create(:user) }
+    let(:attributes) { { title: ["Sample"], on_behalf_of: other_user.login } }
+    subject { work }
+    its(:depositor) { is_expected.to eq(other_user.login) }
+  end
 end


### PR DESCRIPTION
Due to a race condition between GenericWorkActor, AttachFilesToWorkJob and ContentDepositorChangeEventJob, the file set's depositor could be set at the proxy user instead of the proxied user, that is, the user whom is being deposited on behalf of.

This addresses the problem by ensuring the work is set to the proxied user at the first opportunity. ContentDepositorChangeEventJob will still run, which also sets the depositor to the proxied user, but doing it in the actor first ensure that when AttachFilesToWorkJob runs, it will always have the correct depositor set.

Note: I'm not crazy about this solution. Particularly because it doesn't really address the underly problem. Also, the test isn't really covering it because you can't replicate the problem in test since all the jobs and actors are run inline. Still, it ensures that the code is at least executed.