### PR TITLE
Render 404 from public/404.html.erb, ref #924

### DIFF
--- a/public/404.html.erb
+++ b/public/404.html.erb
@@ -1,0 +1,8 @@
+<h1><%= t('errors.active_fedora_object_not_found_error.title') %></h1>
+
+<p><%= t('errors.active_fedora_object_not_found_error.message') %></p>
+
+<p>
+  If this error continues please use the <a href="/contact/">the contact form</a>
+  for assistance uploading your content"
+</p>

--- a/spec/requests/download_spec.rb
+++ b/spec/requests/download_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe "Download requests", type: :request do
+  let(:work) { create(:public_work) }
+  subject { response }
+
+  # Tests public/404.html.erb which is required by Hydra::Controller::DownloadBehavior#render_404
+  context "with a missing image" do
+    before { get "/downloads/#{work.id}" }
+    it { is_expected.to be_not_found }
+  end
+end


### PR DESCRIPTION
HydraCore uses a protected render_404 method that uses public/404.html.erb as a template. Our custom render_404 method is public, so HydraCore never calls it, calling its own protected method instead. Since they both have the same names, we can't really for HydraCore to use our public one.

We're adding the 404.html.erb template so HydraCore will render it properly.