### PR TITLE
Convert dates to strings in Sufia::StatsUsagePresenter, ref #934

### DIFF
--- a/app/prepend/prepended_stats_usage_behavior.rb
+++ b/app/prepend/prepended_stats_usage_behavior.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+# Using Rails' to_prepare hook in config/application.rb, we can inject this module as
+# Sufia::StatsUsagePresenter is loaded, and alter its existing behaviors without having to redefine
+# the entire class.
+module PrependedStatsUsageBehavior
+  private
+
+    # @param [DateTime, String] date_str
+    # @return [Time, nil]
+    # Overrides Sufia::StatsUsagePresenter to convert DateTime objects to strings.
+    def string_to_date(date_str)
+      Time.zone.parse(date_str.to_s)
+    rescue ArgumentError, TypeError
+      nil
+    end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -50,6 +50,7 @@ module ScholarSphere
     config.autoload_paths += %W(#{config.root}/app/models/datastreams)
     config.autoload_paths += %W(#{config.root}/app/forms/concerns)
     config.autoload_paths += %W(#{config.root}/app/renderers)
+    config.autoload_paths += %W(#{config.root}/app/prepend)
 
     config.i18n.enforce_available_locales = true
 
@@ -96,5 +97,10 @@ module ScholarSphere
 
     config.action_mailer.default_options = { from: "umg-up.its.sas.scholarsphere-email@groups.ucs.psu.edu" }
     config.action_mailer.default_url_options = { host: config.service_instance, protocol: 'https' }
+
+    # Inject new behaviors into existing classes without having to override the entire class itself.
+    config.to_prepare do
+      Sufia::StatsUsagePresenter.prepend PrependedStatsUsageBehavior
+    end
   end
 end

--- a/spec/presenters/sufia/work_usage_spec.rb
+++ b/spec/presenters/sufia/work_usage_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe Sufia::WorkUsage do
+  let(:work) { create(:work) }
+  subject { described_class.new(work.id) }
+
+  describe "#date_for_analytics" do
+    context "without date_uploaded" do
+      its(:date_for_analytics) { is_expected.to eq(work.create_date) }
+    end
+
+    context "when date_uploaded is before Sufia.config.analytic_start_date" do
+      let(:work) { create(:work, date_uploaded: DateTime.new(2011, 7, 1)) }
+      its(:date_for_analytics) { is_expected.to eq(Sufia.config.analytic_start_date) }
+    end
+
+    context "when date_uploaded is after Sufia.config.analytic_start_date" do
+      let(:work) { create(:work, date_uploaded: DateTime.new(2014, 7, 1)) }
+      its(:date_for_analytics) { is_expected.to eq("July 1, 2014") }
+    end
+  end
+end


### PR DESCRIPTION
string_to_date was returning nil for parameters that were already DateTime objects because
it does not implicitly convert them to strings.

To fix, we explicitly call to_s to handle the conversion.

@cam156 this is a new technique I was reading about from @jcoyne.