### PR TITLE
Moving where legato is required to allow for the rake tasks to have access

### DIFF
--- a/config/initializers/legato.rb
+++ b/config/initializers/legato.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# These must be required here so that Pageview and Download classes will properly load Legato's
+# additional methods. This allows for the rake tasks to have access to legato.
+require 'legato'
+require 'sufia/pageview'
+require 'sufia/download'

--- a/lib/tasks/scholarsphere/stats.rake
+++ b/lib/tasks/scholarsphere/stats.rake
@@ -3,14 +3,6 @@ namespace :scholarsphere do
 
     desc "Cache file view & download stats for all users"
     task :user_stats => :environment do
-
-      # These must be required here so that Pageview and Download classes will properly load Legato's
-      # additional methods. In a complete Rails production environment, they are eager-loaded, but
-      # for rake tasks they do not appear to be.
-      require 'legato'
-      require 'sufia/pageview'
-      require 'sufia/download'
-
       importer = Sufia::UserStatImporter.new(verbose: true, logging: true, delay_secs: 1.0, number_of_retries: 5)
       importer.import
     end


### PR DESCRIPTION
This moves the require into the path or the app.  When testing on the server this change made the rake tasks work, but the requires in the rake tasks did not.