### PR TITLE
Setting collections to current object instead of empty array

### DIFF
--- a/app/views/curation_concerns/base/_form_relationships.html.erb
+++ b/app/views/curation_concerns/base/_form_relationships.html.erb
@@ -5,7 +5,7 @@
 
 <h2><%= t("sufia.works.#{action_name}.in_collections") %></h2>
 <div id="collection-widget">
-  <%= f.input :collection_ids, as: :select, selected: params.fetch(:collection_ids, []),
+  <%= f.input :collection_ids, as: :select, selected: params.fetch(:collection_ids, f.object.collection_ids),
               collection: available_collections(nil),
               input_html: { class: 'form-control', multiple: true } %>
 </div>


### PR DESCRIPTION
refs #953
Without this when a work is edited that already is part of a collection the relationship gets removed.