### PR TITLE
Proxied user is the depositor in BaseActor, #895

### DIFF
--- a/spec/actors/curation_concerns/generic_work_actor_spec.rb
+++ b/spec/actors/curation_concerns/generic_work_actor_spec.rb
@@ -35,4 +35,11 @@ describe CurationConcerns::Actors::GenericWorkActor do
       expect(work.creator).to eq([])
     end
   end
+
+  context "when uploading on behalf of another user" do
+    let(:other_user) { create(:user) }
+    let(:attributes) { { title: ["Sample"], on_behalf_of: other_user.login } }
+    subject { work }
+    its(:depositor) { is_expected.to eq(other_user.login) }
+  end
 end


### PR DESCRIPTION
This is a reattempt of the solution that was first tried (unsuccessfully) in f5cadae53e887df9292afabe4ca950e87412ae6b.

It also refactors the actor code slightly to account for future changes that will need to occur when #948 and #949 are closed.