### PR TITLE
Uploading in edit mode via BrowseEverything, #958

### DIFF
--- a/app/forms/batch_upload_form.rb
+++ b/app/forms/batch_upload_form.rb
@@ -9,4 +9,8 @@ class BatchUploadForm < Sufia::Forms::BatchUploadForm
   def self.multiple?(term)
     CurationConcerns::GenericWorkForm.multiple?(term)
   end
+
+  def target_selector
+    "#new_#{model.model_name.param_key}"
+  end
 end

--- a/app/forms/curation_concerns/generic_work_form.rb
+++ b/app/forms/curation_concerns/generic_work_form.rb
@@ -16,5 +16,13 @@ module CurationConcerns
       return false if term == :rights
       super
     end
+
+    def target_selector
+      if persisted?
+        "#edit_#{model.model_name.param_key}_#{model.id}"
+      else
+        "#new_#{model.model_name.param_key}"
+      end
+    end
   end
 end

--- a/app/views/curation_concerns/base/_browse_everything.html.erb
+++ b/app/views/curation_concerns/base/_browse_everything.html.erb
@@ -1,4 +1,8 @@
-<!-- overriding patial so I could remove the help text and put it in _form_files -->
-<%= button_tag(t('sufia.upload.browse_everything.browse_files_button'), type: 'button', class: 'btn btn-success', id: "browse-btn",
-               'data-toggle' => 'browse-everything', 'data-route' => browse_everything_engine.root_path,
-               'data-target' => "##{f.object.persisted? ? 'edit' : 'new'}_#{f.object.model.model_name.param_key}" ) %>
+<%# Moves help text to _form_files and uses #target_selector method on form %>
+<%= button_tag(t("sufia.upload.browse_everything.browse_files_button"),
+      type: "button", class: "btn btn-success",
+      id: "browse-btn",
+      data: {
+        toggle: "browse-everything",
+        route: browse_everything_engine.root_path,
+        target: f.object.target_selector } ) %>

--- a/spec/forms/batch_upload_form_spec.rb
+++ b/spec/forms/batch_upload_form_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 describe BatchUploadForm do
   let(:user)    { create(:user, display_name: "Test A User") }
   let(:ability) { Ability.new(user) }
-  let(:form)    { described_class.new(GenericWork.new, ability) }
+  let(:form)    { described_class.new(BatchUploadItem.new, ability) }
 
   describe "::required_fields" do
     subject { described_class }
@@ -25,6 +25,11 @@ describe BatchUploadForm do
     subject { described_class.model_attributes(raw_attrs) }
     let(:raw_attrs) { ActionController::Parameters.new("creator" => ["Santy, Lorraine C", ""], "keyword" => ["hhh"], "rights" => "https://creativecommons.org/licenses/by/4.0/", "description" => ["ghjg"], "contributor" => [""], "publisher" => [""], "date_created" => [""], "subject" => [""], "language" => [""], "identifier" => [""], "based_near" => [""], "related_url" => [""], "source" => [""], "admin_set_id" => "", "collection_ids" => [""], "visibility_during_embargo" => "restricted", "embargo_release_date" => "2017-01-24", "visibility_after_embargo" => "open", "visibility_during_lease" => "open", "lease_expiration_date" => "2017-01-24", "visibility_after_lease" => "restricted", "visibility" => "restricted") }
     it { is_expected.to eq("creator" => ["Santy, Lorraine C"], "keyword" => ["hhh"], "rights" => "https://creativecommons.org/licenses/by/4.0/", "description" => ["ghjg"], "contributor" => [], "publisher" => [], "date_created" => [], "subject" => [], "language" => [], "identifier" => [], "based_near" => [], "related_url" => [], "source" => [], "admin_set_id" => "", "collection_ids" => [], "visibility_during_embargo" => "restricted", "embargo_release_date" => "2017-01-24", "visibility_after_embargo" => "open", "visibility_during_lease" => "open", "lease_expiration_date" => "2017-01-24", "visibility_after_lease" => "restricted", "visibility" => "restricted") }
+  end
+
+  describe "#target_selector" do
+    subject { form.target_selector }
+    it { is_expected.to eq("#new_batch_upload_item") }
   end
 
   it_behaves_like "a standard work form"

--- a/spec/forms/generic_work_form_spec.rb
+++ b/spec/forms/generic_work_form_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 describe CurationConcerns::GenericWorkForm do
   let(:user)    { create(:user, display_name: "Test A User") }
   let(:ability) { Ability.new(user) }
-  let(:work)    { GenericWork.new }
+  let(:work)    { build(:work) }
   let(:form)    { described_class.new(work, ability) }
   describe "#initialize_field" do
     subject { form[:creator] }
@@ -27,6 +27,19 @@ describe CurationConcerns::GenericWorkForm do
       let(:work) { build(:private_work) }
       before { allow(work).to receive(:new_record?).and_return(false) }
       its(:visibility) { is_expected.to eq("restricted") }
+    end
+  end
+
+  describe "#target_selector" do
+    subject { form.target_selector }
+    context "with a new work" do
+      it { is_expected.to eq("#new_generic_work") }
+    end
+
+    context "when editing an existing work" do
+      let(:work) { build(:work, id: "1234") }
+      before { allow(work).to receive(:persisted?).and_return(true) }
+      it { is_expected.to eq("#edit_generic_work_1234") }
     end
   end
 end

--- a/spec/views/curations_concerns/base/_form_files.html.erb_spec.rb
+++ b/spec/views/curations_concerns/base/_form_files.html.erb_spec.rb
@@ -2,19 +2,18 @@
 require 'rails_helper'
 
 describe "curation_concerns/base/_form_files.html.erb" do
-  let(:user)    { create(:user) }
-  let(:work)    { create(:work, depositor: user.login) }
-  let(:ability) { Ability.new(user) }
-  let(:form)    { CurationConcerns::GenericWorkForm.new(work, ability) }
+  let(:user)      { create(:user) }
+  let(:work)      { create(:work, depositor: user.login) }
+  let(:ability)   { Ability.new(user) }
+  let(:form)      { CurationConcerns::GenericWorkForm.new(work, ability) }
+  let(:page)      { Capybara::Node::Simple.new(rendered) }
+  let(:all_label) { page.find('button.all')['aria-label'] }
 
-  let(:page) do
+  before do
     view.simple_form_for form do |f|
       render 'curation_concerns/base/form_files.html.erb', f: f
     end
-    Capybara::Node::Simple.new(rendered)
   end
-
-  let(:all_label) { page.find('button.all')['aria-label'] }
 
   it "displays informative and accessible elements" do
     expect(page).to have_selector("h2", text: "Add Local Files")
@@ -23,5 +22,17 @@ describe "curation_concerns/base/_form_files.html.erb" do
     expect(page).to have_selector("caption", text: "Listing of files ready to be uploaded")
     expect(all_label).to eq("Upload all local files from the listing of files")
     expect(page).to have_selector("button.all", visible: false)
+  end
+
+  describe "BrowseEverything button selector" do
+    subject { page.find("#browse-btn")["data-target"] }
+    context "#edit" do
+      it { is_expected.to eq("#edit_generic_work_#{work.id}") }
+    end
+
+    context "#new" do
+      let(:work) { build(:work, depositor: user.login) }
+      it { is_expected.to eq("#new_generic_work") }
+    end
   end
 end


### PR DESCRIPTION
Adding new files to existing works via BrowseEverything was failing because the form was not using the correct target selector. As a result, BE would insert the wrong html into the form and files could not be uploaded.

This uses a new form method to determine the selector in each case, new and edit views for both single works and batches.