### PR TITLE
Render "Remove from Collection" button, ref #886

### DIFF
--- a/app/views/collections/_sort_and_per_page.html.erb
+++ b/app/views/collections/_sort_and_per_page.html.erb
@@ -1,0 +1,35 @@
+<%# Render Remove  from Collection button even if there's only one work in the collection %>
+<div class="batch-info">
+  <div>
+    <%= render partial: 'collections/form_for_select_collection', locals: { user_collections: @user_collections }  %>
+  </div>
+
+  <% if params[:action] == "edit" && @response.response['numFound'] >= 1  %>
+    <div class="batch-toggle">
+      <% session[:batch_edit_state] = "on" %>
+      <%= button_for_remove_selected_from_collection collection %>
+    </div>
+  <% end %>
+   <div class="sort-toggle">
+     <%# kind of hacky way to get this to work on catalog and folder controllers.  May be able to simple do {action: "index"} but I'm not sure -%>
+     <% if @response.response['numFound'] > 1 && !sort_fields.empty? %>
+        <%= form_tag collection_path(collection), method: :get, class: 'per_page form-horizontal' do %>
+             <div class="form-group form-group-lg">
+               <fieldset class="col-xs-12 col-sm-9 col-md-8 col-lg-10">
+                 <legend class="sr-only"><%= t('sufia.sort_label') %></legend>
+                 <%= label_tag(:sort, "<span>Sort By:</span>".html_safe) %>
+                 <%= select_tag(:sort, options_for_select(sort_fields, h(params[:sort]))) %>
+                 <%= label_tag(:per_page) do %>
+                     Show <%= select_tag(:per_page, options_for_select(['10', '20', '50', '100'], h(params[:per_page])), title: "Number of results to display per page") %>
+                     per page
+                 <% end %>
+                 <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:per_page, :sort)) %>
+                 &nbsp;&nbsp;&nbsp;
+                 <button class="btn btn-info"><span class="glyphicon glyphicon-refresh"></span> Refresh</button>
+               </fieldset>
+               <%= render 'view_type_group' %>
+             </div>
+         <% end %>
+      <% end %>
+   </div>
+</div>

--- a/spec/views/collections/_sort_and_per_page.html.erb_spec.rb
+++ b/spec/views/collections/_sort_and_per_page.html.erb_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe "collections/_sort_and_per_page.html.erb" do
+  let(:collection) { build(:collection, id: "coll1") }
+  let(:page)       { Capybara::Node::Simple.new(rendered) }
+
+  before do
+    assign(:response, solr_response)
+    controller.stub(:params).and_return(action: "edit")
+    render "collections/sort_and_per_page", collection: collection
+  end
+
+  context "when the collection has only one work" do
+    let(:solr_response) { Blacklight::Solr::Response.new({ response: { numFound: 1 } }, nil) }
+    it "renders the button for removing the item from the collection" do
+      expect(page.find(".collection-remove-selected").value).to eq("Remove From Collection")
+    end
+  end
+
+  context "when the collection has no works" do
+    let(:solr_response) { Blacklight::Solr::Response.new({ response: { numFound: 0 } }, nil) }
+    it "does not render the button for removing the item from the collection" do
+      expect(page).not_to have_selector(".collection-remove-selected")
+    end
+  end
+end


### PR DESCRIPTION
The button that removes an item from a collection was not rendered if the collection only had one item. Updating the view allows the button to be used no matter how many items are in the collection.