### PR TITLE
Do not render on_behalf_of in edit mode, ref #970

### DIFF
--- a/app/views/curation_concerns/base/_form_progress.html.erb
+++ b/app/views/curation_concerns/base/_form_progress.html.erb
@@ -45,12 +45,12 @@
     <div class="set-access-controls list-group-item">
       <%= render 'form_visibility_component', f: f %>
     </div>
-    <% unless current_user.can_make_deposits_for.empty? %>
-        <div class="list-group-item">
-          <label for="generic_work_on_behalf_of"><%= t('curation_concerns.base.form_progress.on_behalf_of') %></label>
-          <p class="help-block"><%= t('curation_concerns.base.form_progress.on_behalf_of_help') %></p>
-          <%= f.input :on_behalf_of, label: false, collection: current_user.can_make_deposits_for.map(&:user_key), prompt: "Yourself" %>
-        </div>
+    <% if current_user.can_make_deposits_for.present? && action_name == "new" %>
+      <div class="list-group-item">
+        <label for="generic_work_on_behalf_of"><%= t('curation_concerns.base.form_progress.on_behalf_of') %></label>
+        <p class="help-block"><%= t('curation_concerns.base.form_progress.on_behalf_of_help') %></p>
+        <%= f.input :on_behalf_of, label: false, collection: current_user.can_make_deposits_for.map(&:user_key), prompt: "Yourself" %>
+      </div>
     <% end %>
   </div>
   <div class="panel-footer text-center">

--- a/spec/features/generic_work/edit_work_spec.rb
+++ b/spec/features/generic_work/edit_work_spec.rb
@@ -2,10 +2,11 @@
 require 'feature_spec_helper'
 
 describe "Editing a work" do
-  let(:user1) { create(:user, display_name: "First User") }
-  let(:work)  { create(:public_work, :with_required_metadata, depositor: user1.user_key) }
+  let(:proxy) { create(:first_proxy) }
+  let(:user)  { create(:user, :with_proxy, proxy_for: proxy) }
+  let(:work)  { create(:public_work, :with_required_metadata, depositor: user.user_key) }
 
-  before { sign_in(user1) }
+  before { sign_in(user) }
 
   # Tests the basic outline of the form. This can be expanded later with more detail including
   # refactoring it to incorporate other tests.
@@ -23,5 +24,7 @@ describe "Editing a work" do
     within("#extended-terms") do
       expect(page).to have_selector("h2", text: "Additional Metadata", visible: false)
     end
+
+    expect(page).not_to have_selector("#generic_work_on_behalf_of")
   end
 end

--- a/spec/views/curations_concerns/base/_form_progress.html.erb_spec.rb
+++ b/spec/views/curations_concerns/base/_form_progress.html.erb_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe "curation_concerns/base/_form_progress.html.erb" do
+  let(:work)  { build(:work) }
+  let(:proxy) { create(:first_proxy) }
+  let(:form)  { CurationConcerns::GenericWorkForm.new(work, Ability.new(user)) }
+
+  before { allow(controller).to receive(:current_user).and_return(user) }
+
+  subject do
+    view.simple_form_for(form) do |f|
+      render 'curation_concerns/base/form_progress.html.erb', f: f
+    end
+    Capybara::Node::Simple.new(rendered)
+  end
+
+  describe "#edit" do
+    before { allow(controller).to receive(:action_name).and_return("edit") }
+    context "when the user is a proxy" do
+      let(:user) { create(:user, :with_proxy, proxy_for: proxy) }
+      it { is_expected.not_to have_selector("#generic_work_on_behalf_of") }
+    end
+
+    context "when the user is not a proxy" do
+      let(:user) { create(:user) }
+      it { is_expected.not_to have_selector("#generic_work_on_behalf_of") }
+    end
+  end
+
+  describe "#create" do
+    before { allow(controller).to receive(:action_name).and_return("new") }
+    context "when the user is a proxy" do
+      let(:user) { create(:user, :with_proxy, proxy_for: proxy) }
+      it { is_expected.to have_selector("#generic_work_on_behalf_of") }
+    end
+
+    context "when the user is not a proxy" do
+      let(:user) { create(:user) }
+      it { is_expected.not_to have_selector("#generic_work_on_behalf_of") }
+    end
+  end
+end


### PR DESCRIPTION
During edits, users had the ability to change the proxy for whom they're depositing. While this might be okay in general, an admin could accidentally change the proxy to someone completely different.

Until we have a better overall solution, changing the value of on_behalf_of is disabled.