### PR TITLE
Removes File Format Metadata for Works from Search Index View 

### DIFF
--- a/app/services/field_configurator.rb
+++ b/app/services/field_configurator.rb
@@ -1,28 +1,13 @@
 # frozen_string_literal: true
 class FieldConfigurator
-  def self.common_fields
-    {
-      resource_type: FieldConfig.new("Resource Type"),
-      creator: FieldConfig.new(label: "Creator", facet_cleaners: [:titleize]),
-      keyword:  FieldConfig.new(label: "Keyword", facet_cleaners: [:downcase]),
-      subject: FieldConfig.new("Subject"),
-      language: FieldConfig.new("Language"),
-      based_near: FieldConfig.new("Location"),
-      publisher: FieldConfig.new(label: "Publisher", facet_cleaners: [:titleize]),
-      file_format: FieldConfig.new("File Format"),
-      has_model: FieldConfig.new(label: "Object Type",
-                                 helper_method: :titleize,
-                                 index_solr_type: :symbol,
-                                 solr_type: :symbol)
-    }
-  end
-
+  # Defines what fields are shown on the search index view for each item
   def self.index_fields
     common_fields.merge(date_uploaded: FieldConfig.new(label: "Date Uploaded",
                                                        index_solr_type: :stored_sortable,
                                                        index_type: :date))
   end
 
+  # Defines what fields are shown on the work show page
   def self.show_fields
     index_fields
       .except(:has_model)
@@ -37,11 +22,32 @@ class FieldConfigurator
              description: FieldConfig.new("Description"))
   end
 
+  # Defines what fields are shown in the facets on the search index view
   def self.facet_fields
-    common_fields.merge(collection: FieldConfig.new(label: "Collection", helper_method: :collection_helper_method))
+    common_fields.merge(collection: FieldConfig.new(label: "Collection", helper_method: :collection_helper_method),
+                        file_format: FieldConfig.new("File Format"))
   end
 
+  # Defines what fields are available to the user in the universal search
   def self.search_fields
-    show_fields.merge(title: FieldConfig.new("Title"))
+    show_fields.merge(title: FieldConfig.new("Title"),
+                      file_format: FieldConfig.new("File Format"))
+  end
+
+  # Common fields between all lists
+  def self.common_fields
+    {
+      resource_type: FieldConfig.new("Resource Type"),
+      creator: FieldConfig.new(label: "Creator", facet_cleaners: [:titleize]),
+      keyword:  FieldConfig.new(label: "Keyword", facet_cleaners: [:downcase]),
+      subject: FieldConfig.new("Subject"),
+      language: FieldConfig.new("Language"),
+      based_near: FieldConfig.new("Location"),
+      publisher: FieldConfig.new(label: "Publisher", facet_cleaners: [:titleize]),
+      has_model: FieldConfig.new(label: "Object Type",
+                                 helper_method: :titleize,
+                                 index_solr_type: :symbol,
+                                 solr_type: :symbol)
+    }
   end
 end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -27,7 +27,6 @@ describe CatalogController, type: :controller do
       subject { described_class.blacklight_config.index_fields.keys }
       it { is_expected.to contain_exactly("based_near_tesim",
                                           "date_uploaded_dtsi",
-                                          "file_format_tesim",
                                           "keyword_tesim",
                                           "language_tesim",
                                           "publisher_tesim",
@@ -40,7 +39,7 @@ describe CatalogController, type: :controller do
     describe "show_fields" do
       subject { described_class.blacklight_config.show_fields.keys }
       it { is_expected.to contain_exactly("depositor_tesim", "based_near_tesim", "date_modified_dtsi", "date_uploaded_dtsi",
-                                          "description_tesim", "file_format_tesim", "identifier_tesim", "keyword_tesim",
+                                          "description_tesim", "identifier_tesim", "keyword_tesim",
                                           "language_tesim", "publisher_tesim", "resource_type_tesim", "rights_tesim",
                                           "subject_tesim", "contributor_tesim", "creator_tesim", "date_created_tesim")
       }

--- a/spec/services/field_configurator_spec.rb
+++ b/spec/services/field_configurator_spec.rb
@@ -11,7 +11,6 @@ describe FieldConfigurator do
                                        :language,
                                        :based_near,
                                        :publisher,
-                                       :file_format,
                                        :has_model,
                                        :date_uploaded) }
   end
@@ -26,7 +25,6 @@ describe FieldConfigurator do
                                        :language,
                                        :based_near,
                                        :publisher,
-                                       :file_format,
                                        :contributor,
                                        :date_uploaded,
                                        :date_modified,


### PR DESCRIPTION
Removes the file format field on the search view for works from the file configurator.

Removes file format from the common fields but adds it to the facet fields in the field configurator. Removes file format spec test from catalog controller, works controller, and field configurator because we are dealing with works not files.