### PR TITLE
Updating to use ScholarSphere rake task

### DIFF
--- a/config/cronjobs/update_user_stats.bash
+++ b/config/cronjobs/update_user_stats.bash
@@ -20,7 +20,7 @@ fi
 export RAILS_ENV
 
 
-RESULTS=`bundle exec rake sufia:stats:user_stats 2>&1`
+RESULTS=`bundle exec rake scholarsphere:stats:user_stats 2>&1`
 
 if [ $? -ne 0 ]; then
   SUBJECT="`hostname` user stats task"


### PR DESCRIPTION
The ScholarSphere rake task is configured to retry and is more stable than the sufia rake task which is not configured to retry

I believe this change should have happened when I created the rake task, since I change the error output, but the actual command was missed.