### PR TITLE
Updates published sitemap to reflect Works  

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -155,8 +155,8 @@ namespace :deploy do
       end
     end
   end
-  # Disabled, see psu-stewardship/scholarsphere#285
-  # after :published, :sitemapxml
+  # Re-enabled, see psu-stewardship/scholarsphere#285
+  after :published, :sitemapxml
 
   desc "Compile assets on for selected server roles"
   task :roleassets do


### PR DESCRIPTION
The sitemap was reflecting works as files with the `/files/` directory. The code is fine we just needed to uncomment and re-enable the code for the published sitemap in `deploy.rb`.