### PR TITLE
Adding work level information into the csv file

### DIFF
--- a/app/services/generic_work_list_to_csv_service.rb
+++ b/app/services/generic_work_list_to_csv_service.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class GenericWorkListToCSVService
   attr_reader :works, :terms
 
@@ -7,17 +8,38 @@ class GenericWorkListToCSVService
   end
 
   def csv
-    csv_data = Sufia::FileSetCSVService.new(files[0], terms).csv_header.titleize
+    # using all terms here to create a work and fileset heading
+    csv_data = Sufia::FileSetCSVService.new(files[0], all_terms).csv_header.titleize
+
     files.each do |fs|
-      csv_data.concat(Sufia::FileSetCSVService.new(fs, terms).csv)
+      # get the csv data for the fileset only
+      file_csv_data = Sufia::FileSetCSVService.new(fs, file_set_terms).csv
+
+      # since the FileSetCSVService does not really care what type of object it works on
+      # we are going to use it to produce work level data for each file set parent work
+      work_csv_data = Sufia::FileSetCSVService.new(fs.parent, work_terms).csv.delete("\n")
+
+      # add the entire line to the csv file
+      csv_data.concat("#{work_csv_data},#{file_csv_data}")
     end
     csv_data
   end
 
   private
 
-    def terms
-      @terms ||= [:url, :time_uploaded].concat(Sufia::FileSetCSVService.new(nil).terms)
+    def all_terms
+      return @all_terms if @all_terms.present?
+      mapped_work_terms = work_terms.map { |term| "work_#{term}" }
+      mapped_file_set_terms = file_set_terms.map { |term| "file_set_#{term}" }
+      @all_terms = mapped_work_terms + mapped_file_set_terms
+    end
+
+    def file_set_terms
+      @file_set_terms ||= %i(url time_uploaded id title depositor creator visibility file_format)
+    end
+
+    def work_terms
+      @work_terms ||= %i(url id title resource_type rights)
     end
 
     def files

--- a/spec/controllers/admin/stats_controller_spec.rb
+++ b/spec/controllers/admin/stats_controller_spec.rb
@@ -6,7 +6,7 @@ describe Admin::StatsController, type: :controller do
   before { allow(controller).to receive(:query_service).and_return(query_service) }
   describe "#export" do
     context "when format is csv" do
-      let(:header) { "Url,Time Uploaded,Id,Title,Depositor,Creator,Visibility,Resource Type,Rights,File Format\n" }
+      let(:header) { "Work Url,Work Id,Work Title,Work Resource Type,Work Rights,File Set Url,File Set Time Uploaded,File Set Id,File Set Title,File Set Depositor,File Set Creator,File Set Visibility,File Set File Format\n" }
       before do
         allow(query_service).to receive(:find_by_date_created).and_return(file_list)
       end

--- a/spec/services/generic_work_list_to_csv_spec.rb
+++ b/spec/services/generic_work_list_to_csv_spec.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 describe GenericWorkListToCSVService do
   let(:service) { described_class.new(file_list) }
-  let(:header) { "Url,Time Uploaded,Id,Title,Depositor,Creator,Visibility,Resource Type,Rights,File Format\n" }
+  let(:header) { "Work Url,Work Id,Work Title,Work Resource Type,Work Rights,File Set Url,File Set Time Uploaded,File Set Id,File Set Title,File Set Depositor,File Set Creator,File Set Visibility,File Set File Format\n" }
 
   describe "#csv" do
     subject { service.csv }
@@ -14,13 +15,14 @@ describe GenericWorkListToCSVService do
     end
 
     context "with one file" do
-      let(:file_list) { [create(:work, :with_one_file, file_title: ["CSV Report 1"])] }
-      it { is_expected.to include("CSV Report 1") }
+      let(:file_list) { [create(:work, :with_one_file, file_title: ["CSV Report 1"], resource_type: ["Image"], rights: ["mine"])] }
+      let(:file_set)  { file_list[0].file_sets[0] }
+      let(:work)      { file_set.parent }
       it "can be parsed" do
         parsed = CSV.parse(subject)
         expect(parsed.count).to eq 2
-        expect(parsed[0]).to eq(["Url", "Time Uploaded", "Id", "Title", "Depositor", "Creator", "Visibility", "Resource Type", "Rights", "File Format"])
-        expect(parsed[1]).to include("CSV Report 1")
+        expect(parsed[0]).to eq(["Work Url", "Work Id", "Work Title", "Work Resource Type", "Work Rights", "File Set Url", "File Set Time Uploaded", "File Set Id", "File Set Title", "File Set Depositor", "File Set Creator", "File Set Visibility", "File Set File Format"])
+        expect(parsed[1]).to eq(["http://test.com/concern/generic_works/#{work.id}", work.id, "Sample Title", "Image", "mine", "http://test.com/concern/file_sets/#{file_set.id}", "", file_set.id, "CSV Report 1", file_set.depositor, "", "restricted", ""])
       end
     end
 
@@ -36,7 +38,7 @@ describe GenericWorkListToCSVService do
       it "can be parsed" do
         parsed = CSV.parse(subject)
         expect(parsed.count).to eq 4
-        expect(parsed[0]).to eq(["Url", "Time Uploaded", "Id", "Title", "Depositor", "Creator", "Visibility", "Resource Type", "Rights", "File Format"])
+        expect(parsed[0]).to eq(["Work Url", "Work Id", "Work Title", "Work Resource Type", "Work Rights", "File Set Url", "File Set Time Uploaded", "File Set Id", "File Set Title", "File Set Depositor", "File Set Creator", "File Set Visibility", "File Set File Format"])
         expect(parsed[1]).to include("CSV Multifile-Report 1")
         expect(parsed[2]).to include("CSV Multifile-Report 2")
         expect(parsed[3]).to include("CSV Multifile-Report 3")


### PR DESCRIPTION
This PR modifies the output of the csv export which is emailed to Rob weekly to include work level information like resource type, work url and rights.

The information was previously just in the GenericFile and when the code was translated to FileSets the results were just blank