### PR TITLE
Redirecting the work download to the representative fileset

### DIFF
--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -2,7 +2,16 @@
 class DownloadsController < ApplicationController
   include CurationConcerns::DownloadBehavior
   prepend_before_action only: [:show] do
-    handle_legacy_url_prefix { |new_id| redirect_to sufia.download_path(new_id), status: :moved_permanently }
+    handle_legacy_url_prefix { |new_id| redirect_to main_app.download_path(new_id), status: :moved_permanently }
+  end
+
+  def show
+    case asset
+    when GenericWork
+      redirect_to main_app.download_path(asset.representative_id), status: :moved_permanently
+    else
+      super
+    end
   end
 
   protected

--- a/spec/requests/download_spec.rb
+++ b/spec/requests/download_spec.rb
@@ -2,12 +2,12 @@
 require 'rails_helper'
 
 describe "Download requests", type: :request do
-  let(:work) { create(:public_work) }
+  let(:collection) { create(:collection) }
   subject { response }
 
   # Tests public/404.html.erb which is required by Hydra::Controller::DownloadBehavior#render_404
   context "with a missing image" do
-    before { get "/downloads/#{work.id}" }
+    before { get "/downloads/#{collection.id}" }
     it { is_expected.to be_not_found }
   end
 end


### PR DESCRIPTION
This will handle legacy urls for download.  In the future we will want to download the entire item not redirect, but that is for a later date.