### PR TITLE
Only show the representative media section when editing a work

### DIFF
--- a/app/views/curation_concerns/base/_form_metadata.html.erb
+++ b/app/views/curation_concerns/base/_form_metadata.html.erb
@@ -5,11 +5,13 @@
   <% end %>
 </div>
 
+<% if action_name == 'edit' %>
 <div id="work-media">
   <h2>Media</h2>
   <p><%= t('scholarsphere.media') %></p>
   <%= render 'form_media', f: f %>
 </div>
+<% end %>
 
 <p class="hidden-xs">
   <a href="#savework" target="_self"><%= t('curation_concerns.base.back_to_top') %></a>

--- a/spec/features/generic_work/upload_and_delete_spec.rb
+++ b/spec/features/generic_work/upload_and_delete_spec.rb
@@ -61,6 +61,7 @@ describe 'Generic File uploading and deletion:', type: :feature do
         select 'Audio', from: 'generic_work_resource_type'
 
         within("#metadata")      { expect(page).to have_link("Licenses") }
+        within("#metadata")      { expect(page).not_to have_css("#work-media") }
         within("div#savewidget") { expect(page).to have_link("Required metadata complete") }
 
         # Check for additional fields


### PR DESCRIPTION
This fixes the media section appearing on the new work page when the media hasn't been set. Only display the media section with values when we are editing a work.  Uses if action == edit and tests that the media section is not present on the new work form.