### PR TITLE
Make feature-only RSpec configs explicit

### DIFF
--- a/spec/feature_spec_helper.rb
+++ b/spec/feature_spec_helper.rb
@@ -7,6 +7,6 @@ require 'features/support/batch_edit_actions'
 
 RSpec.configure do |config|
   config.include Warden::Test::Helpers, type: :feature
-  config.after(:each) { Warden.test_reset! }
-  config.before(:each) { allow(Hydra::Works::VirusCheckerService).to receive(:file_has_virus?).and_return(false) }
+  config.after(type: :feature) { Warden.test_reset! }
+  config.before(type: :feature) { allow(Hydra::Works::VirusCheckerService).to receive(:file_has_virus?).and_return(false) }
 end

--- a/spec/features/support/feature_cleanup.rb
+++ b/spec/features/support/feature_cleanup.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 RSpec.configure do |config|
   # Clean out Redis, Fedora and Solr prior to each feature test
-  config.before :each do |_example|
+  config.before(type: :feature) do
     begin
       redis_instance = Sufia::RedisEventStore.instance
       redis_instance.keys('events:*').each { |key| redis_instance.del key }
@@ -13,7 +13,7 @@ RSpec.configure do |config|
     ActiveFedora::Cleaner.clean!
   end
 
-  config.after(:each) do
+  config.after(type: :feature) do
     sleep 0.1
     Capybara.reset_sessions!
     sleep 0.1


### PR DESCRIPTION
We were getting strange RSpec errors with feature test helpers during non-feature tests.

Before and after configs that were supposed to be run only on feature tests were actually running on all tests. This ensures that only feature tests will apply this configuration steps.