### PR TITLE
Replace broken thumbnail images with defaults, ref #892

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,4 +14,5 @@
 //= require openseadragon
 //= require scholarsphere/fileupload
 //= require scholarsphere/layout
+//= require scholarsphere/thumbnails
 //= require sufia

--- a/app/assets/javascripts/scholarsphere/thumbnails.js.erb
+++ b/app/assets/javascripts/scholarsphere/thumbnails.js.erb
@@ -1,0 +1,9 @@
+/**
+ * Display default work icon for broken thumbnails in catalog search results
+ */
+
+Blacklight.onLoad(function() {
+  $(".catalog img").error(function(){
+    $(this).attr("src", "<%= asset_path('work.png') %>");
+  });
+});

--- a/spec/features/generic_work/show_public_work_spec.rb
+++ b/spec/features/generic_work/show_public_work_spec.rb
@@ -128,4 +128,31 @@ describe GenericWork do
       end
     end
   end
+
+  context "with a public work and a restricted thumbnail" do
+    let(:work) do
+      build(:public_work, :with_complete_metadata,
+            id: "public-work",
+            title: ["Restricted thumbnail"],
+            depositor: current_user.login)
+    end
+
+    before do
+      doc = work.to_solr
+      doc["thumbnail_path_ss"] = "/downloads/restricted-id?file=thumbnail"
+      index_document(doc)
+      sign_in_with_named_js(:thumbnail)
+      visit(root_path)
+    end
+
+    it "displays the default work image for the thumbnail" do
+      within('#search-form-header') do
+        fill_in('search-field-header', with: work.title.first)
+        click_button("Go")
+      end
+      within("#document_public-work") do
+        expect(page.find("img")["src"]).to end_with(ActionController::Base.helpers.image_path("work.png"))
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is the "option three" solution. See my notes to #892. It should only apply to images within the catalog display, which are search results. Any other image would appear with the standard "?" in the blue box or broken image default.