### PR TITLE
Clean up deprecation warnings, ref #1001

### DIFF
--- a/app/models/file_set.rb
+++ b/app/models/file_set.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 class FileSet < ActiveFedora::Base
-  extend Deprecation
   include ::CurationConcerns::FileSetBehavior
   include Sufia::FileSetBehavior
   include AdditionalMetadata
@@ -9,11 +8,9 @@ class FileSet < ActiveFedora::Base
     FileSetIndexer
   end
 
+  # @return [String, nil]
+  # Field value is constructed at index time in CurationConcerns::FileSetIndexer
   def file_format
-    Deprecation.warn(self, "Calling FileSet.file_format is deprecated. Use the value in its solr_document instead")
-    return nil if mime_type.blank? && format_label.blank?
-    return mime_type.split('/')[1] + " (" + format_label.join(", ") + ")" unless mime_type.blank? || format_label.blank?
-    return mime_type.split('/')[1] unless mime_type.blank?
-    format_label
+    to_solr.fetch("file_format_sim", nil)
   end
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -10,6 +10,10 @@ class SolrDocument
   # Adds Sufia behaviors to the SolrDocument.
   include Sufia::SolrDocumentBehavior
 
+  # Avoid deprecation warning in Blacklight::Document#initialize
+  # Expects a hash-like object responding to :to_hash
+  alias to_hash to_h
+
   def collections
     return nil if self[Solrizer.solr_name(:collection)].blank?
     collections_in = Array(self[Solrizer.solr_name(:collection)])

--- a/app/services/solr_document_groomer.rb
+++ b/app/services/solr_document_groomer.rb
@@ -1,16 +1,18 @@
 # frozen_string_literal: true
-# Cleans up existing fields in the solr document before it is sent on for indexing
+# Cleans up existing fields in the solr document before it is sent on for indexing. Because this is
+# used in conjunction with Blacklight::Document, which prefers hashes, SolrDocument objects are
+# converted to hashes and a hash is always returned.
 class SolrDocumentGroomer
   attr_reader :document
 
   # @param [SolrDocument, Hash]
-  # @return [SolrDocument, Hash]
+  # @return [Hash]
   def self.call(document)
     new(document).groom
   end
 
   def initialize(document)
-    @document = document
+    @document = document.to_h
   end
 
   def groom

--- a/config/application.yml
+++ b/config/application.yml
@@ -5,21 +5,19 @@
 # Scholarsphere::Config::REQUIREMENTS otherwise, the cap deploy will fail.
 #
 development:
-  TMPDIR: "/tmp"
   ffmpeg_path: "ffmpeg"
   service_instance: "localhost"
   virtual_host: "http://localhost:3000/"
   stats_email: "ScholarSphere Stats <umg-up.its.sas.scholarsphere-email@groups.ucs.psu.edu>"
   google_analytics_id: "test-id"
-  read_only: false
+  read_only: "false"
 test:
-  TMPDIR: "/tmp"
   ffmpeg_path: "ffmpeg-test"
   service_instance: "example-test"
   virtual_host: "http://test.com/"
   stats_email: "Test email"
   google_analytics_id: "test-id"
-  read_only: false
+  read_only: "false"
 production:
   TMPDIR: "/tmp"
   ffmpeg_path: "ffmpeg-test"
@@ -28,4 +26,4 @@ production:
   stats_email: "Test email"
   google_analytics_id: "test-id"
   derivatives_path: "path"
-  read_only: false
+  read_only: "false"

--- a/lib/tasks/scholarsphere/solr.rake
+++ b/lib/tasks/scholarsphere/solr.rake
@@ -15,7 +15,7 @@ namespace :scholarsphere do
       raise "Fedora's #{fedora.to_s} objects exceeds Solr's #{solr}" if fedora > solr
       puts "Things appear to be OK"
     end
-    
+
   end
 
   def number_of_objects_in_fedora
@@ -28,7 +28,7 @@ namespace :scholarsphere do
     result = ActiveFedora.fedora.connection.get(url).body
     triples = ::RDF::Reader.for(:ttl).new(result)
     rdf = ::RDF::Graph.new << triples
-    rdf.query(predicate: ::Ldp.contains).count
+    rdf.query(predicate: ::RDF::Vocab::LDP.contains).count
   end
 
   def number_of_objects_in_solr

--- a/spec/factories/file_sets.rb
+++ b/spec/factories/file_sets.rb
@@ -43,7 +43,7 @@ FactoryGirl.define do
 
     trait :with_file_size do
       after(:build) do |fs|
-        fs.stub(:file_size).and_return '1234'
+        allow(fs).to receive(:file_size).and_return("1234")
       end
     end
   end

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -21,10 +21,7 @@ describe FileSet, type: :model do
   end
 
   describe "#file_format" do
-    it "is deprecated" do
-      expect(Deprecation).to receive(:warn)
-      expect(subject.file_format).to eq("png")
-    end
+    its(:file_format) { is_expected.to eq("png") }
   end
 
   describe "#visibility" do

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -25,4 +25,8 @@ describe SolrDocument do
     subject { described_class.new(bytes_lts: ["1234"]) }
     its(:bytes) { is_expected.to eq("1234") }
   end
+
+  describe "#to_hash" do
+    its(:to_hash) { is_expected.to eq(subject.to_h) }
+  end
 end

--- a/spec/presenters/work_show_presenter_spec.rb
+++ b/spec/presenters/work_show_presenter_spec.rb
@@ -20,7 +20,7 @@ describe WorkShowPresenter do
     end
 
     context "with two files in the work" do
-      let(:solr_doc)    { SolrDocument.new(work.to_solr).merge!('member_ids_ssim' => ["thing1", "thing2"]) }
+      let(:solr_doc)    { SolrDocument.new(work.to_solr).to_h.merge!('member_ids_ssim' => ["thing1", "thing2"]) }
       its(:total_items) { is_expected.to eq(2) }
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -19,6 +19,11 @@ Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!
 
+# Monkeypatch FactoryGirl so we can use RSpec's latest syntax to mock responses with factory objects
+FactoryGirl::SyntaxRunner.class_eval do
+  include RSpec::Mocks::ExampleMethods
+end
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"

--- a/spec/views/collections/_sort_and_per_page.html.erb_spec.rb
+++ b/spec/views/collections/_sort_and_per_page.html.erb_spec.rb
@@ -7,7 +7,7 @@ describe "collections/_sort_and_per_page.html.erb" do
 
   before do
     assign(:response, solr_response)
-    controller.stub(:params).and_return(action: "edit")
+    allow(controller).to receive(:params).and_return(action: "edit")
     render "collections/sort_and_per_page", collection: collection
   end
 

--- a/spec/views/curations_concerns/base/_form.html.erb_spec.rb
+++ b/spec/views/curations_concerns/base/_form.html.erb_spec.rb
@@ -8,7 +8,7 @@ describe "curation_concerns/base/_form.html.erb" do
 
   before do
     assign(:form, form)
-    controller.stub(:params).and_return(params)
+    allow(controller).to receive(:params).and_return(params)
     stub_template "_form_files.html.erb" => ""
     stub_template "_form_metadata.html.erb" => ""
     stub_template "_form_relationships.html.erb" => ""

--- a/spec/views/sufia/batch_uploads/_form.html.erb_spec.rb
+++ b/spec/views/sufia/batch_uploads/_form.html.erb_spec.rb
@@ -6,7 +6,7 @@ describe "sufia/batch_uploads/_form.html.erb" do
 
   before do
     assign(:form, form)
-    controller.stub(:params).and_return(params)
+    allow(controller).to receive(:params).and_return(params)
     stub_template "_form_files.html.erb" => ""
     stub_template "_form_metadata.html.erb" => ""
     stub_template "_form_relationships.html.erb" => ""


### PR DESCRIPTION
This makes a number of changes to remove deprecation warnings and other warnings when running RSpec:

* corrects Figaro warnings due to ignored or incorrect variable values
* removes the deprecation warning on FileSet#file_format by using its derived value from Solr
* removes a number of deprecation warnings due to Blacklight::Document preferring hash-like objects
* updates Ldp.contains to RDF::Vocab::LDP.contains
* removes instances of `stub` from RSpec tests