### PR TITLE
Limit selection of representative file sets, ref #892

### DIFF
--- a/app/forms/curation_concerns/generic_work_form.rb
+++ b/app/forms/curation_concerns/generic_work_form.rb
@@ -26,14 +26,10 @@ module CurationConcerns
     end
 
     def select_files
-      Hash[file_presenters.map { |file| [name_for_select_file(file), file.id] }]
-    end
-
-    private
-
-      def name_for_select_file(file)
-        return file.to_s unless model.visibility == "open" && file.solr_document.visibility == "authenticated"
-        [file, I18n.t("scholarsphere.select_file_restriction")].join(" ").to_s
+      available_files = file_presenters.select do |file|
+        model.visibility == file.solr_document.visibility
       end
+      Hash[available_files.map { |file| [file.to_s, file.id] }]
+    end
   end
 end

--- a/app/views/curation_concerns/base/_form_metadata.html.erb
+++ b/app/views/curation_concerns/base/_form_metadata.html.erb
@@ -6,11 +6,10 @@
 </div>
 
 <% if action_name == 'edit' %>
-<div id="work-media">
-  <h2>Media</h2>
-  <p><%= t('scholarsphere.media') %></p>
-  <%= render 'form_media', f: f %>
-</div>
+  <div id="work-media">
+    <h2>Media</h2>
+    <%= render 'form_media', f: f %>
+  </div>
 <% end %>
 
 <p class="hidden-xs">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -64,15 +64,11 @@ en:
       local: "Files must be added before they can be uploaded"
     batch_edit:
       permissions_warning: "Warning! Making changes to visibility or sharing permissions will remove any existing permissions on the files in this batch and replace them with the ones specified here."
-    select_file_restriction: "(less visible)"
-    media: "Choosing a representative listed as <em>less visible</em> may not appear if the work is public"
-
   statistic:
     report:
       subject: "ScholarSphere - Statistic Report"
       csv:
         file_name: "scholarsphere-stats_%{date_str}.csv"
-
 
   # Error messages used in conjunction with ErrorPresenter. The key for each error is derived as follows:
   #   StandardError => standard_error

--- a/spec/features/generic_work/edit_work_spec.rb
+++ b/spec/features/generic_work/edit_work_spec.rb
@@ -18,7 +18,6 @@ describe "Editing a work" do
 
     within("#work-media") do
       expect(page).to have_selector("h2", text: "Media")
-      expect(page).to have_content(I18n.t('scholarsphere.media'))
     end
 
     within("#extended-terms") do

--- a/spec/forms/generic_work_form_spec.rb
+++ b/spec/forms/generic_work_form_spec.rb
@@ -64,6 +64,6 @@ describe CurationConcerns::GenericWorkForm do
     before { allow(form).to receive(:file_presenters).and_return(file_presenters) }
 
     subject { form }
-    its(:select_files) { is_expected.to include("Registered File (less visible)", "Public File") }
+    its(:select_files) { is_expected.to eq("Public File" => "public-fileset") }
   end
 end


### PR DESCRIPTION
Selection of representative file sets should be limited to those whose visibility matches that of the work.

This alters some of the decisions that were made in 7fce7edfd211e9fa1d64f21972ec9782afa867ce. Instead of allowing less-visible representatives, only equally visible file sets will be allowed for representatives or thumbnails.