### PR TITLE
Single Value Title and Subtitle

### DIFF
--- a/app/forms/curation_concerns/generic_work_form.rb
+++ b/app/forms/curation_concerns/generic_work_form.rb
@@ -4,7 +4,7 @@
 module CurationConcerns
   class GenericWorkForm < Sufia::Forms::WorkForm
     self.model_class = ::GenericWork
-    self.terms += [:resource_type]
+    self.terms += [:resource_type, :subtitle]
     self.required_fields += [:description, :resource_type]
 
     include HydraEditor::Form::Permissions
@@ -12,9 +12,32 @@ module CurationConcerns
     include WithCleanerAttributes
     include WithOpenAccess
 
-    def self.multiple?(term)
-      return false if term == :rights
-      super
+    def self.multiple?(field)
+      if [:title, :rights].include? field.to_sym
+        false
+      else
+        super
+      end
+    end
+
+    def self.model_attributes(_)
+      attrs = super
+      attrs[:title] = Array(attrs[:title]) if attrs[:title]
+      attrs[:rights] = Array(attrs[:rights]) if attrs[:rights]
+      attrs
+    end
+
+    def title
+      super.first || ""
+    end
+
+    def rights
+      super.first || ""
+    end
+
+    # Fields that are automatically drawn on the page above the fold
+    def primary_terms
+      [:title, :subtitle, :creator, :keyword, :rights, :description, :resource_type]
     end
 
     def target_selector

--- a/app/models/generic_work.rb
+++ b/app/models/generic_work.rb
@@ -12,6 +12,10 @@ class GenericWork < ActiveFedora::Base
 
   property :upload_set, predicate: ::RDF::URI.new('http://scholarsphere.psu.edu/ns#upload_set'), multiple: false
 
+  property :subtitle, predicate: ::RDF::Vocab::EBUCore.subtitle, multiple: false do |index|
+    index.as :stored_searchable
+  end
+
   def self.indexer
     WorkIndexer
   end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -37,6 +37,10 @@ class SolrDocument
     Array(self[Solrizer.solr_name(:bytes, CurationConcerns::CollectionIndexer::STORED_LONG)]).first
   end
 
+  def subtitle
+    self[Solrizer.solr_name('subtitle')]
+  end
+
   private
 
     def ul_start_tags

--- a/app/presenters/work_show_presenter.rb
+++ b/app/presenters/work_show_presenter.rb
@@ -3,7 +3,7 @@ class WorkShowPresenter < Sufia::WorkShowPresenter
   include ActionView::Helpers::NumberHelper
   include Sufia::WithEvents
 
-  delegate :bytes, to: :solr_document
+  delegate :bytes, :subtitle, to: :solr_document
 
   self.file_presenter_class = ::FileSetPresenter
 

--- a/app/services/field_configurator.rb
+++ b/app/services/field_configurator.rb
@@ -19,7 +19,8 @@ class FieldConfigurator
              date_created: FieldConfig.new("Date Created"),
              rights: FieldConfig.new("Rights"),
              identifier: FieldConfig.new("Identifier"),
-             description: FieldConfig.new("Description"))
+             description: FieldConfig.new("Description"),
+             subtitle: FieldConfig.new("Subtitle"))
   end
 
   # Defines what fields are shown in the facets on the search index view

--- a/app/views/curation_concerns/base/_form_metadata.html.erb
+++ b/app/views/curation_concerns/base/_form_metadata.html.erb
@@ -1,5 +1,5 @@
 <div class="base-terms">
-  <h2>Required Metadata</h2>
+  <h2><%= t('simple_form.headings.base') %></h2>
   <% f.object.primary_terms.each do |term| %>
       <%= render_edit_field_partial(term, f: f) %>
   <% end %>
@@ -26,7 +26,7 @@
             'aria-controls'=> "extended-terms" %>
 
 <div id="extended-terms" class='collapse'>
-  <h2>Additional Metadata</h2>
+  <h2><%= t('simple_form.headings.additional') %></h2>
   <% f.object.secondary_terms.each do |term| %>
       <%= render_edit_field_partial(term, f: f) %>
   <% end %>

--- a/app/views/curation_concerns/base/_work_subtitle.erb
+++ b/app/views/curation_concerns/base/_work_subtitle.erb
@@ -1,0 +1,3 @@
+<% if presenter.subtitle.present? %>
+    <h2><%= presenter.subtitle.first %></h2>
+<% end %>

--- a/app/views/curation_concerns/base/show.html.erb
+++ b/app/views/curation_concerns/base/show.html.erb
@@ -18,6 +18,7 @@
   <div class="col-xs-12">
     <header>
       <%= render 'work_title', presenter: @presenter %>
+      <%= render 'work_subtitle', presenter: @presenter %>
     </header>
   </div>
   <div class="col-sm-8">

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -57,6 +57,9 @@ en:
       files:
         instructions: "The file structure will be flattened and each file will be uploaded to a separate new work resulting in one work per uploaded file. If you'd like to maintain the file structure, consider using the zip or similar format."
   simple_form:
+    headings:
+      base: 'Basic Metadata'
+      additional: 'Additional Metadata'
     labels:
       collection:
         description: "Description"

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -41,7 +41,8 @@ describe CatalogController, type: :controller do
       it { is_expected.to contain_exactly("depositor_tesim", "based_near_tesim", "date_modified_dtsi", "date_uploaded_dtsi",
                                           "description_tesim", "identifier_tesim", "keyword_tesim",
                                           "language_tesim", "publisher_tesim", "resource_type_tesim", "rights_tesim",
-                                          "subject_tesim", "contributor_tesim", "creator_tesim", "date_created_tesim")
+                                          "subject_tesim", "contributor_tesim", "creator_tesim", "date_created_tesim",
+                                          "subtitle_tesim")
       }
     end
     describe "facet_fields" do

--- a/spec/controllers/curation_concerns/generic_works_controller_spec.rb
+++ b/spec/controllers/curation_concerns/generic_works_controller_spec.rb
@@ -21,7 +21,7 @@ describe CurationConcerns::GenericWorksController, type: :controller do
       end
     end
 
-    context "when file is registered" do
+    context "when work is registered" do
       let(:work)   { create(:registered_file) }
       let(:path)   { Rails.application.routes.url_helpers.curation_concerns_generic_work_path(work) }
       it "redirects with file in url" do
@@ -74,25 +74,25 @@ describe CurationConcerns::GenericWorksController, type: :controller do
     end
   end
 
-  context "when file is private" do
-    let(:gf) { create(:private_file) }
-    before   { sign_in user }
+  context "when work is private" do
+    let(:work) { create(:private_work, id: "1234") }
+    before { sign_in user }
 
     context "when user is not administrator" do
       let(:user) { FactoryGirl.create(:user) }
 
       it "does not allow any user to view" do
-        get :show, id: gf.id
+        get :show, id: work.id
         expect(response.status).to eq(401)
       end
 
       it "does not allow any user to edit" do
-        get :edit, id: gf.id
+        get :edit, id: work.id
         expect(response.status).to eq(401)
       end
 
       it "does not allow any user to update" do
-        post :update, id: gf.id, generic_file: { title: ['new_title'] }
+        post :update, id: work.id, generic_work: { title: 'new_title' }
         expect(response.status).to eq(401)
       end
     end
@@ -101,19 +101,19 @@ describe CurationConcerns::GenericWorksController, type: :controller do
       let(:user) { FactoryGirl.create(:administrator) }
 
       it "does allow user to view" do
-        get :show, id: gf.id
+        get :show, id: work.id
         expect(response.status).to eq(200)
       end
 
       it "allows edits" do
-        get :edit, id: gf.id
+        get :edit, id: work.id
         expect(response.status).to eq(200)
       end
 
       it "allows updates" do
-        post :update, id: gf.id, generic_work: { title: ['new_title'] }
+        post :update, id: work.id, generic_work: { title: 'new_title' }
         expect(response.status).to eq(302)
-        expect(gf.reload.title).to eq(['new_title'])
+        expect(work.reload.title.first).to eq('new_title')
       end
     end
   end

--- a/spec/features/dashboard/dashboard_works_spec.rb
+++ b/spec/features/dashboard/dashboard_works_spec.rb
@@ -63,7 +63,7 @@ describe 'Dashboard Works', type: :feature do
       db_item_actions_toggle(work1).click
       click_link 'Edit Work'
       expect(page).to have_content("Edit Work")
-      expect(page).to have_field("generic_work[title][]", with: filename)
+      expect(page).to have_field("generic_work[title]", with: filename)
       expect(page).to have_content 'Visibility'
 
       # TODO: This part of the test won't pass until this Sufia

--- a/spec/features/generic_work/edit_work_spec.rb
+++ b/spec/features/generic_work/edit_work_spec.rb
@@ -13,7 +13,8 @@ describe "Editing a work" do
   it "displays the edit form" do
     visit("/concern/generic_works/#{work.id}/edit")
     within(".base-terms") do
-      expect(page).to have_selector("h2", text: "Required Metadata")
+      expect(page).to have_selector("h2", text: "Basic Metadata")
+      expect(page).to have_selector("label", text: "Subtitle")
     end
 
     within("#work-media") do

--- a/spec/forms/generic_work_form_spec.rb
+++ b/spec/forms/generic_work_form_spec.rb
@@ -14,8 +14,15 @@ describe CurationConcerns::GenericWorkForm do
   describe "::model_attributes" do
     subject { described_class.model_attributes(params) }
     context "when attributes have multiple spaces" do
-      let(:params) { ActionController::Parameters.new(title: [" I am  in a  space "], rights: " url ") }
-      it { is_expected.to include(title: ["I am in a space"], rights: "url") }
+      let(:params) { ActionController::Parameters.new(title: " I am  in a  space ", rights: " url ") }
+
+      it 'checks that title parameter does not have extra spaces' do
+        expect(subject['title']).to eq ['I am in a space']
+      end
+
+      it 'checks that rights parameter does not have extra spaces' do
+        expect(subject['rights']).to eq ['url']
+      end
     end
   end
 

--- a/spec/services/field_configurator_spec.rb
+++ b/spec/services/field_configurator_spec.rb
@@ -31,7 +31,8 @@ describe FieldConfigurator do
                                        :date_created,
                                        :rights,
                                        :identifier,
-                                       :depositor) }
+                                       :depositor,
+                                       :subtitle) }
   end
 
   describe "::facet_fields" do
@@ -81,6 +82,7 @@ describe FieldConfigurator do
                                        :date_created,
                                        :rights,
                                        :identifier,
-                                       :depositor) }
+                                       :depositor,
+                                       :subtitle) }
   end
 end


### PR DESCRIPTION
Updates generic work form spec to check each paramater to make sure that they do not contain spaces. Removes empty array from generic work field since the title is displayed as a single value string.

Adds subtitle to the model, new/edit form, show page, property to be displayed, field configurator. Removes subtitle from attribute rows, adds subtitle to the show page under the title, and creates new subtitle partial.

Fixes the catalog controller and field configurator tests for the addition of subtitle. Reworks primary terms method to include subtitle unerneath title in the required metadata section. Adds headings to sufia.en.yml file for the new/edit work form. Updates tests to check for the presence of subtitle.

Updates tests to check for the presence of subtitle.