### PR TITLE
Prefer single-quotes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -73,7 +73,10 @@ Style/RegexpLiteral:
   Enabled: false
 
 Style/StringLiterals:
-  Enabled: false
+  Description: 'Checks if uses of quotes match the configured preference.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#consistent-string-literals'
+  EnforcedStyle: single_quotes
+  Enabled: true
 
 Style/ClassAndModuleChildren:
   Enabled: false

--- a/app/actors/curation_concerns/actors/generic_work_actor.rb
+++ b/app/actors/curation_concerns/actors/generic_work_actor.rb
@@ -24,8 +24,8 @@ module CurationConcerns
         # Overrides CurationConcerns::Actors::BaseActor to reassign the depositor
         # if the user is depositing on behalf of someone else.
         def apply_save_data_to_curation_concern(attributes)
-          if attributes.fetch("on_behalf_of", nil).present?
-            depositor = ::User.find_by_user_key(attributes.fetch("on_behalf_of"))
+          if attributes.fetch('on_behalf_of', nil).present?
+            depositor = ::User.find_by_user_key(attributes.fetch('on_behalf_of'))
             curation_concern.apply_depositor_metadata(depositor)
             curation_concern.edit_users += [depositor, user.user_key]
           end

--- a/app/actors/sufia/create_with_remote_files_actor.rb
+++ b/app/actors/sufia/create_with_remote_files_actor.rb
@@ -44,7 +44,7 @@ module Sufia
 
       def log(user)
         CurationConcerns::Operation.create!(user: user,
-                                            operation_type: "Attach Remote File")
+                                            operation_type: 'Attach Remote File')
       end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -53,7 +53,7 @@ class ApplicationController < ActionController::Base
   def render_404
     @presenter = ErrorPresenter.new
     @presenter.log_exception
-    render template: '/error', layout: "error", formats: [:html], status: @presenter.status
+    render template: '/error', layout: 'error', formats: [:html], status: @presenter.status
   end
 
   # @param [Exception] exception
@@ -67,7 +67,7 @@ class ApplicationController < ActionController::Base
     else
       @presenter = ErrorPresenter.new(exception)
       @presenter.log_exception
-      render template: '/error', layout: "error", formats: [:html], status: @presenter.status
+      render template: '/error', layout: 'error', formats: [:html], status: @presenter.status
     end
   end
 
@@ -83,7 +83,7 @@ class ApplicationController < ActionController::Base
   end
 
   def handle_legacy_url_prefix
-    legacy_prefix = "scholarsphere:"
+    legacy_prefix = 'scholarsphere:'
     id = params[:id].to_s
     return id unless id.start_with?(legacy_prefix)
     new_id = id[legacy_prefix.length..-1]
@@ -101,7 +101,7 @@ class ApplicationController < ActionController::Base
       return if current_user && current_user.ldap_exist? && !ReadOnly.read_only?
       if ReadOnly.read_only?
         @announcement = ReadOnly.announcement_text
-        render template: '/error/read_only', layout: "homepage", formats: [:html], status: 503
+        render template: '/error/read_only', layout: 'homepage', formats: [:html], status: 503
       else
         logger.error "User: `#{current_user.user_key}' does not exist in ldap"
         render 'curation_concerns/base/unauthorized', status: :unauthorized
@@ -116,7 +116,7 @@ class ApplicationController < ActionController::Base
     end
 
     def nil_request
-      logger.warn("Request is Nil, how weird!!!")
+      logger.warn('Request is Nil, how weird!!!')
       nil
     end
 end

--- a/app/controllers/batch_edits_controller.rb
+++ b/app/controllers/batch_edits_controller.rb
@@ -13,7 +13,7 @@ class BatchEditsController < ApplicationController
 
   def update
     batch.map { |id| update_document(ActiveFedora::Base.find(id)) }
-    flash[:notice] = "Batch update complete"
+    flash[:notice] = 'Batch update complete'
     after_update
   end
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -61,14 +61,14 @@ class CatalogController < ApplicationController
 
     ## Default parameters to send to solr for all search-like requests. See also SolrHelper#solr_search_params
     config.default_solr_params = {
-      qt: "search",
+      qt: 'search',
       rows: 10,
-      qf: "title_tesim name_tesim"
+      qf: 'title_tesim name_tesim'
     }
 
     # solr field configuration for document/show views
-    config.index.title_field = solr_name("title", :stored_searchable)
-    config.index.display_type_field = solr_name("has_model", :symbol)
+    config.index.title_field = solr_name('title', :stored_searchable)
+    config.index.display_type_field = solr_name('has_model', :symbol)
     config.index.thumbnail_field = 'thumbnail_path_ss'
 
     # solr fields that will be treated as facets by the blacklight application
@@ -106,8 +106,8 @@ class CatalogController < ApplicationController
     # solr request handler? The one set in config[:default_solr_parameters][:qt],
     # since we aren't specifying it otherwise.
     config.add_search_field('all_fields', label: 'All Fields', include_in_advanced_search: false) do |field|
-      all_names = search_fields.join(" ")
-      title_name = solr_name("title", :stored_searchable)
+      all_names = search_fields.join(' ')
+      title_name = solr_name('title', :stored_searchable)
       field.solr_parameters = {
         qf: "#{all_names} id all_text_timv",
         pf: title_name.to_s
@@ -121,13 +121,13 @@ class CatalogController < ApplicationController
     # subject, language, resource_type, format, identifier, based_near,
     config.add_search_field('contributor') do |field|
       # solr_parameters hash are sent to Solr as ordinary url query params.
-      field.solr_parameters = { "spellcheck.dictionary": "contributor" }
+      field.solr_parameters = { "spellcheck.dictionary": 'contributor' }
 
       # :solr_local_parameters will be sent using Solr LocalParams
       # syntax, as eg {! qf=$title_qf }. This is neccesary to use
       # Solr parameter de-referencing like $title_qf.
       # See: http://wiki.apache.org/solr/LocalParams
-      solr_name = solr_name("contributor", :stored_searchable)
+      solr_name = solr_name('contributor', :stored_searchable)
       field.solr_local_parameters = {
         qf: solr_name,
         pf: solr_name
@@ -136,7 +136,7 @@ class CatalogController < ApplicationController
 
     config.add_search_field('creator') do |field|
       # field.solr_parameters = { "spellcheck.dictionary": "creator" }
-      solr_name = solr_name("creator", :stored_searchable)
+      solr_name = solr_name('creator', :stored_searchable)
       field.solr_local_parameters = {
         qf: solr_name,
         pf: solr_name
@@ -147,7 +147,7 @@ class CatalogController < ApplicationController
       # field.solr_parameters = {
       #   "spellcheck.dictionary": "title"
       # }
-      solr_name = solr_name("title", :stored_searchable)
+      solr_name = solr_name('title', :stored_searchable)
       field.solr_local_parameters = {
         qf: solr_name,
         pf: solr_name
@@ -155,11 +155,11 @@ class CatalogController < ApplicationController
     end
 
     config.add_search_field('description') do |field|
-      field.label = "Abstract or Summary"
+      field.label = 'Abstract or Summary'
       # field.solr_parameters = {
       #   "spellcheck.dictionary": "description"
       # }
-      solr_name = solr_name("description", :stored_searchable)
+      solr_name = solr_name('description', :stored_searchable)
       field.solr_local_parameters = {
         qf: solr_name,
         pf: solr_name
@@ -170,7 +170,7 @@ class CatalogController < ApplicationController
       # field.solr_parameters = {
       #   "spellcheck.dictionary": "publisher"
       # }
-      solr_name = solr_name("publisher", :stored_searchable)
+      solr_name = solr_name('publisher', :stored_searchable)
       field.solr_local_parameters = {
         qf: solr_name,
         pf: solr_name
@@ -181,7 +181,7 @@ class CatalogController < ApplicationController
       # field.solr_parameters = {
       #   "spellcheck.dictionary": "date_created"
       # }
-      solr_name = solr_name("created", :stored_searchable)
+      solr_name = solr_name('created', :stored_searchable)
       field.solr_local_parameters = {
         qf: solr_name,
         pf: solr_name
@@ -192,7 +192,7 @@ class CatalogController < ApplicationController
       # field.solr_parameters = {
       #   "spellcheck.dictionary": "subject"
       # }
-      solr_name = solr_name("subject", :stored_searchable)
+      solr_name = solr_name('subject', :stored_searchable)
       field.solr_local_parameters = {
         qf: solr_name,
         pf: solr_name
@@ -203,7 +203,7 @@ class CatalogController < ApplicationController
       # field.solr_parameters = {
       #   "spellcheck.dictionary": "language"
       # }
-      solr_name = solr_name("language", :stored_searchable)
+      solr_name = solr_name('language', :stored_searchable)
       field.solr_local_parameters = {
         qf: solr_name,
         pf: solr_name
@@ -214,7 +214,7 @@ class CatalogController < ApplicationController
       # field.solr_parameters = {
       #   "spellcheck.dictionary": "resource_type"
       # }
-      solr_name = solr_name("resource_type", :stored_searchable)
+      solr_name = solr_name('resource_type', :stored_searchable)
       field.solr_local_parameters = {
         qf: solr_name,
         pf: solr_name
@@ -226,7 +226,7 @@ class CatalogController < ApplicationController
       # field.solr_parameters = {
       #   "spellcheck.dictionary": "format"
       # }
-      solr_name = solr_name("format", :stored_searchable)
+      solr_name = solr_name('format', :stored_searchable)
       field.solr_local_parameters = {
         qf: solr_name,
         pf: solr_name
@@ -238,7 +238,7 @@ class CatalogController < ApplicationController
       # field.solr_parameters = {
       #   "spellcheck.dictionary": "identifier"
       # }
-      solr_name = solr_name("id", :stored_searchable)
+      solr_name = solr_name('id', :stored_searchable)
       field.solr_local_parameters = {
         qf: solr_name,
         pf: solr_name
@@ -246,11 +246,11 @@ class CatalogController < ApplicationController
     end
 
     config.add_search_field('based_near') do |field|
-      field.label = "Location"
+      field.label = 'Location'
       # field.solr_parameters = {
       #   "spellcheck.dictionary": "based_near"
       # }
-      solr_name = solr_name("based_near", :stored_searchable)
+      solr_name = solr_name('based_near', :stored_searchable)
       field.solr_local_parameters = {
         qf: solr_name,
         pf: solr_name
@@ -258,7 +258,7 @@ class CatalogController < ApplicationController
     end
 
     config.add_search_field('keyword') do |field|
-      solr_name = solr_name("keyword", :stored_searchable)
+      solr_name = solr_name('keyword', :stored_searchable)
       field.solr_local_parameters = {
         qf: solr_name,
         pf: solr_name
@@ -266,7 +266,7 @@ class CatalogController < ApplicationController
     end
 
     config.add_search_field('depositor') do |field|
-      solr_name = solr_name("depositor", :stored_searchable)
+      solr_name = solr_name('depositor', :stored_searchable)
       field.solr_local_parameters = {
         qf: solr_name,
         pf: solr_name
@@ -274,7 +274,7 @@ class CatalogController < ApplicationController
     end
 
     config.add_search_field('rights') do |field|
-      solr_name = solr_name("rights", :stored_searchable)
+      solr_name = solr_name('rights', :stored_searchable)
       field.solr_local_parameters = {
         qf: solr_name,
         pf: solr_name

--- a/app/controllers/curation_concerns/generic_works_controller.rb
+++ b/app/controllers/curation_concerns/generic_works_controller.rb
@@ -32,7 +32,7 @@ class CurationConcerns::GenericWorksController < ApplicationController
 
   def redirect_when_uploading
     return unless QueuedFile.where(work_id: params[:id]).present?
-    flash[:notice] = "Edits or deletes not allowed while files are being uploaded to a work"
+    flash[:notice] = 'Edits or deletes not allowed while files are being uploaded to a work'
     redirect_to polymorphic_path([main_app, curation_concern])
   end
 

--- a/app/controllers/curation_concerns/permissions_controller.rb
+++ b/app/controllers/curation_concerns/permissions_controller.rb
@@ -13,6 +13,6 @@ class CurationConcerns::PermissionsController < ApplicationController
   def copy_access
     authorize! :edit, curation_concern
     CopyPermissionsJob.perform_later(curation_concern)
-    redirect_to [main_app, curation_concern], notice: I18n.t("sufia.upload.change_access_flash_message")
+    redirect_to [main_app, curation_concern], notice: I18n.t('sufia.upload.change_access_flash_message')
   end
 end

--- a/app/controllers/directory_controller.rb
+++ b/app/controllers/directory_controller.rb
@@ -7,7 +7,7 @@ class DirectoryController < ApplicationController
   end
 
   def user_attribute
-    res = if params[:attribute] == "groups"
+    res = if params[:attribute] == 'groups'
             User.groups(params[:uid])
           else
             User.directory_attributes(params[:uid], params[:attribute])

--- a/app/controllers/mailbox_controller.rb
+++ b/app/controllers/mailbox_controller.rb
@@ -27,7 +27,7 @@ class MailboxController < ApplicationController
         empty_trash(msg.participants[0])
       end
     else
-      flash[:alert] = "You do not have privileges to delete the notification..."
+      flash[:alert] = 'You do not have privileges to delete the notification...'
     end
     redirect_to :back
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -9,10 +9,10 @@ class SessionsController < ApplicationController
   end
 
   def new
-    redirect_url = session["user_return_to"]
-    session["user_return_to"] = nil if redirect_url # clear so we do not get it next time
-    webaccess = Sufia::Engine.config.login_url.split("&")[0]
-    dashboard = Sufia::Engine.config.login_url.split("&")[1]
-    redirect_to webaccess + "&" + (redirect_url.blank? ? dashboard : redirect_url)
+    redirect_url = session['user_return_to']
+    session['user_return_to'] = nil if redirect_url # clear so we do not get it next time
+    webaccess = Sufia::Engine.config.login_url.split('&')[0]
+    dashboard = Sufia::Engine.config.login_url.split('&')[1]
+    redirect_to webaccess + '&' + (redirect_url.blank? ? dashboard : redirect_url)
   end
 end

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -3,11 +3,11 @@ class StaticController < ApplicationController
   rescue_from AbstractController::ActionNotFound, with: :render_404
 
   def about
-    @page = ContentBlock.find_or_create_by(name: "about")
+    @page = ContentBlock.find_or_create_by(name: 'about')
   end
 
   def help
-    @page = ContentBlock.find_or_create_by(name: "help_faq")
+    @page = ContentBlock.find_or_create_by(name: 'help_faq')
   end
 
   def zotero

--- a/app/controllers/sufia/batch_uploads_controller.rb
+++ b/app/controllers/sufia/batch_uploads_controller.rb
@@ -34,7 +34,7 @@ class Sufia::BatchUploadsController < ApplicationController
 
     def create_update_job
       log = Sufia::BatchCreateOperation.create!(user: current_user,
-                                                operation_type: "Batch Create")
+                                                operation_type: 'Batch Create')
       # ActionController::Parameters are not serializable, so cast to a hash
       BatchCreateJob.perform_later(current_user,
                                    params[:title].permit!.to_h,

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -33,8 +33,8 @@ class UsersController < ApplicationController
 
     def format_linkedin_url
       handle = @user.linkedin_handle
-      handle = "http://www.linkedin.com/in/" + handle unless handle.blank? || handle.include?('linkedin.com')
-      handle = "http://" + handle unless handle.blank? || handle.include?('http')
+      handle = 'http://www.linkedin.com/in/' + handle unless handle.blank? || handle.include?('linkedin.com')
+      handle = 'http://' + handle unless handle.blank? || handle.include?('http')
       handle
     end
 end

--- a/app/forms/collection_form.rb
+++ b/app/forms/collection_form.rb
@@ -43,6 +43,6 @@ class CollectionForm < Sufia::Forms::CollectionForm
 
     def batch_document_ids
       return [] unless request
-      request.filtered_parameters.fetch("batch_document_ids", [])
+      request.filtered_parameters.fetch('batch_document_ids', [])
     end
 end

--- a/app/forms/curation_concerns/generic_work_form.rb
+++ b/app/forms/curation_concerns/generic_work_form.rb
@@ -28,11 +28,11 @@ module CurationConcerns
     end
 
     def title
-      super.first || ""
+      super.first || ''
     end
 
     def rights
-      super.first || ""
+      super.first || ''
     end
 
     # Fields that are automatically drawn on the page above the fold

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,16 +24,16 @@ module ApplicationHelper
   def permission_level_tag(document)
     if document.registered?
       value = t('sufia.institution_name')
-      class_name = "label-info"
+      class_name = 'label-info'
     elsif document.public?
-      value = "Open Access"
-      class_name = "label-success"
+      value = 'Open Access'
+      class_name = 'label-success'
     else
-      value = "Private"
-      class_name = "label-danger"
+      value = 'Private'
+      class_name = 'label-danger'
     end
     path = if can? :edit, document
-             sufia.edit_generic_file_path(document, tab: "permissions")
+             sufia.edit_generic_file_path(document, tab: 'permissions')
            else
              sufia.generic_file_path(document)
            end

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -11,8 +11,8 @@ module CatalogHelper
   # @param [Hash] url_options to pass to #link_to_document
   # @return [String]
   def render_thumbnail_tag(document, image_options = {}, url_options = {})
-    image_options[:alt] = ""
-    image_options["aria-hidden"] = true
+    image_options[:alt] = ''
+    image_options['aria-hidden'] = true
     value = if blacklight_config.view_config(document_index_view_type).thumbnail_method
               send(blacklight_config.view_config(document_index_view_type).thumbnail_method, document, image_options)
             elsif blacklight_config.view_config(document_index_view_type).thumbnail_field

--- a/app/helpers/sufia_helper.rb
+++ b/app/helpers/sufia_helper.rb
@@ -10,7 +10,7 @@ module SufiaHelper
   end
 
   def help_icon
-    content_tag 'span', nil, "aria-hidden" => true, class: "help-icon"
+    content_tag 'span', nil, 'aria-hidden' => true, class: 'help-icon'
   end
 
   def should_render_index_field?(document, field_config)

--- a/app/jobs/batch_create_job.rb
+++ b/app/jobs/batch_create_job.rb
@@ -26,8 +26,8 @@ class BatchCreateJob < ActiveJob::Base
   private
 
     def create(attributes, titles = {}, resource_types = {})
-      uploaded_files = attributes.delete("uploaded_files")
-      remote_files = attributes.delete("remote_files")
+      uploaded_files = attributes.delete('uploaded_files')
+      remote_files = attributes.delete('remote_files')
       create_uploaded_files(titles, resource_types, attributes, uploaded_files)
       create_remote_files(titles, resource_types, attributes, remote_files)
     end
@@ -41,7 +41,7 @@ class BatchCreateJob < ActiveJob::Base
                                       resource_type: resource_type)
         model = model_to_create(attributes)
         child_log = CurationConcerns::Operation.create!(user: user,
-                                                        operation_type: "Create Work",
+                                                        operation_type: 'Create Work',
                                                         parent: log)
         CreateWorkJob.perform_later(user, model, attributes, child_log)
       end
@@ -49,12 +49,12 @@ class BatchCreateJob < ActiveJob::Base
 
     def create_remote_files(titles, resource_types, attributes, remote_files = [])
       remote_files.each do |file|
-        upload_id = file.fetch("url")
+        upload_id = file.fetch('url')
         attributes = attributes.merge(remote_files: [file],
                                       title: Array.wrap(titles.fetch(upload_id)),
                                       resource_type: Array.wrap(resource_types.fetch(upload_id)))
         child_log = CurationConcerns::Operation.create!(user: user,
-                                                        operation_type: "Create Work",
+                                                        operation_type: 'Create Work',
                                                         parent: log)
         CreateWorkJob.perform_later(user, model_to_create(attributes), attributes, child_log)
       end

--- a/app/jobs/import_url_job.rb
+++ b/app/jobs/import_url_job.rb
@@ -23,10 +23,10 @@ class ImportUrlJob < ActiveJob::Base
   def perform(file_set, file_name, log)
     log.performing!
     user = User.find_by_user_key(file_set.depositor)
-    File.open(File.join(Dir.tmpdir, CarrierWave::SanitizedFile.new(file_name).filename), "w+") do |f|
+    File.open(File.join(Dir.tmpdir, CarrierWave::SanitizedFile.new(file_name).filename), 'w+') do |f|
       status = copy_remote_file(file_set, f)
       unless status
-        file_set.errors.add("Error", "Downloading Content for #{ActionController::Base.helpers.link_to(file_name, Rails.application.routes.url_helpers.curation_concerns_file_set_path(file_set.id))}")
+        file_set.errors.add('Error', "Downloading Content for #{ActionController::Base.helpers.link_to(file_name, Rails.application.routes.url_helpers.curation_concerns_file_set_path(file_set.id))}")
         on_error(log, file_set, user)
         return false
       end

--- a/app/jobs/ingest_file_job.rb
+++ b/app/jobs/ingest_file_job.rb
@@ -13,7 +13,7 @@ class IngestFileJob < ActiveJob::Base
     relation = opts.fetch(:relation, :original_file).to_sym
 
     # Wrap in an IO decorator to attach passed-in options
-    local_file = Hydra::Derivatives::IoDecorator.new(File.open(filepath, "rb"))
+    local_file = Hydra::Derivatives::IoDecorator.new(File.open(filepath, 'rb'))
     local_file.mime_type = opts.fetch(:mime_type, nil)
     local_file.original_name = opts.fetch(:filename, File.basename(filepath))
 

--- a/app/jobs/language_authority_import_job.rb
+++ b/app/jobs/language_authority_import_job.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 class LanguageAuthorityImportJob < RDFAuthorityImportJob
-  self.authority = "languages"
-  self.default_options = { format: "rdfxml", predicate: RDF::URI("http://www.w3.org/2008/05/skos#prefLabel") }
+  self.authority = 'languages'
+  self.default_options = { format: 'rdfxml', predicate: RDF::URI('http://www.w3.org/2008/05/skos#prefLabel') }
 end

--- a/app/jobs/rdf_authority_import_job.rb
+++ b/app/jobs/rdf_authority_import_job.rb
@@ -6,7 +6,7 @@ class RDFAuthorityImportJob < ActiveJob::Base
   queue_as :authority_import
 
   def perform(file, opts = {})
-    raise(NotImplementedError, "No authority defined") if authority.nil?
+    raise(NotImplementedError, 'No authority defined') if authority.nil?
     Qa::LocalAuthority.find_or_create_by(name: authority)
     Qa::Services::RDFAuthorityParser.import_rdf(authority, [file], default_options.merge!(opts))
   end

--- a/app/jobs/share_notify_delete_event_job.rb
+++ b/app/jobs/share_notify_delete_event_job.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class ShareNotifyDeleteEventJob < ContentEventJob
   def action
-    "File was successfully marked for deletion from SHARE Notify"
+    'File was successfully marked for deletion from SHARE Notify'
   end
 end

--- a/app/jobs/share_notify_delete_failure_event_job.rb
+++ b/app/jobs/share_notify_delete_failure_event_job.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class ShareNotifyDeleteFailureEventJob < ContentEventJob
   def action
-    "File could not be marked for deletion from SHARE Notify"
+    'File could not be marked for deletion from SHARE Notify'
   end
 end

--- a/app/jobs/share_notify_failure_event_job.rb
+++ b/app/jobs/share_notify_failure_event_job.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class ShareNotifyFailureEventJob < ContentEventJob
   def action
-    "File could not be sent to SHARE Notify"
+    'File could not be sent to SHARE Notify'
   end
 end

--- a/app/jobs/share_notify_success_event_job.rb
+++ b/app/jobs/share_notify_success_event_job.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class ShareNotifySuccessEventJob < ContentEventJob
   def action
-    "File was successfully sent to SHARE Notify"
+    'File was successfully sent to SHARE Notify'
   end
 end

--- a/app/jobs/subject_authority_import_job.rb
+++ b/app/jobs/subject_authority_import_job.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 class SubjectAuthorityImportJob < RDFAuthorityImportJob
-  self.authority = "subjects"
-  self.default_options = { format: "rdfxml" }
+  self.authority = 'subjects'
+  self.default_options = { format: 'rdfxml' }
 end

--- a/app/models/concerns/additional_metadata.rb
+++ b/app/models/concerns/additional_metadata.rb
@@ -7,14 +7,14 @@ module AdditionalMetadata
   end
 
   def time_uploaded
-    return "" if date_uploaded.blank?
-    date_uploaded.strftime("%Y-%m-%d %H:%M:%S")
+    return '' if date_uploaded.blank?
+    date_uploaded.strftime('%Y-%m-%d %H:%M:%S')
   end
 
   private
 
     def current_host
-      Rails.application.config.virtual_host.chomp("/")
+      Rails.application.config.virtual_host.chomp('/')
     end
 
     def path

--- a/app/models/file_set.rb
+++ b/app/models/file_set.rb
@@ -11,6 +11,6 @@ class FileSet < ActiveFedora::Base
   # @return [String, nil]
   # Field value is constructed at index time in CurationConcerns::FileSetIndexer
   def file_format
-    to_solr.fetch("file_format_sim", nil)
+    to_solr.fetch('file_format_sim', nil)
   end
 end

--- a/app/models/generic_work.rb
+++ b/app/models/generic_work.rb
@@ -27,7 +27,7 @@ class GenericWork < ActiveFedora::Base
   # @raise [RuntimeError] unsaved record does not exist in solr
   def bytes
     return 0 if member_ids.count == 0
-    raise "Work must be saved to query for bytes" if new_record?
+    raise 'Work must be saved to query for bytes' if new_record?
     sizes = member_ids.collect { |fs_id| file_set_size(fs_id) }
     sizes.compact.map { |fs| fs[file_size_field] }.reduce(0, :+)
   end

--- a/app/models/ldap_user.rb
+++ b/app/models/ldap_user.rb
@@ -16,8 +16,8 @@ class LdapUser
     end
 
     def filter_for(*people)
-      return "" if people.empty?
-      "(| " + people.map { |p| "(eduPersonPrimaryAffiliation=#{p.to_s.upcase})" }.join(" ") + ")))"
+      return '' if people.empty?
+      '(| ' + people.map { |p| "(eduPersonPrimaryAffiliation=#{p.to_s.upcase})" }.join(' ') + ')))'
     end
 
     private
@@ -37,7 +37,7 @@ class LdapUser
           return result unless unwilling?
           sleep(Rails.application.config.ldap_unwilling_sleep)
         end
-        Rails.logger.warn "LDAP is unwilling to perform this operation, try upping the number of tries"
+        Rails.logger.warn 'LDAP is unwilling to perform this operation, try upping the number of tries'
         nil
       rescue Net::LDAP::Error => e
         Rails.logger.warn "Error getting LDAP response: #{ldap_error_message(e)}"

--- a/app/models/permissions_change_set.rb
+++ b/app/models/permissions_change_set.rb
@@ -51,6 +51,6 @@ class PermissionsChangeSet
     end
 
     def public_group_read
-      { name: "public", type: "group", access: "read" }
+      { name: 'public', type: 'group', access: 'read' }
     end
 end

--- a/app/models/resource_filtered_list.rb
+++ b/app/models/resource_filtered_list.rb
@@ -2,7 +2,7 @@
 class ResourceFilteredList
   attr_reader :generic_files, :resource_types
 
-  def initialize(generic_files, resource_types = ["Dataset", "Poster", "Thesis", "Dissertation"])
+  def initialize(generic_files, resource_types = ['Dataset', 'Poster', 'Thesis', 'Dissertation'])
     @generic_files = generic_files
     @resource_types = resource_types
   end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -30,7 +30,7 @@ class SolrDocument
 
   # Remove this once https://github.com/projecthydra/curation_concerns/issues/1055 is resolved
   def file_size
-    Array(self["file_size_lts"]).first
+    Array(self['file_size_lts']).first
   end
 
   def bytes
@@ -52,7 +52,7 @@ class SolrDocument
     end
 
     def ul_end_tags
-      "</li></ul>"
+      '</li></ul>'
     end
 
     def person_separator

--- a/app/models/trophy.rb
+++ b/app/models/trophy.rb
@@ -4,6 +4,6 @@ class Trophy < ActiveRecord::Base
 
   def count_within_limit
     return unless Trophy.where(user_id: user_id).count >= 5
-    errors.add(:base, "Exceeded trophy limit")
+    errors.add(:base, 'Exceeded trophy limit')
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,7 +28,7 @@ class User < ActiveRecord::Base
     end
 
     def groups(login)
-      Deprecation.warn(nil, "User.groups has been deprecated, use LdapUser.get_groups instead")
+      Deprecation.warn(nil, 'User.groups has been deprecated, use LdapUser.get_groups instead')
       LdapUser.get_groups(login)
     end
 
@@ -37,7 +37,7 @@ class User < ActiveRecord::Base
       filter = Net::LDAP::Filter.construct("(& (| (uid=#{id_or_name_part}* ) (givenname=#{id_or_name_part}*) (sn=#{id_or_name_part}*)) #{person_filter})")
       users = LdapUser.get_user(filter, ['uid', 'displayname'])
       # handle the issue that searching with a few letters returns more than 1000 items wich causes an error in the system
-      if users.nil? && (Hydra::LDAP.connection.get_operation_result[:message] == "Size Limit Exceeded")
+      if users.nil? && (Hydra::LDAP.connection.get_operation_result[:message] == 'Size Limit Exceeded')
         filter2 = Net::LDAP::Filter.construct("(& (uid=#{id_or_name_part}* ) #{person_filter})")
         users = LdapUser.get_user(filter2, ['uid', 'displayname'])
       end
@@ -100,7 +100,7 @@ class User < ActiveRecord::Base
 
   # Groups that user is a member of
   def groups
-    return group_list.split(";?;") unless groups_last_update.blank? || ((Time.now - groups_last_update) > 24 * 60 * 60)
+    return group_list.split(';?;') unless groups_last_update.blank? || ((Time.now - groups_last_update) > 24 * 60 * 60)
     update_ldap_groups
   end
 
@@ -134,7 +134,7 @@ class User < ActiveRecord::Base
     end
 
     def get_net_attribute_with_new_lines(entry, attribute_name)
-      attribute = get_net_attribute(entry, attribute_name, "").tr('$', "\n")
+      attribute = get_net_attribute(entry, attribute_name, '').tr('$', "\n")
       attribute.blank? ? nil : attribute
     end
 
@@ -146,7 +146,7 @@ class User < ActiveRecord::Base
       list = LdapUser.get_groups(login).sort!
       return list if list.empty?
       Rails.logger.debug "$#{login}$ groups = #{list}"
-      update_attributes(group_list: list.join(";?;"), groups_last_update: Time.now)
+      update_attributes(group_list: list.join(';?;'), groups_last_update: Time.now)
       list
     end
 

--- a/app/models/user_mailer.rb
+++ b/app/models/user_mailer.rb
@@ -14,13 +14,13 @@ class UserMailer < ActionMailer::Base
     attachments[stats_report_name] = stats_report
     mail(to:      ScholarSphere::Application.config.stats_email,
          from:    ScholarSphere::Application.config.stats_from_email,
-         subject: ::I18n.t("statistic.report.subject"))
+         subject: ::I18n.t('statistic.report.subject'))
   end
 
   private
 
     def stats_report_name
-      ::I18n.t("statistic.report.csv.file_name", date_str: presenter.date_str)
+      ::I18n.t('statistic.report.csv.file_name', date_str: presenter.date_str)
     end
 
     def stats_report

--- a/app/presenters/error_presenter.rb
+++ b/app/presenters/error_presenter.rb
@@ -12,11 +12,11 @@ class ErrorPresenter
   end
 
   def title
-    I18n.t("errors.#{error}.title", default: "Error")
+    I18n.t("errors.#{error}.title", default: 'Error')
   end
 
   def message
-    I18n.t("errors.#{error}.message", default: "There was an error with your request")
+    I18n.t("errors.#{error}.message", default: 'There was an error with your request')
   end
 
   def log_exception
@@ -30,7 +30,7 @@ class ErrorPresenter
   private
 
     def error
-      exception_class.to_s.underscore.gsub(/\//, "_")
+      exception_class.to_s.underscore.gsub(/\//, '_')
     end
 
     def exception_class

--- a/app/presenters/work_show_presenter.rb
+++ b/app/presenters/work_show_presenter.rb
@@ -56,7 +56,7 @@ class WorkShowPresenter < Sufia::WorkShowPresenter
     # Also note: https://github.com/projecthydra-labs/hyrax/issues/352
     def file_set_ids
       @file_set_ids ||= begin
-                          ActiveFedora::SolrService.query("{!field f=has_model_ssim}FileSet",
+                          ActiveFedora::SolrService.query('{!field f=has_model_ssim}FileSet',
                                                           fl: ActiveFedora.id_field,
                                                           rows: 1000,
                                                           fq: "{!join from=ordered_targets_ssim to=id}id:\"#{id}/list_source\"")

--- a/app/services/attach_files_to_work_failure_service.rb
+++ b/app/services/attach_files_to_work_failure_service.rb
@@ -12,6 +12,6 @@ class AttachFilesToWorkFailureService < Sufia::MessageUserService
   end
 
   def subject
-    "File failed to attach"
+    'File failed to attach'
   end
 end

--- a/app/services/attach_files_to_work_success_service.rb
+++ b/app/services/attach_files_to_work_success_service.rb
@@ -12,6 +12,6 @@ class AttachFilesToWorkSuccessService < Sufia::MessageUserService
   end
 
   def subject
-    "File successfully attached"
+    'File successfully attached'
   end
 end

--- a/app/services/facet_value_cleaning_service.rb
+++ b/app/services/facet_value_cleaning_service.rb
@@ -8,9 +8,9 @@ class FacetValueCleaningService
     return values unless cleaners.present? && values.is_a?(Array)
 
     if cleaners.include?(:titleize)
-      values.map { |name| name.titleize.gsub(/[\.\,]/, "") }
+      values.map { |name| name.titleize.gsub(/[\.\,]/, '') }
     elsif cleaners.include?(:downcase)
-      values.map { |name| name.downcase.gsub(/[\.\,]/, "") }
+      values.map { |name| name.downcase.gsub(/[\.\,]/, '') }
     else
       values
     end

--- a/app/services/field_configurator.rb
+++ b/app/services/field_configurator.rb
@@ -2,7 +2,7 @@
 class FieldConfigurator
   # Defines what fields are shown on the search index view for each item
   def self.index_fields
-    common_fields.merge(date_uploaded: FieldConfig.new(label: "Date Uploaded",
+    common_fields.merge(date_uploaded: FieldConfig.new(label: 'Date Uploaded',
                                                        index_solr_type: :stored_sortable,
                                                        index_type: :date))
   end
@@ -11,41 +11,41 @@ class FieldConfigurator
   def self.show_fields
     index_fields
       .except(:has_model)
-      .merge(depositor:  FieldConfig.new("Depositor"),
-             contributor: FieldConfig.new("Contributor"),
-             date_modified: FieldConfig.new(label: "Date Modified",
+      .merge(depositor:  FieldConfig.new('Depositor'),
+             contributor: FieldConfig.new('Contributor'),
+             date_modified: FieldConfig.new(label: 'Date Modified',
                                             index_solr_type: :stored_sortable,
                                             index_type: :date),
-             date_created: FieldConfig.new("Date Created"),
-             rights: FieldConfig.new("Rights"),
-             identifier: FieldConfig.new("Identifier"),
-             description: FieldConfig.new("Description"),
-             subtitle: FieldConfig.new("Subtitle"))
+             date_created: FieldConfig.new('Date Created'),
+             rights: FieldConfig.new('Rights'),
+             identifier: FieldConfig.new('Identifier'),
+             description: FieldConfig.new('Description'),
+             subtitle: FieldConfig.new('Subtitle'))
   end
 
   # Defines what fields are shown in the facets on the search index view
   def self.facet_fields
-    common_fields.merge(collection: FieldConfig.new(label: "Collection", helper_method: :collection_helper_method),
-                        file_format: FieldConfig.new("File Format"))
+    common_fields.merge(collection: FieldConfig.new(label: 'Collection', helper_method: :collection_helper_method),
+                        file_format: FieldConfig.new('File Format'))
   end
 
   # Defines what fields are available to the user in the universal search
   def self.search_fields
-    show_fields.merge(title: FieldConfig.new("Title"),
-                      file_format: FieldConfig.new("File Format"))
+    show_fields.merge(title: FieldConfig.new('Title'),
+                      file_format: FieldConfig.new('File Format'))
   end
 
   # Common fields between all lists
   def self.common_fields
     {
-      resource_type: FieldConfig.new("Resource Type"),
-      creator: FieldConfig.new(label: "Creator", facet_cleaners: [:titleize]),
-      keyword:  FieldConfig.new(label: "Keyword", facet_cleaners: [:downcase]),
-      subject: FieldConfig.new("Subject"),
-      language: FieldConfig.new("Language"),
-      based_near: FieldConfig.new("Location"),
-      publisher: FieldConfig.new(label: "Publisher", facet_cleaners: [:titleize]),
-      has_model: FieldConfig.new(label: "Object Type",
+      resource_type: FieldConfig.new('Resource Type'),
+      creator: FieldConfig.new(label: 'Creator', facet_cleaners: [:titleize]),
+      keyword:  FieldConfig.new(label: 'Keyword', facet_cleaners: [:downcase]),
+      subject: FieldConfig.new('Subject'),
+      language: FieldConfig.new('Language'),
+      based_near: FieldConfig.new('Location'),
+      publisher: FieldConfig.new(label: 'Publisher', facet_cleaners: [:titleize]),
+      has_model: FieldConfig.new(label: 'Object Type',
                                  helper_method: :titleize,
                                  index_solr_type: :symbol,
                                  solr_type: :symbol)

--- a/app/services/file_set_management_service.rb
+++ b/app/services/file_set_management_service.rb
@@ -28,8 +28,8 @@ class FileSetManagementService
     end
 
     def all_ids
-      args = { fq: "#{Solrizer.solr_name('has_model', :symbol)}:FileSet", fl: ["id"], rows: "100000" }
-      ActiveFedora::SolrService.query("*:*", args).map(&:id)
+      args = { fq: "#{Solrizer.solr_name('has_model', :symbol)}:FileSet", fl: ['id'], rows: '100000' }
+      ActiveFedora::SolrService.query('*:*', args).map(&:id)
     end
 
     def queue_derivatives_job(id)

--- a/app/services/generic_work_to_share_json_service.rb
+++ b/app/services/generic_work_to_share_json_service.rb
@@ -27,6 +27,6 @@ class GenericWorkToShareJSONService
 
     def email_for_name(name)
       value = NameDisambiguationService.new(name).disambiguate
-      value.blank? ? "" : value[0][:email]
+      value.blank? ? '' : value[0][:email]
     end
 end

--- a/app/services/permissions_change_service.rb
+++ b/app/services/permissions_change_service.rb
@@ -18,7 +18,7 @@ class PermissionsChangeService
 
   def inform_users
     state.added.each do |permission|
-      next unless permission[:type] == "person"
+      next unless permission[:type] == 'person'
       send_message(permission[:access], User.find_by_user_key(permission[:name]))
     end
   end
@@ -48,7 +48,7 @@ class PermissionsChangeService
       User.batchuser.send_message(
         recipient,
         "You can now #{access} file #{generic_work.title}",
-        "Permission change notification"
+        'Permission change notification'
       )
     end
 end

--- a/app/services/read_only.rb
+++ b/app/services/read_only.rb
@@ -14,7 +14,7 @@ class ReadOnly
 
       def homepage_text
         block = ContentBlock.find_by(name: 'annoucement_text')
-        return "" unless block
+        return '' unless block
         block.value.html_safe
       end
 
@@ -26,7 +26,7 @@ class ReadOnly
         config_value = ScholarSphere::Application.config.read_only
         return config_value if config_value.class == TrueClass || @config_value == FalseClass
 
-        config_value.to_s.casecmp("true").zero?
+        config_value.to_s.casecmp('true').zero?
       end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,19 +24,19 @@ module ScholarSphere
     # -- all .rb files in that directory are automatically loaded.
 
     # Environment variables list here are defined in application.yml
-    config.ffmpeg_path = ENV.fetch("ffmpeg_path", "ffmpeg")
-    config.derivatives_path = ENV.fetch("derivatives_path", File.join(Rails.root, 'tmp', 'derivatives'))
-    config.service_instance = ENV.fetch("service_instance", Socket.gethostname)
-    config.virtual_host = ENV.fetch("virtual_host", "https://#{Socket.gethostname}")
-    config.google_analytics_id = ENV.fetch("google_analytics_id", nil)
-    config.stats_email = ENV.fetch("stats_email", "ScholarSphere Stats <umg-up.its.sas.scholarsphere-email@groups.ucs.psu.edu>")
+    config.ffmpeg_path = ENV.fetch('ffmpeg_path', 'ffmpeg')
+    config.derivatives_path = ENV.fetch('derivatives_path', File.join(Rails.root, 'tmp', 'derivatives'))
+    config.service_instance = ENV.fetch('service_instance', Socket.gethostname)
+    config.virtual_host = ENV.fetch('virtual_host', "https://#{Socket.gethostname}")
+    config.google_analytics_id = ENV.fetch('google_analytics_id', nil)
+    config.stats_email = ENV.fetch('stats_email', 'ScholarSphere Stats <umg-up.its.sas.scholarsphere-email@groups.ucs.psu.edu>')
 
     # Set the  system to read only mode.  Does not allow new uploads, file edits, new collections, and collection edits
-    config.read_only = ENV.fetch("read_only", false)
+    config.read_only = ENV.fetch('read_only', false)
 
-    config.scholarsphere_version = "v3.0"
-    config.scholarsphere_release_date = "June 9, 2016"
-    config.redis_namespace = "scholarsphere"
+    config.scholarsphere_version = 'v3.0'
+    config.scholarsphere_release_date = 'June 9, 2016'
+    config.redis_namespace = 'scholarsphere'
 
     # Number of fits array items shown on the Generic File show page
     config.fits_message_length = 5
@@ -73,10 +73,10 @@ module ScholarSphere
     # config.action_view.javascript_expansions[:defaults] = %w(jquery rails)
 
     # Configure the default encoding used in templates for Ruby 1.9.
-    config.encoding = "utf-8"
+    config.encoding = 'utf-8'
 
     # Always render things in UTF-8
-    config.action_dispatch.default_charset = "utf-8"
+    config.action_dispatch.default_charset = 'utf-8'
 
     # Configure sensitive parameters which will be filtered from the log file.
     config.filter_parameters += [:password]
@@ -95,7 +95,7 @@ module ScholarSphere
     # allow errors to be raised in callbacks
     config.active_record.raise_in_transactional_callbacks = true
 
-    config.action_mailer.default_options = { from: "umg-up.its.sas.scholarsphere-email@groups.ucs.psu.edu" }
+    config.action_mailer.default_options = { from: 'umg-up.its.sas.scholarsphere-email@groups.ucs.psu.edu' }
     config.action_mailer.default_url_options = { host: config.service_instance, protocol: 'https' }
 
     # Inject new behaviors into existing classes without having to override the entire class itself.

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -10,4 +10,4 @@ end
 
 # Initialize the rails application
 ScholarSphere::Application.initialize!
-ActiveRecord::Base.connection.execute("SET AUTOCOMMIT=1") if defined?(ActiveRecord::ConnectionAdapters::Mysql2Adapter) && (ActiveRecord::Base.connection.instance_of? ActiveRecord::ConnectionAdapters::Mysql2Adapter)
+ActiveRecord::Base.connection.execute('SET AUTOCOMMIT=1') if defined?(ActiveRecord::ConnectionAdapters::Mysql2Adapter) && (ActiveRecord::Base.connection.instance_of? ActiveRecord::ConnectionAdapters::Mysql2Adapter)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -28,7 +28,7 @@ ScholarSphere::Application.configure do
   config.action_controller.perform_caching = true
 
   # Specifies the header that your server uses for sending files
-  config.action_dispatch.x_sendfile_header = "X-Sendfile"
+  config.action_dispatch.x_sendfile_header = 'X-Sendfile'
 
   # For nginx:
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect'

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -12,7 +12,7 @@ Devise.setup do |config|
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class with default "from" parameter.
-  config.mailer_sender = "mjg36@psu.edu"
+  config.mailer_sender = 'mjg36@psu.edu'
 
   # Configure the class responsible to send e-mails.
   # config.mailer = "Devise::Mailer"

--- a/config/initializers/hydra_derivatives_config.rb
+++ b/config/initializers/hydra_derivatives_config.rb
@@ -5,4 +5,4 @@ Hydra::Derivatives::Processors::Video::Processor.timeout = 10.minutes
 Hydra::Derivatives::Processors::Document.timeout = 5.minutes
 Hydra::Derivatives::Processors::Audio.timeout = 10.minutes
 Hydra::Derivatives::Processors::Image.timeout = 5.minutes
-Hydra::Derivatives::Processors::Video::Processor.config.mpeg4.codec = "-vcodec mpeg4 -acodec aac -strict -2"
+Hydra::Derivatives::Processors::Video::Processor.config.mpeg4.codec = '-vcodec mpeg4 -acodec aac -strict -2'

--- a/config/initializers/mailboxer.rb
+++ b/config/initializers/mailboxer.rb
@@ -4,7 +4,7 @@ Mailboxer.setup do |config|
   config.uses_emails = true
 
   # Configures the default from for the email sent for Messages and Notifications of Mailboxer
-  config.default_from = "no-reply@mailboxer.com"
+  config.default_from = 'no-reply@mailboxer.com'
 
   # Configures the methods needed by mailboxer
   config.email_method = :mailboxer_email

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 # Be sure to restart your server when you modify this file.Mime::Type.register_alias "text/plain", :refworks_marc_txt
-Mime::Type.register_alias "text/plain", :openurl_kev
-Mime::Type.register_alias "text/plain", :refworks_marc_txt
-Mime::Type.register_alias "text/html", :textile
-Mime::Type.register_alias "text/html", :inline
-Mime::Type.register "application/x-endnote-refer", :endnote
-Mime::Type.register "application/marc", :marc
-Mime::Type.register "application/marcxml+xml", :marcxml, ["application/x-marc+xml", "application/x-marcxml+xml", "application/marc+xml"]
-Mime::Type.register "audio/mpeg", :audio
-Mime::Type.register "application/n-triples", :nt
-Mime::Type.register "application/ld+json", :jsonld
-Mime::Type.register "text/turtle", :ttl
+Mime::Type.register_alias 'text/plain', :openurl_kev
+Mime::Type.register_alias 'text/plain', :refworks_marc_txt
+Mime::Type.register_alias 'text/html', :textile
+Mime::Type.register_alias 'text/html', :inline
+Mime::Type.register 'application/x-endnote-refer', :endnote
+Mime::Type.register 'application/marc', :marc
+Mime::Type.register 'application/marcxml+xml', :marcxml, ['application/x-marc+xml', 'application/x-marcxml+xml', 'application/marc+xml']
+Mime::Type.register 'audio/mpeg', :audio
+Mime::Type.register 'application/n-triples', :nt
+Mime::Type.register 'application/ld+json', :jsonld
+Mime::Type.register 'text/turtle', :ttl

--- a/config/initializers/qa.rb
+++ b/config/initializers/qa.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 Qa::Authorities::Local.register_subauthority('languages', 'Qa::Authorities::Local::TableBasedAuthority')
 Qa::Authorities::Local.register_subauthority('subjects', 'Qa::Authorities::Local::TableBasedAuthority')
-Qa::Authorities::Geonames.username = "scholarsphere_test"
+Qa::Authorities::Geonames.username = 'scholarsphere_test'

--- a/config/initializers/setup_mail.rb
+++ b/config/initializers/setup_mail.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 ActionMailer::Base.smtp_settings = {
-  address: "smtp.psu.edu"
+  address: 'smtp.psu.edu'
 }

--- a/config/initializers/sufia.rb
+++ b/config/initializers/sufia.rb
@@ -4,26 +4,26 @@ Sufia.config do |config|
 
   config.register_curation_concern :generic_work
 
-  config.contact_email = "scholarsphere@servicedesk.css.psu.edu, umg-up.its.scholarsphere-support@groups.ucs.psu.edu"
-  config.subject_prefix = "ScholarSphere Contact Form - "
+  config.contact_email = 'scholarsphere@servicedesk.css.psu.edu, umg-up.its.scholarsphere-support@groups.ucs.psu.edu'
+  config.subject_prefix = 'ScholarSphere Contact Form - '
 
-  config.fits_path = "fits.sh"
+  config.fits_path = 'fits.sh'
   config.max_days_between_audits = 7
   config.enable_ffmpeg = true
   config.ffmpeg_path = Rails.application.config.ffmpeg_path
 
   config.ingest_queue_name = :files
 
-  config.persistent_hostpath = "http://scholarsphere.psu.edu/files/"
+  config.persistent_hostpath = 'http://scholarsphere.psu.edu/files/'
 
   config.permission_levels = {
-    "Choose Access" => "none",
-    "View/Download" => "read",
-    "Edit" => "edit"
+    'Choose Access' => 'none',
+    'View/Download' => 'read',
+    'Edit' => 'edit'
   }
 
   config.owner_permission_levels = {
-    "Edit" => "edit"
+    'Edit' => 'edit'
   }
 
   config.analytics = true
@@ -36,19 +36,19 @@ Sufia.config do |config|
     if defined? BrowseEverything
       config.browse_everything = BrowseEverything.config
     else
-      logger.warn "BrowseEverything is not installed"
+      logger.warn 'BrowseEverything is not installed'
     end
   rescue Errno::ENOENT
     config.browse_everything = nil
   end
 
-  config.temp_file_base = "/tmp"
+  config.temp_file_base = '/tmp'
 
   config.derivatives_path = Rails.application.config.derivatives_path
 
-  config.noid_template = ".reeeddeeddk"
+  config.noid_template = '.reeeddeeddk'
 
   config.google_analytics_id = Rails.application.config.google_analytics_id
 
-  config.redis_namespace = "scholarsphere"
+  config.redis_namespace = 'scholarsphere'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ ScholarSphere::Application.routes.draw do
   get '/managedata', to: redirect('/contact')
 
   # "Recently added files" route for catalog index view (needed before BL routes)
-  get "catalog/recent" => "catalog#recent", as: :catalog_recent
+  get 'catalog/recent' => 'catalog#recent', as: :catalog_recent
 
   mount BrowseEverything::Engine => '/browse'
   mount Blacklight::Engine => '/'
@@ -73,7 +73,7 @@ ScholarSphere::Application.routes.draw do
 
   get ':action' => 'static#:action', constraints: { action: /error_help/ }, as: :static
 
-  get "licenses", controller: 'static', action: "licenses", as: "licenses"
+  get 'licenses', controller: 'static', action: 'licenses', as: 'licenses'
 
   get 'about' => 'static#about', id: 'about_page'
 

--- a/config/sample/initializers/qa.rb
+++ b/config/sample/initializers/qa.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 Qa::Authorities::Local.register_subauthority('languages', 'Qa::Authorities::Local::TableBasedAuthority')
 Qa::Authorities::Local.register_subauthority('subjects', 'Qa::Authorities::Local::TableBasedAuthority')
-Qa::Authorities::Geonames.username = "username"
+Qa::Authorities::Geonames.username = 'username'

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -13,8 +13,8 @@
 
 set :output, "#{path}/log/wheneveroutput.log"
 
-every :day, at: "12:00am", roles: [:app] do
-  command "/scholarsphere/bin/whenever_generate_sitemap.sh"
+every :day, at: '12:00am', roles: [:app] do
+  command '/scholarsphere/bin/whenever_generate_sitemap.sh'
 end
 
 # TODO: turn this back on once share notify implementation is back up and working
@@ -22,19 +22,19 @@ end
 #   rake 'share:files'
 # end
 
-every :day, at: "12:20am", roles: [:job] do
-  command "/scholarsphere/bin/whenever_audit_repository.sh"
+every :day, at: '12:20am', roles: [:job] do
+  command '/scholarsphere/bin/whenever_audit_repository.sh'
 end
 
-every :day, at: "1:00 am", roles: [:job] do
+every :day, at: '1:00 am', roles: [:job] do
   command "#{path}/config/cronjobs/compare_solr.bash"
 end
 
-every :day, at: "3:00 am", roles: [:job] do
+every :day, at: '3:00 am', roles: [:job] do
   command "#{path}/config/cronjobs/update_user_stats.bash"
 end
 
-every :monday, at: "6:00 am", roles: [:job] do
+every :monday, at: '6:00 am', roles: [:job] do
   command "#{path}/config/cronjobs/send_weekly_stats.bash"
 end
 

--- a/lib/devise/behaviors/http_header_authenticatable_behavior.rb
+++ b/lib/devise/behaviors/http_header_authenticatable_behavior.rb
@@ -15,9 +15,9 @@ module Devise
         # happen depending on the setup or testing framework, so we allow both.
         def remote_user(headers)
           if Rails.env.production?
-            headers.fetch("REMOTE_USER", nil)
+            headers.fetch('REMOTE_USER', nil)
           else
-            headers.fetch("REMOTE_USER", nil) || headers.fetch("HTTP_REMOTE_USER", nil)
+            headers.fetch('REMOTE_USER', nil) || headers.fetch('HTTP_REMOTE_USER', nil)
           end
         end
     end

--- a/lib/hydra/derivatives/processors/document.rb
+++ b/lib/hydra/derivatives/processors/document.rb
@@ -24,7 +24,7 @@ module Hydra::Derivatives::Processors
       # For jpeg files, a pdf is created from the original source and then passed to the Image processor class
       # so we can get a better conversion with resizing options. Otherwise, the ::encode method is used.
       def convert_to_format
-        if directives.fetch(:format) == "jpg"
+        if directives.fetch(:format) == 'jpg'
           Hydra::Derivatives::Processors::Image.new(converted_file, directives).process
         else
           output_file_service.call(File.read(converted_file), directives)
@@ -32,10 +32,10 @@ module Hydra::Derivatives::Processors
       end
 
       def converted_file
-        @converted_file ||= if directives.fetch(:format) == "jpg"
+        @converted_file ||= if directives.fetch(:format) == 'jpg'
                               # TODO: This is the only change from HydraDerivaties
                               #      It would be good if we could configure this instead of overriding
-                              convert_to("png")
+                              convert_to('png')
                             else
                               convert_to(directives.fetch(:format))
                             end
@@ -43,7 +43,7 @@ module Hydra::Derivatives::Processors
 
       def convert_to(format)
         self.class.encode(source_path, format, Hydra::Derivatives.temp_file_base)
-        File.join(Hydra::Derivatives.temp_file_base, [File.basename(source_path, ".*"), format].join('.'))
+        File.join(Hydra::Derivatives.temp_file_base, [File.basename(source_path, '.*'), format].join('.'))
       end
   end
 end

--- a/lib/redirect_to_web_access_failure.rb
+++ b/lib/redirect_to_web_access_failure.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class RedirectToWebAccessFailure < Devise::FailureApp
   def redirect_url
-    Sufia::Engine.config.login_url.chomp("/dashboard") + (request.env["ORIGINAL_FULLPATH"].blank? ? '' : request.env["ORIGINAL_FULLPATH"])
+    Sufia::Engine.config.login_url.chomp('/dashboard') + (request.env['ORIGINAL_FULLPATH'].blank? ? '' : request.env['ORIGINAL_FULLPATH'])
   end
 
   def respond

--- a/lib/scholarsphere/config.rb
+++ b/lib/scholarsphere/config.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class Scholarsphere::Config
   def self.check
-    config_files = Dir.glob(File.join(Rails.root, "config", "*.yml")).map { |f| ConfigFile.new(f) }
+    config_files = Dir.glob(File.join(Rails.root, 'config', '*.yml')).map { |f| ConfigFile.new(f) }
     config_files.map(&:validate)
   end
 
@@ -9,15 +9,15 @@ class Scholarsphere::Config
     attr_reader :file
 
     REQUIREMENTS = {
-      "application.yml" => [
-        "TMPDIR",
-        "ffmpeg_path",
-        "service_instance",
-        "virtual_host",
-        "stats_email",
-        "google_analytics_id",
-        "derivatives_path",
-        "read_only"
+      'application.yml' => [
+        'TMPDIR',
+        'ffmpeg_path',
+        'service_instance',
+        'virtual_host',
+        'stats_email',
+        'google_analytics_id',
+        'derivatives_path',
+        'read_only'
       ]
     }.freeze
 
@@ -26,7 +26,7 @@ class Scholarsphere::Config
     end
 
     def keys
-      YAML.load(File.open(file)).fetch("production", {}).keys
+      YAML.load(File.open(file)).fetch('production', {}).keys
     end
 
     def validate

--- a/lib/scholarsphere/import/batch_translator.rb
+++ b/lib/scholarsphere/import/batch_translator.rb
@@ -16,7 +16,7 @@ module Import
       end
 
       def default_prefix
-        "batch_"
+        'batch_'
       end
   end
 end

--- a/lib/scholarsphere/import/version_builder.rb
+++ b/lib/scholarsphere/import/version_builder.rb
@@ -15,7 +15,7 @@ module Import
     def build(file_set, generic_file_versions)
       time_start = DateTime.now
       if file_set.id.nil?
-        raise "FileSet must have an id before importing any versions"
+        raise 'FileSet must have an id before importing any versions'
       end
       sorted_versions = generic_file_versions.sort_by { |ver| ver[:created] }
       sorted_versions.each_with_index do |gf_version, index|
@@ -93,13 +93,13 @@ module Import
       end
 
       def f3_to_f4_migration_date?(date)
-        date.starts_with?("2015-04-11")
+        date.starts_with?('2015-04-11')
       end
 
       def temp_file_name(file_set, version)
-        label = file_set.label || "null_label"
+        label = file_set.label || 'null_label'
         label = label.gsub(/[^0-9A-Za-z.\-]/, '_')
-        File.join Rails.root, "tmp/uploads", "#{file_set.id}_#{version[:label]}_#{label}"
+        File.join Rails.root, 'tmp/uploads', "#{file_set.id}_#{version[:label]}_#{label}"
       end
 
       def version_creator(file_set, version)

--- a/spec/actors/curation_concerns/generic_work_actor_spec.rb
+++ b/spec/actors/curation_concerns/generic_work_actor_spec.rb
@@ -15,7 +15,7 @@ describe CurationConcerns::Actors::GenericWorkActor do
     work.reload
   end
 
-  context "with ordered attributes" do
+  context 'with ordered attributes' do
     let(:attributes) do
       {
         creator: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'],
@@ -23,22 +23,22 @@ describe CurationConcerns::Actors::GenericWorkActor do
       }
     end
 
-    it "keeps the correct order" do
+    it 'keeps the correct order' do
       expect(work.creator).to eq(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'])
       expect(work.title).to eq(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'])
     end
   end
 
-  context "creator nil" do
+  context 'creator nil' do
     let(:attributes) { { creator: nil } }
-    it "does not error" do
+    it 'does not error' do
       expect(work.creator).to eq([])
     end
   end
 
-  context "when uploading on behalf of another user" do
+  context 'when uploading on behalf of another user' do
     let(:other_user) { create(:user) }
-    let(:attributes) { { title: ["Sample"], on_behalf_of: other_user.login } }
+    let(:attributes) { { title: ['Sample'], on_behalf_of: other_user.login } }
     subject { work }
     its(:depositor) { is_expected.to eq(other_user.login) }
   end

--- a/spec/actors/sufia/create_with_remote_files_actor_spec.rb
+++ b/spec/actors/sufia/create_with_remote_files_actor_spec.rb
@@ -15,9 +15,9 @@ describe Sufia::CreateWithRemoteFilesActor do
   end
 
   let(:remote_files) do
-    [{ url: "file:///local/file/ pigs .txt",
-       expires: "2014-03-31T20:37:36.214Z",
-       file_name: "here.txt" }]
+    [{ url: 'file:///local/file/ pigs .txt',
+       expires: '2014-03-31T20:37:36.214Z',
+       file_name: 'here.txt' }]
   end
 
   let(:attributes) { { remote_files: remote_files } }
@@ -27,9 +27,9 @@ describe Sufia::CreateWithRemoteFilesActor do
     allow(create_actor).to receive(:create).and_return(true)
   end
 
-  context "with local files" do
-    it "attaches files with spaces" do
-      expect(IngestLocalFileJob).to receive(:perform_later).with(FileSet, "/local/file/ pigs .txt", user)
+  context 'with local files' do
+    it 'attaches files with spaces' do
+      expect(IngestLocalFileJob).to receive(:perform_later).with(FileSet, '/local/file/ pigs .txt', user)
       expect(actor.create(attributes)).to be true
     end
   end

--- a/spec/config/application_spec.rb
+++ b/spec/config/application_spec.rb
@@ -1,36 +1,36 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-describe "Application configuration" do
+describe 'Application configuration' do
   let(:config) { Rails.application.config }
 
-  describe "ffmpeg_path" do
+  describe 'ffmpeg_path' do
     subject { config.ffmpeg_path }
-    it { is_expected.to eq("ffmpeg-test") }
+    it { is_expected.to eq('ffmpeg-test') }
   end
 
-  describe "service_instance" do
+  describe 'service_instance' do
     subject { config.service_instance }
-    it { is_expected.to eq("example-test") }
+    it { is_expected.to eq('example-test') }
   end
 
-  describe "virtual_host" do
+  describe 'virtual_host' do
     subject { config.virtual_host }
-    it { is_expected.to eq("http://test.com/") }
+    it { is_expected.to eq('http://test.com/') }
   end
 
-  describe "stats_email" do
+  describe 'stats_email' do
     subject { config.stats_email }
-    it { is_expected.to eq("Test email") }
+    it { is_expected.to eq('Test email') }
   end
 
-  describe "derivatives path" do
+  describe 'derivatives path' do
     subject { config.derivatives_path }
-    it { is_expected.to end_with("tmp/derivatives") }
+    it { is_expected.to end_with('tmp/derivatives') }
   end
 
-  describe "Google analytics ID" do
+  describe 'Google analytics ID' do
     subject { config.google_analytics_id }
-    it { is_expected.to eq("test-id") }
+    it { is_expected.to eq('test-id') }
   end
 end

--- a/spec/config/licenses_spec.rb
+++ b/spec/config/licenses_spec.rb
@@ -4,48 +4,48 @@ require 'rails_helper'
 describe CurationConcerns::LicenseService do
   let(:service) { described_class.new }
 
-  describe "all licenses" do
+  describe 'all licenses' do
     let(:all_license_urls) do
       [
-        "http://creativecommons.org/licenses/by/3.0/us/",
-        "http://creativecommons.org/licenses/by-sa/3.0/us/",
-        "http://creativecommons.org/licenses/by-nc/3.0/us/",
-        "http://creativecommons.org/licenses/by-nd/3.0/us/",
-        "http://creativecommons.org/licenses/by-nc-nd/3.0/us/",
-        "http://creativecommons.org/licenses/by-nc-sa/3.0/us/",
-        "https://creativecommons.org/licenses/by/4.0/",
-        "https://creativecommons.org/licenses/by-sa/4.0/",
-        "https://creativecommons.org/licenses/by-nc/4.0/",
-        "https://creativecommons.org/licenses/by-nd/4.0/",
-        "https://creativecommons.org/licenses/by-nc-nd/4.0/",
-        "https://creativecommons.org/licenses/by-nc-sa/4.0/",
-        "http://creativecommons.org/publicdomain/mark/1.0/",
-        "http://creativecommons.org/publicdomain/zero/1.0/",
-        "http://www.europeana.eu/portal/rights/rr-r.html",
-        "http://www.apache.org/licenses/LICENSE-2.0",
-        "https://www.gnu.org/licenses/gpl.html",
-        "https://opensource.org/licenses/MIT"
+        'http://creativecommons.org/licenses/by/3.0/us/',
+        'http://creativecommons.org/licenses/by-sa/3.0/us/',
+        'http://creativecommons.org/licenses/by-nc/3.0/us/',
+        'http://creativecommons.org/licenses/by-nd/3.0/us/',
+        'http://creativecommons.org/licenses/by-nc-nd/3.0/us/',
+        'http://creativecommons.org/licenses/by-nc-sa/3.0/us/',
+        'https://creativecommons.org/licenses/by/4.0/',
+        'https://creativecommons.org/licenses/by-sa/4.0/',
+        'https://creativecommons.org/licenses/by-nc/4.0/',
+        'https://creativecommons.org/licenses/by-nd/4.0/',
+        'https://creativecommons.org/licenses/by-nc-nd/4.0/',
+        'https://creativecommons.org/licenses/by-nc-sa/4.0/',
+        'http://creativecommons.org/publicdomain/mark/1.0/',
+        'http://creativecommons.org/publicdomain/zero/1.0/',
+        'http://www.europeana.eu/portal/rights/rr-r.html',
+        'http://www.apache.org/licenses/LICENSE-2.0',
+        'https://www.gnu.org/licenses/gpl.html',
+        'https://opensource.org/licenses/MIT'
       ]
     end
     subject { service.select_all_options.map(&:last) }
     it { is_expected.to contain_exactly(*all_license_urls) }
   end
 
-  describe "active licenses" do
+  describe 'active licenses' do
     let(:active_license_urls) do
       [
-        "https://creativecommons.org/licenses/by/4.0/",
-        "https://creativecommons.org/licenses/by-sa/4.0/",
-        "https://creativecommons.org/licenses/by-nc/4.0/",
-        "https://creativecommons.org/licenses/by-nd/4.0/",
-        "https://creativecommons.org/licenses/by-nc-nd/4.0/",
-        "https://creativecommons.org/licenses/by-nc-sa/4.0/",
-        "http://creativecommons.org/publicdomain/mark/1.0/",
-        "http://creativecommons.org/publicdomain/zero/1.0/",
-        "http://www.europeana.eu/portal/rights/rr-r.html",
-        "http://www.apache.org/licenses/LICENSE-2.0",
-        "https://www.gnu.org/licenses/gpl.html",
-        "https://opensource.org/licenses/MIT"
+        'https://creativecommons.org/licenses/by/4.0/',
+        'https://creativecommons.org/licenses/by-sa/4.0/',
+        'https://creativecommons.org/licenses/by-nc/4.0/',
+        'https://creativecommons.org/licenses/by-nd/4.0/',
+        'https://creativecommons.org/licenses/by-nc-nd/4.0/',
+        'https://creativecommons.org/licenses/by-nc-sa/4.0/',
+        'http://creativecommons.org/publicdomain/mark/1.0/',
+        'http://creativecommons.org/publicdomain/zero/1.0/',
+        'http://www.europeana.eu/portal/rights/rr-r.html',
+        'http://www.apache.org/licenses/LICENSE-2.0',
+        'https://www.gnu.org/licenses/gpl.html',
+        'https://opensource.org/licenses/MIT'
       ]
     end
     subject { service.select_active_options.map(&:last) }

--- a/spec/controllers/admin/stats_controller_spec.rb
+++ b/spec/controllers/admin/stats_controller_spec.rb
@@ -4,70 +4,70 @@ require 'rails_helper'
 describe Admin::StatsController, type: :controller do
   let(:query_service) { Sufia::QueryService.new }
   before { allow(controller).to receive(:query_service).and_return(query_service) }
-  describe "#export" do
-    context "when format is csv" do
+  describe '#export' do
+    context 'when format is csv' do
       let(:header) { "Work Url,Work Id,Work Title,Work Resource Type,Work Rights,File Set Url,File Set Time Uploaded,File Set Id,File Set Title,File Set Depositor,File Set Creator,File Set Visibility,File Set File Format\n" }
       before do
         allow(query_service).to receive(:find_by_date_created).and_return(file_list)
       end
-      context "no files" do
+      context 'no files' do
         let(:file_list) { [] }
-        it "exports csv" do
-          get :export, format: "csv"
+        it 'exports csv' do
+          get :export, format: 'csv'
           expect(response.status).to eq(200)
           expect(response.body).to eq(header)
         end
       end
-      context "with files" do
-        let(:file_list) { [create(:work, :with_one_file, file_title: ["my file"])] }
-        it "exports csv" do
-          get :export, format: "csv"
+      context 'with files' do
+        let(:file_list) { [create(:work, :with_one_file, file_title: ['my file'])] }
+        it 'exports csv' do
+          get :export, format: 'csv'
           expect(response.status).to eq(200)
           expect(response.body).to include(header)
-          expect(response.body).to include("my file")
+          expect(response.body).to include('my file')
         end
       end
 
-      context "with dates" do
+      context 'with dates' do
         let(:start_datetime_str) { start_datetime.to_s }
         let(:end_datetime_str) { end_datetime.to_s }
         let(:begining) { start_datetime.beginning_of_day.to_datetime }
         let(:ending) { end_datetime.end_of_day.to_datetime }
 
-        context "with start date" do
-          let(:file_list) { [build(:file, id: "abc123", title: ["my file"])] }
+        context 'with start date' do
+          let(:file_list) { [build(:file, id: 'abc123', title: ['my file'])] }
           let(:start_datetime) { 2.days.ago }
           let(:end_datetime) { 1.day.ago.end_of_day }
-          it "defaults end date and pasess start date parameters" do
+          it 'defaults end date and pasess start date parameters' do
             expect(query_service).to receive(:find_by_date_created).with(begining, ending).and_return([])
-            get :export, format: "csv", start_datetime: start_datetime_str
+            get :export, format: 'csv', start_datetime: start_datetime_str
           end
         end
 
-        context "with end date" do
-          let(:file_list) { [build(:file, id: "abc123", title: ["my file"])] }
+        context 'with end date' do
+          let(:file_list) { [build(:file, id: 'abc123', title: ['my file'])] }
           let(:start_datetime) { 1.day.ago.beginning_of_day }
           let(:end_datetime) { 1.day.ago }
-          it "defaults start date and pasess end date parameters" do
+          it 'defaults start date and pasess end date parameters' do
             expect(query_service).to receive(:find_by_date_created).with(begining, ending).and_return([])
-            get :export, format: "csv", end_datetime: end_datetime_str
+            get :export, format: 'csv', end_datetime: end_datetime_str
           end
         end
 
-        context "with start and end date parameters" do
-          let(:file_list) { [build(:file, id: "abc123", title: ["my file"])] }
+        context 'with start and end date parameters' do
+          let(:file_list) { [build(:file, id: 'abc123', title: ['my file'])] }
           let(:start_datetime) { 2.days.ago }
           let(:end_datetime) { 1.day.ago }
-          it "pasess start and end date" do
+          it 'pasess start and end date' do
             expect(query_service).to receive(:find_by_date_created).with(begining, ending).and_return([])
-            get :export, format: "csv", start_datetime: start_datetime_str, end_datetime: end_datetime_str
+            get :export, format: 'csv', start_datetime: start_datetime_str, end_datetime: end_datetime_str
           end
         end
       end
     end
 
-    context "when format is html" do
-      it "renders the form" do
+    context 'when format is html' do
+      it 'renders the form' do
         get :export
         expect(response).to be_success
         expect(response).to render_template('admin/stats/export')

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 describe ApplicationController do
   subject { response }
 
-  context "with ActiveFedora::ObjectNotFoundError" do
+  context 'with ActiveFedora::ObjectNotFoundError' do
     controller do
       def index
         raise ActiveFedora::ObjectNotFoundError
@@ -14,7 +14,7 @@ describe ApplicationController do
     its(:status) { is_expected.to be(404) }
   end
 
-  context "with AbstractController::ActionNotFound" do
+  context 'with AbstractController::ActionNotFound' do
     controller do
       def index
         raise AbstractController::ActionNotFound
@@ -24,17 +24,17 @@ describe ApplicationController do
     its(:status) { is_expected.to be(404) }
   end
 
-  context "with ActionController::RoutingError" do
+  context 'with ActionController::RoutingError' do
     controller do
       def index
-        raise ActionController::RoutingError.new("message")
+        raise ActionController::RoutingError.new('message')
       end
     end
     before { get :index }
     its(:status) { is_expected.to be(404) }
   end
 
-  context "with ActionDispatch::Cookies::CookieOverflow" do
+  context 'with ActionDispatch::Cookies::CookieOverflow' do
     controller do
       def index
         raise ActionDispatch::Cookies::CookieOverflow
@@ -44,7 +44,7 @@ describe ApplicationController do
     its(:status) { is_expected.to be(500) }
   end
 
-  context "with ActionView::Template::Error" do
+  context 'with ActionView::Template::Error' do
     controller do
       def index
         raise ActionView::Template::Error.new(nil, nil)
@@ -54,7 +54,7 @@ describe ApplicationController do
     its(:status) { is_expected.to be(500) }
   end
 
-  context "with ActiveRecord::RecordNotFound" do
+  context 'with ActiveRecord::RecordNotFound' do
     controller do
       def index
         raise ActiveRecord::RecordNotFound
@@ -64,7 +64,7 @@ describe ApplicationController do
     its(:status) { is_expected.to be(404) }
   end
 
-  context "with ActiveRecord::StatementInvalid" do
+  context 'with ActiveRecord::StatementInvalid' do
     controller do
       def index
         raise ActiveRecord::StatementInvalid.new(nil)
@@ -74,7 +74,7 @@ describe ApplicationController do
     its(:status) { is_expected.to be(500) }
   end
 
-  context "with Blacklight::Exceptions::ECONNREFUSED" do
+  context 'with Blacklight::Exceptions::ECONNREFUSED' do
     controller do
       def index
         raise Blacklight::Exceptions::ECONNREFUSED
@@ -84,20 +84,20 @@ describe ApplicationController do
     its(:status) { is_expected.to be(500) }
   end
 
-  context "with Blacklight::Exceptions::InvalidSolrID" do
+  context 'with Blacklight::Exceptions::InvalidSolrID' do
     controller do
       def index
         raise Blacklight::Exceptions::InvalidSolrID
       end
     end
     before { get :index }
-    it "returns a 404" do
-      pending "Returning 500 instead of 404"
+    it 'returns a 404' do
+      pending 'Returning 500 instead of 404'
       expect(response.status).to be(404)
     end
   end
 
-  context "with Errno::ECONNREFUSED" do
+  context 'with Errno::ECONNREFUSED' do
     controller do
       def index
         raise Errno::ECONNREFUSED
@@ -107,7 +107,7 @@ describe ApplicationController do
     its(:status) { is_expected.to be(500) }
   end
 
-  context "with NameError" do
+  context 'with NameError' do
     controller do
       def index
         raise NameError
@@ -117,7 +117,7 @@ describe ApplicationController do
     its(:status) { is_expected.to be(500) }
   end
 
-  context "with Net::LDAP::LdapError" do
+  context 'with Net::LDAP::LdapError' do
     controller do
       def index
         raise Net::LDAP::LdapError
@@ -127,7 +127,7 @@ describe ApplicationController do
     its(:status) { is_expected.to be(500) }
   end
 
-  context "with Redis::CannotConnectError" do
+  context 'with Redis::CannotConnectError' do
     controller do
       def index
         raise Redis::CannotConnectError
@@ -137,17 +137,17 @@ describe ApplicationController do
     its(:status) { is_expected.to be(500) }
   end
 
-  context "with RSolr::Error::Http" do
+  context 'with RSolr::Error::Http' do
     controller do
       def index
-        raise RSolr::Error::Http.new({ uri: "uri" }, nil)
+        raise RSolr::Error::Http.new({ uri: 'uri' }, nil)
       end
     end
     before { get :index }
     its(:status) { is_expected.to be(500) }
   end
 
-  context "with Ldp::BadRequest" do
+  context 'with Ldp::BadRequest' do
     controller do
       def index
         raise Ldp::BadRequest
@@ -157,7 +157,7 @@ describe ApplicationController do
     its(:status) { is_expected.to be(500) }
   end
 
-  context "with RuntimeError" do
+  context 'with RuntimeError' do
     controller do
       def index
         raise RuntimeError
@@ -167,7 +167,7 @@ describe ApplicationController do
     its(:status) { is_expected.to be(500) }
   end
 
-  context "with StandardError" do
+  context 'with StandardError' do
     controller do
       def index
         raise StandardError
@@ -177,7 +177,7 @@ describe ApplicationController do
     its(:status) { is_expected.to be(500) }
   end
 
-  describe "#render_404" do
+  describe '#render_404' do
     controller do
       def index
         render_404

--- a/spec/controllers/batch_edits_controller_spec.rb
+++ b/spec/controllers/batch_edits_controller_spec.rb
@@ -9,40 +9,40 @@ describe BatchEditsController do
     allow_any_instance_of(User).to receive(:groups).and_return([])
   end
 
-  describe "#form_class" do
+  describe '#form_class' do
     subject { described_class.new }
     its(:form_class) { is_expected.to eq(::BatchEditForm) }
   end
 
-  describe "#update" do
+  describe '#update' do
     let(:work1) { create(:private_work, depositor: user.login) }
     let(:work2) { create(:private_work, depositor: user.login) }
     let(:work3) { create(:public_work,  depositor: user.login) }
 
-    before { request.env["HTTP_REFERER"] = "where_i_came_from" }
+    before { request.env['HTTP_REFERER'] = 'where_i_came_from' }
 
-    context "when changing visibility" do
+    context 'when changing visibility' do
       let(:parameters) do
         {
-          update_type:        "update",
-          batch_edit_item:    { visibility: "authenticated" },
+          update_type:        'update',
+          batch_edit_item:    { visibility: 'authenticated' },
           batch_document_ids: [work1.id, work2.id]
         }
       end
 
-      it "applies the new setting to all works" do
+      it 'applies the new setting to all works' do
         expect(VisibilityCopyJob).to receive(:perform_later).twice
         expect(InheritPermissionsJob).not_to receive(:perform_later)
         put :update, parameters.as_json
-        expect(work1.reload.visibility).to eq("authenticated")
-        expect(work2.reload.visibility).to eq("authenticated")
+        expect(work1.reload.visibility).to eq('authenticated')
+        expect(work2.reload.visibility).to eq('authenticated')
       end
     end
 
-    context "when visibility is nil" do
+    context 'when visibility is nil' do
       let(:parameters) do
         {
-          update_type:        "update",
+          update_type:        'update',
           batch_edit_item:    {},
           batch_document_ids: [work1.id, work3.id]
         }
@@ -52,16 +52,16 @@ describe BatchEditsController do
         expect(VisibilityCopyJob).not_to receive(:perform_later)
         expect(InheritPermissionsJob).not_to receive(:perform_later)
         put :update, parameters.as_json
-        expect(work1.reload.visibility).to eq("restricted")
-        expect(work3.reload.visibility).to eq("open")
+        expect(work1.reload.visibility).to eq('restricted')
+        expect(work3.reload.visibility).to eq('open')
       end
     end
 
-    context "when visibility is unchanged" do
+    context 'when visibility is unchanged' do
       let(:parameters) do
         {
-          update_type:        "update",
-          batch_edit_item:    { visibility: "restricted" },
+          update_type:        'update',
+          batch_edit_item:    { visibility: 'restricted' },
           batch_document_ids: [work1.id, work2.id]
         }
       end
@@ -70,27 +70,27 @@ describe BatchEditsController do
         expect(VisibilityCopyJob).not_to receive(:perform_later)
         expect(InheritPermissionsJob).not_to receive(:perform_later)
         put :update, parameters.as_json
-        expect(work1.reload.visibility).to eq("restricted")
-        expect(work2.reload.visibility).to eq("restricted")
+        expect(work1.reload.visibility).to eq('restricted')
+        expect(work2.reload.visibility).to eq('restricted')
       end
     end
 
-    context "when permissions are changed" do
-      let(:group_permission) { { "0" => { type: "group", name: "newgroop", access: "edit" } } }
+    context 'when permissions are changed' do
+      let(:group_permission) { { '0' => { type: 'group', name: 'newgroop', access: 'edit' } } }
       let(:parameters) do
         {
-          update_type:        "update",
+          update_type:        'update',
           batch_edit_item:    { permissions_attributes: group_permission },
           batch_document_ids: [work1.id, work2.id]
         }
       end
 
-      it "updates the permissions on all the works" do
+      it 'updates the permissions on all the works' do
         expect(VisibilityCopyJob).not_to receive(:perform_later)
         expect(InheritPermissionsJob).to receive(:perform_later).twice
         put :update, parameters.as_json
-        expect(work1.reload.edit_groups).to contain_exactly("newgroop")
-        expect(work2.reload.edit_groups).to contain_exactly("newgroop")
+        expect(work1.reload.edit_groups).to contain_exactly('newgroop')
+        expect(work2.reload.edit_groups).to contain_exactly('newgroop')
       end
     end
   end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -4,10 +4,10 @@ require 'rails_helper'
 describe CatalogController, type: :controller do
   include FactoryHelpers
 
-  let!(:file_set) { build(:file_set, id: "fs") }
-  let!(:work1)    { build(:public_work, :with_pdf, title: ['Test Document PDF'], id: "1") }
-  let!(:work2)    { build(:public_work, title: ['Test 2 Document'], contributor: ['Contrib2'], id: "2") }
-  let!(:work3)    { build(:public_work, :with_complete_metadata, id: "3", members: [file_set]) }
+  let!(:file_set) { build(:file_set, id: 'fs') }
+  let!(:work1)    { build(:public_work, :with_pdf, title: ['Test Document PDF'], id: '1') }
+  let!(:work2)    { build(:public_work, title: ['Test 2 Document'], contributor: ['Contrib2'], id: '2') }
+  let!(:work3)    { build(:public_work, :with_complete_metadata, id: '3', members: [file_set]) }
 
   let(:text) { mock_file_factory(content: 'full_textfull_text') }
   let(:file) { mock_file_factory(format_label: ['format_labelformat_label']) }
@@ -20,42 +20,42 @@ describe CatalogController, type: :controller do
   end
 
   # Default depositor if none is supplied
-  let(:user) { "user" }
+  let(:user) { 'user' }
 
-  describe "config" do
-    describe "index_fields" do
+  describe 'config' do
+    describe 'index_fields' do
       subject { described_class.blacklight_config.index_fields.keys }
-      it { is_expected.to contain_exactly("based_near_tesim",
-                                          "date_uploaded_dtsi",
-                                          "keyword_tesim",
-                                          "language_tesim",
-                                          "publisher_tesim",
-                                          "resource_type_tesim",
-                                          "subject_tesim",
-                                          "has_model_ssim",
-                                          "creator_tesim")
+      it { is_expected.to contain_exactly('based_near_tesim',
+                                          'date_uploaded_dtsi',
+                                          'keyword_tesim',
+                                          'language_tesim',
+                                          'publisher_tesim',
+                                          'resource_type_tesim',
+                                          'subject_tesim',
+                                          'has_model_ssim',
+                                          'creator_tesim')
       }
     end
-    describe "show_fields" do
+    describe 'show_fields' do
       subject { described_class.blacklight_config.show_fields.keys }
-      it { is_expected.to contain_exactly("depositor_tesim", "based_near_tesim", "date_modified_dtsi", "date_uploaded_dtsi",
-                                          "description_tesim", "identifier_tesim", "keyword_tesim",
-                                          "language_tesim", "publisher_tesim", "resource_type_tesim", "rights_tesim",
-                                          "subject_tesim", "contributor_tesim", "creator_tesim", "date_created_tesim",
-                                          "subtitle_tesim")
+      it { is_expected.to contain_exactly('depositor_tesim', 'based_near_tesim', 'date_modified_dtsi', 'date_uploaded_dtsi',
+                                          'description_tesim', 'identifier_tesim', 'keyword_tesim',
+                                          'language_tesim', 'publisher_tesim', 'resource_type_tesim', 'rights_tesim',
+                                          'subject_tesim', 'contributor_tesim', 'creator_tesim', 'date_created_tesim',
+                                          'subtitle_tesim')
       }
     end
-    describe "facet_fields" do
+    describe 'facet_fields' do
       subject { described_class.blacklight_config.facet_fields.keys }
-      it { is_expected.to contain_exactly("based_near_sim", "collection_sim", "has_model_ssim",
-                                          "file_format_sim", "keyword_sim",
-                                          "language_sim", "publisher_sim", "resource_type_sim",
-                                          "subject_sim", "creator_sim")
+      it { is_expected.to contain_exactly('based_near_sim', 'collection_sim', 'has_model_ssim',
+                                          'file_format_sim', 'keyword_sim',
+                                          'language_sim', 'publisher_sim', 'resource_type_sim',
+                                          'subject_sim', 'creator_sim')
       }
     end
   end
 
-  describe "#index" do
+  describe '#index' do
     before do
       ActiveFedora::Cleaner.cleanout_solr
       index_file_set(file_set)
@@ -63,126 +63,126 @@ describe CatalogController, type: :controller do
       index_work(work2)
       index_work(work3)
     end
-    describe "term search" do
-      it "finds pdf files" do
-        xhr :get, :index, q: "pdf"
+    describe 'term search' do
+      it 'finds pdf files' do
+        xhr :get, :index, q: 'pdf'
         expect(response).to be_success
         expect(response).to render_template('catalog/index')
         expect(assigns(:document_list).count).to be(1)
-        expect(assigns(:document_list)[0].fetch(solr_field("title"))[0]).to eql('Test Document PDF')
+        expect(assigns(:document_list)[0].fetch(solr_field('title'))[0]).to eql('Test Document PDF')
       end
-      it "finds a file by title" do
-        xhr :get, :index, q: "titletitle"
+      it 'finds a file by title' do
+        xhr :get, :index, q: 'titletitle'
         expect(response).to be_success
         expect(response).to render_template('catalog/index')
         expect(assigns(:document_list).count).to be(1)
-        expect(assigns(:document_list)[0].fetch(solr_field("title"))[0]).to eql('titletitle')
+        expect(assigns(:document_list)[0].fetch(solr_field('title'))[0]).to eql('titletitle')
       end
-      it "finds a file by keyword" do
-        xhr :get, :index, q: "tagtag"
+      it 'finds a file by keyword' do
+        xhr :get, :index, q: 'tagtag'
         expect(response).to be_success
         expect(response).to render_template('catalog/index')
         expect(assigns(:document_list).count).to be(1)
-        expect(assigns(:document_list)[0].fetch(solr_field("keyword"))[0]).to eql('tagtag')
+        expect(assigns(:document_list)[0].fetch(solr_field('keyword'))[0]).to eql('tagtag')
       end
-      it "finds a file by subject" do
-        xhr :get, :index, q: "subjectsubject"
+      it 'finds a file by subject' do
+        xhr :get, :index, q: 'subjectsubject'
         expect(response).to be_success
         expect(response).to render_template('catalog/index')
         expect(assigns(:document_list).count).to be(1)
-        expect(assigns(:document_list)[0].fetch(solr_field("subject"))[0]).to eql('subjectsubject')
+        expect(assigns(:document_list)[0].fetch(solr_field('subject'))[0]).to eql('subjectsubject')
       end
-      it "finds a file by creator" do
-        xhr :get, :index, q: "creatorcreator"
+      it 'finds a file by creator' do
+        xhr :get, :index, q: 'creatorcreator'
         expect(response).to be_success
         expect(response).to render_template('catalog/index')
         expect(assigns(:document_list).count).to be(1)
-        expect(assigns(:document_list)[0].fetch(solr_field("creator"))[0]).to eql('creatorcreator')
+        expect(assigns(:document_list)[0].fetch(solr_field('creator'))[0]).to eql('creatorcreator')
       end
-      it "finds a file by contributor" do
-        xhr :get, :index, q: "contributorcontributor"
+      it 'finds a file by contributor' do
+        xhr :get, :index, q: 'contributorcontributor'
         expect(response).to be_success
         expect(response).to render_template('catalog/index')
         expect(assigns(:document_list).count).to be(1)
-        expect(assigns(:document_list)[0].fetch(solr_field("contributor"))[0]).to eql('contributorcontributor')
+        expect(assigns(:document_list)[0].fetch(solr_field('contributor'))[0]).to eql('contributorcontributor')
       end
-      it "finds a file by publisher" do
-        xhr :get, :index, q: "publisherpublisher"
+      it 'finds a file by publisher' do
+        xhr :get, :index, q: 'publisherpublisher'
         expect(response).to be_success
         expect(response).to render_template('catalog/index')
         expect(assigns(:document_list).count).to be(1)
-        expect(assigns(:document_list)[0].fetch(solr_field("publisher"))[0]).to eql('publisherpublisher')
+        expect(assigns(:document_list)[0].fetch(solr_field('publisher'))[0]).to eql('publisherpublisher')
       end
-      it "finds a file by based_near" do
-        xhr :get, :index, q: "based_nearbased_near"
+      it 'finds a file by based_near' do
+        xhr :get, :index, q: 'based_nearbased_near'
         expect(response).to be_success
         expect(response).to render_template('catalog/index')
         expect(assigns(:document_list).count).to be(1)
-        expect(assigns(:document_list)[0].fetch(solr_field("based_near"))[0]).to eql('based_nearbased_near')
+        expect(assigns(:document_list)[0].fetch(solr_field('based_near'))[0]).to eql('based_nearbased_near')
       end
-      it "finds a file by language" do
-        xhr :get, :index, q: "languagelanguage"
+      it 'finds a file by language' do
+        xhr :get, :index, q: 'languagelanguage'
         expect(response).to be_success
         expect(response).to render_template('catalog/index')
         expect(assigns(:document_list).count).to be(1)
-        expect(assigns(:document_list)[0].fetch(solr_field("language"))[0]).to eql('languagelanguage')
+        expect(assigns(:document_list)[0].fetch(solr_field('language'))[0]).to eql('languagelanguage')
       end
-      it "finds a file by resource_type" do
-        xhr :get, :index, q: "resource_typeresource_type"
+      it 'finds a file by resource_type' do
+        xhr :get, :index, q: 'resource_typeresource_type'
         expect(response).to be_success
         expect(response).to render_template('catalog/index')
         expect(assigns(:document_list).count).to be(1)
-        expect(assigns(:document_list)[0].fetch(solr_field("resource_type"))[0]).to eql('resource_typeresource_type')
+        expect(assigns(:document_list)[0].fetch(solr_field('resource_type'))[0]).to eql('resource_typeresource_type')
       end
-      it "finds a file by format_label" do
-        xhr :get, :index, q: "format_labelformat_label"
+      it 'finds a file by format_label' do
+        xhr :get, :index, q: 'format_labelformat_label'
         expect(response).to be_success
         expect(response).to render_template('catalog/index')
         expect(assigns(:document_list).count).to be(1)
-        expect(assigns(:document_list)[0].fetch(solr_field("file_format"))[0]).to eql('plain (format_labelformat_label)')
+        expect(assigns(:document_list)[0].fetch(solr_field('file_format'))[0]).to eql('plain (format_labelformat_label)')
       end
-      it "finds a file by description" do
-        xhr :get, :index, q: "descriptiondescription"
+      it 'finds a file by description' do
+        xhr :get, :index, q: 'descriptiondescription'
         expect(response).to be_success
         expect(response).to render_template('catalog/index')
         expect(assigns(:document_list).count).to be(1)
-        expect(assigns(:document_list)[0].fetch(solr_field("description"))[0]).to eql('descriptiondescription')
+        expect(assigns(:document_list)[0].fetch(solr_field('description'))[0]).to eql('descriptiondescription')
       end
-      it "finds a file by full_text" do
-        xhr :get, :index, q: "full_textfull_text"
+      it 'finds a file by full_text' do
+        xhr :get, :index, q: 'full_textfull_text'
         expect(response).to be_success
         expect(response).to render_template('catalog/index')
         expect(assigns(:document_list).count).to be(1)
       end
-      it "finds a file by depositor" do
+      it 'finds a file by depositor' do
         xhr :get, :index, q: user
         expect(response).to be_success
         expect(response).to render_template('catalog/index')
         expect(assigns(:document_list).count).to be(3)
       end
-      it "finds a file by depositor in advanced search" do
-        xhr :get, :index, depositor: user, search_field: "advanced"
+      it 'finds a file by depositor in advanced search' do
+        xhr :get, :index, depositor: user, search_field: 'advanced'
         expect(response).to be_success
         expect(response).to render_template('catalog/index')
         expect(assigns(:document_list).count).to be(3)
       end
     end
-    describe "facet search" do
+    describe 'facet search' do
       before do
         xhr :get, :index, q: "{f=#{contributor_facet}}Contrib2"
       end
-      it "finds facet files" do
+      it 'finds facet files' do
         expect(response).to be_success
         expect(response).to render_template('catalog/index')
         expect(assigns(:document_list).count).to be(1)
       end
     end
-    describe "user with group search" do
+    describe 'user with group search' do
       before do
         allow_any_instance_of(User).to receive(:groups).and_return(['umg/personal.testuser.testgroup'])
         xhr :get, :index, q: "{f=#{contributor_facet}}Contrib2"
       end
-      it "finds facet files" do
+      it 'finds facet files' do
         expect(response).to be_success
         expect(response).to render_template('catalog/index')
         expect(assigns(:document_list).count).to be(1)

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -9,13 +9,13 @@ describe CollectionsController, type: :controller do
     its(:status) { is_expected.to eq(302) }
   end
 
-  context "when requesting a legacy URL" do
+  context 'when requesting a legacy URL' do
     before { get :show, id: 'scholarsphere:123' }
     its(:status) { is_expected.to eq(301) }
-    its(:location) { is_expected.to eq("http://test.host/collections/123") }
+    its(:location) { is_expected.to eq('http://test.host/collections/123') }
   end
 
-  context "when requesting an existing collection" do
+  context 'when requesting an existing collection' do
     let(:work1)       { create(:public_work) }
     let(:work2)       { create(:public_work) }
     let!(:collection) { create(:public_collection, members: [work1, work2]) }
@@ -23,12 +23,12 @@ describe CollectionsController, type: :controller do
     it { is_expected.to be_success }
   end
 
-  describe "::form_class" do
+  describe '::form_class' do
     subject { described_class }
     its(:form_class) { is_expected.to be(CollectionForm) }
   end
 
-  describe "#delete" do
+  describe '#delete' do
     let(:user) { create(:user) }
     let(:collection) { create(:collection, depositor: user.login) }
 
@@ -37,18 +37,18 @@ describe CollectionsController, type: :controller do
       allow_any_instance_of(User).to receive(:groups).and_return([])
     end
 
-    context "when the collection is successfully deleted" do
+    context 'when the collection is successfully deleted' do
       before { delete :destroy, id: collection }
-      it { is_expected.to redirect_to("/dashboard/collections") }
+      it { is_expected.to redirect_to('/dashboard/collections') }
     end
 
-    context "when the collection is not successfully deleted" do
+    context 'when the collection is not successfully deleted' do
       before do
         controller.instance_variable_set(:@collection, collection)
         allow(collection).to receive(:destroy).and_return(false)
         delete :destroy, id: collection
       end
-      it { is_expected.to redirect_to("/dashboard/collections") }
+      it { is_expected.to redirect_to('/dashboard/collections') }
     end
   end
 end

--- a/spec/controllers/curation_concerns/file_sets_controller_spec.rb
+++ b/spec/controllers/curation_concerns/file_sets_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 describe CurationConcerns::FileSetsController do
-  describe "::show_presenter" do
+  describe '::show_presenter' do
     its(:show_presenter) { is_expected.to eq(::FileSetPresenter) }
   end
 end

--- a/spec/controllers/curation_concerns/generic_works_controller_spec.rb
+++ b/spec/controllers/curation_concerns/generic_works_controller_spec.rb
@@ -4,10 +4,10 @@ require 'rails_helper'
 describe CurationConcerns::GenericWorksController, type: :controller do
   let(:user) { create(:user) }
 
-  describe "#show" do
-    context "with a public user" do
+  describe '#show' do
+    context 'with a public user' do
       let(:work) { create(:public_work) }
-      it "loads from solr" do
+      it 'loads from solr' do
         expect_any_instance_of(CanCan::ControllerResource).not_to receive(:load_and_authorize_resource)
         get :show, id: work.id
         expect(assigns(:presenter)).to be_kind_of ::WorkShowPresenter
@@ -15,16 +15,16 @@ describe CurationConcerns::GenericWorksController, type: :controller do
     end
 
     context "when the work doesn't exist" do
-      it "redirects to the login" do
+      it 'redirects to the login' do
         get :show, id: 'non-existent-id'
-        expect(response.redirect_url).to eq("http://test.host/login_session")
+        expect(response.redirect_url).to eq('http://test.host/login_session')
       end
     end
 
-    context "when work is registered" do
+    context 'when work is registered' do
       let(:work)   { create(:registered_file) }
       let(:path)   { Rails.application.routes.url_helpers.curation_concerns_generic_work_path(work) }
-      it "redirects with file in url" do
+      it 'redirects with file in url' do
         get :show, id: work.id
         expect(response.status).to eq(302)
         expect(session[:user_return_to]).to include(path)
@@ -32,85 +32,85 @@ describe CurationConcerns::GenericWorksController, type: :controller do
     end
   end
 
-  describe "#delete" do
+  describe '#delete' do
     before do
       allow_any_instance_of(Devise::Strategies::HttpHeaderAuthenticatable).to receive(:remote_user).and_return(user.login)
       allow_any_instance_of(User).to receive(:groups).and_return([])
     end
 
-    context "when the work has been pushed to Share" do
+    context 'when the work has been pushed to Share' do
       let!(:work) { create(:share_file, depositor: user.login) }
-      it "is deleted from SHARE notify" do
+      it 'is deleted from SHARE notify' do
         expect(ShareNotifyDeleteJob).to receive(:perform_later).with(work)
         delete :destroy, id: work
       end
     end
 
-    context "after deletion" do
+    context 'after deletion' do
       let!(:work) { create(:work, depositor: user.login) }
-      it "redirects to My Works" do
+      it 'redirects to My Works' do
         delete :destroy, id: work
         expect(response).to redirect_to(Sufia::Engine.routes.url_helpers.dashboard_works_path)
       end
     end
   end
 
-  describe "#edit" do
+  describe '#edit' do
     before do
       allow_any_instance_of(Devise::Strategies::HttpHeaderAuthenticatable).to receive(:remote_user).and_return(user.login)
       allow_any_instance_of(User).to receive(:groups).and_return([])
     end
 
-    context "when files are being uploaded to a work" do
+    context 'when files are being uploaded to a work' do
       let!(:work) { create(:work, depositor: user.login) }
 
-      before { allow(QueuedFile).to receive(:where).and_return(["queued file"]) }
+      before { allow(QueuedFile).to receive(:where).and_return(['queued file']) }
 
-      it "redirects" do
+      it 'redirects' do
         get :edit, id: work
-        expect(flash.notice).to eq("Edits or deletes not allowed while files are being uploaded to a work")
+        expect(flash.notice).to eq('Edits or deletes not allowed while files are being uploaded to a work')
         expect(response).to be_redirect
       end
     end
   end
 
-  context "when work is private" do
-    let(:work) { create(:private_work, id: "1234") }
+  context 'when work is private' do
+    let(:work) { create(:private_work, id: '1234') }
     before { sign_in user }
 
-    context "when user is not administrator" do
+    context 'when user is not administrator' do
       let(:user) { FactoryGirl.create(:user) }
 
-      it "does not allow any user to view" do
+      it 'does not allow any user to view' do
         get :show, id: work.id
         expect(response.status).to eq(401)
       end
 
-      it "does not allow any user to edit" do
+      it 'does not allow any user to edit' do
         get :edit, id: work.id
         expect(response.status).to eq(401)
       end
 
-      it "does not allow any user to update" do
+      it 'does not allow any user to update' do
         post :update, id: work.id, generic_work: { title: 'new_title' }
         expect(response.status).to eq(401)
       end
     end
 
-    context "when user is an administrator" do
+    context 'when user is an administrator' do
       let(:user) { FactoryGirl.create(:administrator) }
 
-      it "does allow user to view" do
+      it 'does allow user to view' do
         get :show, id: work.id
         expect(response.status).to eq(200)
       end
 
-      it "allows edits" do
+      it 'allows edits' do
         get :edit, id: work.id
         expect(response.status).to eq(200)
       end
 
-      it "allows updates" do
+      it 'allows updates' do
         post :update, id: work.id, generic_work: { title: 'new_title' }
         expect(response.status).to eq(302)
         expect(work.reload.title.first).to eq('new_title')

--- a/spec/controllers/curation_concerns/permissions_controller_spec.rb
+++ b/spec/controllers/curation_concerns/permissions_controller_spec.rb
@@ -2,15 +2,15 @@
 require 'rails_helper'
 
 describe CurationConcerns::PermissionsController do
-  let(:curation_concern) { build(:work, id: "1234") }
+  let(:curation_concern) { build(:work, id: '1234') }
 
-  describe "#copy_access" do
+  describe '#copy_access' do
     before do
       allow(controller).to receive(:curation_concern).and_return(curation_concern)
       allow(controller).to receive(:authorize!).with(:edit, curation_concern).and_return(true)
     end
 
-    it "calls CopyPermissionsJob" do
+    it 'calls CopyPermissionsJob' do
       expect(CopyPermissionsJob).to receive(:perform_later).with(curation_concern)
       expect(controller).to receive(:redirect_to)
       controller.copy_access

--- a/spec/controllers/directory_controller_spec.rb
+++ b/spec/controllers/directory_controller_spec.rb
@@ -3,14 +3,14 @@ require 'rails_helper'
 
 describe DirectoryController, type: :controller do
   let(:user) { create(:user) }
-  describe "#user" do
-    it "gets an existing user" do
+  describe '#user' do
+    it 'gets an existing user' do
       allow(User).to receive(:directory_attributes).and_return('{"attr":"abc"}')
       get :user, uid: user.id
       expect(response).to be_success
       expect { JSON.parse(response.body) }.not_to raise_error
       results = JSON.parse(response.body)
-      expect(results["attr"]).to eq("abc")
+      expect(results['attr']).to eq('abc')
     end
   end
 end

--- a/spec/controllers/downloads_controller_spec.rb
+++ b/spec/controllers/downloads_controller_spec.rb
@@ -14,82 +14,82 @@ describe DownloadsController do
     allow_any_instance_of(Devise::Strategies::HttpHeaderAuthenticatable).to receive(:remote_user).and_return(user.login)
   end
 
-  describe "#authorize_download!" do
+  describe '#authorize_download!' do
     subject { controller.send(:authorize_download!) }
 
-    context "with a regular user" do
+    context 'with a regular user' do
       before do
         allow_any_instance_of(User).to receive(:groups).and_return([])
       end
 
-      context "with my own file" do
+      context 'with my own file' do
         before { controller.params[:id] = my_file.id }
         it { is_expected.to eq(my_file.id) }
       end
 
-      context "with a file I do not have read access to" do
+      context 'with a file I do not have read access to' do
         before { controller.params[:id] = other_file.id }
-        it "denies access" do
+        it 'denies access' do
           expect { subject }.to raise_error(CanCan::AccessDenied)
         end
       end
 
-      context "with my own work" do
+      context 'with my own work' do
         let(:my_work) { create :public_work_with_png, depositor: user.login }
         before { controller.params[:id] = my_work.id }
         it { is_expected.to eq(my_work.id) }
       end
     end
 
-    context "with an administrator" do
+    context 'with an administrator' do
       before do
-        allow_any_instance_of(User).to receive(:groups).and_return(["umg/up.dlt.scholarsphere-admin-viewers"])
+        allow_any_instance_of(User).to receive(:groups).and_return(['umg/up.dlt.scholarsphere-admin-viewers'])
       end
 
-      context "with my own file" do
+      context 'with my own file' do
         before { controller.params[:id] = my_file.id }
         it { is_expected.to eq(my_file.id) }
       end
 
-      context "with a file I do not have read access to" do
+      context 'with a file I do not have read access to' do
         before { controller.params[:id] = other_file.id }
         it { is_expected.to eq(other_file.id) }
       end
     end
 
-    context "with no user" do
+    context 'with no user' do
       before do
         allow_any_instance_of(Devise::Strategies::HttpHeaderAuthenticatable).to receive(:remote_user).and_return(nil)
       end
 
-      context "with a public file" do
+      context 'with a public file' do
         before { controller.params[:id] = public_file.id }
         it { is_expected.to eq(public_file.id) }
       end
 
-      context "with a public file" do
+      context 'with a public file' do
         before { controller.params[:id] = other_file.id }
-        it "denies access" do
+        it 'denies access' do
           expect { subject }.to raise_error(CanCan::AccessDenied)
         end
       end
     end
   end
-  describe "#show" do
+  describe '#show' do
     subject { controller.send(:show) }
     before do
       allow_any_instance_of(User).to receive(:groups).and_return([])
     end
 
-    context "with a FileSet" do
+    context 'with a FileSet' do
       before { controller.params[:id] = my_file.id }
-      it "sends content" do
+      it 'sends content' do
         expect(controller).to receive(:send_content)
         subject
       end
     end
 
-    context "with a GenericWork" do
+    context 'with a GenericWork' do
       let(:my_work) { create :public_work_with_png, depositor: user.login }
       before do
         # I must save the work again becuase the factory just sends the representative id to solr
@@ -97,7 +97,7 @@ describe DownloadsController do
         my_work.save
         controller.params[:id] = my_work.id
       end
-      it "redirects" do
+      it 'redirects' do
         expect(controller).to receive(:redirect_to).with("/downloads/#{my_work.file_sets[0].id}", status: :moved_permanently)
         subject
       end

--- a/spec/controllers/my/works_controller_spec.rb
+++ b/spec/controllers/my/works_controller_spec.rb
@@ -7,60 +7,60 @@ describe My::WorksController, type: :controller do
 
   let(:user) { create(:archivist) }
 
-  describe "logged in user" do
+  describe 'logged in user' do
     before do
       allow_any_instance_of(Devise::Strategies::HttpHeaderAuthenticatable).to receive(:remote_user).and_return(user.login)
       allow_any_instance_of(User).to receive(:groups).and_return([])
     end
 
-    describe "#index" do
+    describe '#index' do
       let!(:work)       { create(:file, depositor: user.login) }
       let!(:other_work) { create(:file) }
       let(:user_results) do
-        ActiveFedora::SolrService.instance.conn.get "select",
+        ActiveFedora::SolrService.instance.conn.get 'select',
                                                     params: { fq: ["edit_access_group_ssim:public OR edit_access_person_ssim:#{user.user_key}"] }
       end
 
-      context "with a standard request" do
+      context 'with a standard request' do
         before { xhr :get, :index }
 
-        it "returns an array of documents I can edit" do
+        it 'returns an array of documents I can edit' do
           expect(response).to be_success
           expect(response).to render_template('my/index')
-          expect(assigns(:document_list).count).to eql(user_results["response"]["numFound"])
+          expect(assigns(:document_list).count).to eql(user_results['response']['numFound'])
           doc_ids = assigns(:document_list).map(&:id)
           expect(doc_ids).to include(work.id)
           expect(doc_ids).not_to include(other_work.id)
         end
       end
 
-      describe "specifying a collection to add" do
+      describe 'specifying a collection to add' do
         let(:incorporate_collection) { create(:collection) }
 
         before { get :index, add_files_to_collection: collection }
 
         subject { assigns(:incorporate_collection_presenter) }
 
-        context "when the collection exists" do
+        context 'when the collection exists' do
           let(:collection) { incorporate_collection.id }
           it { is_expected.to be_kind_of(CollectionPresenter) }
         end
 
-        context "with a null collection to add" do
+        context 'with a null collection to add' do
           let(:collection) { '' }
           it { is_expected.to be_nil }
         end
 
-        context "with a non-existent collection to add" do
+        context 'with a non-existent collection to add' do
           let(:collection) { 'idontexist' }
           it { is_expected.to be_nil }
         end
       end
     end
 
-    describe "term search" do
-      let!(:file_set) { build(:file_set, id: "fs") }
-      let!(:work)     { build(:public_work, :with_complete_metadata, members: [file_set], depositor: "archivist1", id: "1234") }
+    describe 'term search' do
+      let!(:file_set) { build(:file_set, id: 'fs') }
+      let!(:work)     { build(:public_work, :with_complete_metadata, members: [file_set], depositor: 'archivist1', id: '1234') }
 
       let(:file) { mock_file_factory(format_label: ['format_labelformat_label']) }
 
@@ -71,89 +71,89 @@ describe My::WorksController, type: :controller do
         index_file_set(file_set)
         index_work(work)
       end
-      it "finds a file by title" do
-        xhr :get, :index, q: "titletitle"
+      it 'finds a file by title' do
+        xhr :get, :index, q: 'titletitle'
         expect(response).to be_success
         expect(response).to render_template('my/index')
         expect(assigns(:document_list).count).to eql(1)
-        expect(assigns(:document_list)[0].fetch(solr_field("title"))[0]).to eql('titletitle')
+        expect(assigns(:document_list)[0].fetch(solr_field('title'))[0]).to eql('titletitle')
       end
-      it "finds a file by keyword" do
-        xhr :get, :index, q: "tagtag"
+      it 'finds a file by keyword' do
+        xhr :get, :index, q: 'tagtag'
         expect(response).to be_success
         expect(response).to render_template('my/index')
         expect(assigns(:document_list).count).to eql(1)
-        expect(assigns(:document_list)[0].fetch(solr_field("keyword"))[0]).to eql('tagtag')
+        expect(assigns(:document_list)[0].fetch(solr_field('keyword'))[0]).to eql('tagtag')
       end
-      it "finds a file by subject" do
-        xhr :get, :index, q: "subjectsubject"
+      it 'finds a file by subject' do
+        xhr :get, :index, q: 'subjectsubject'
         expect(response).to be_success
         expect(response).to render_template('my/index')
         expect(assigns(:document_list).count).to eql(1)
-        expect(assigns(:document_list)[0].fetch(solr_field("subject"))[0]).to eql('subjectsubject')
+        expect(assigns(:document_list)[0].fetch(solr_field('subject'))[0]).to eql('subjectsubject')
       end
-      it "finds a file by creator" do
-        xhr :get, :index, q: "creatorcreator"
+      it 'finds a file by creator' do
+        xhr :get, :index, q: 'creatorcreator'
         expect(response).to be_success
         expect(response).to render_template('my/index')
         expect(assigns(:document_list).count).to eql(1)
-        expect(assigns(:document_list)[0].fetch(solr_field("creator"))[0]).to eql('creatorcreator')
+        expect(assigns(:document_list)[0].fetch(solr_field('creator'))[0]).to eql('creatorcreator')
       end
-      it "finds a file by contributor" do
-        xhr :get, :index, q: "contributorcontributor"
+      it 'finds a file by contributor' do
+        xhr :get, :index, q: 'contributorcontributor'
         expect(response).to be_success
         expect(response).to render_template('my/index')
         expect(assigns(:document_list).count).to eql(1)
-        expect(assigns(:document_list)[0].fetch(solr_field("contributor"))[0]).to eql('contributorcontributor')
+        expect(assigns(:document_list)[0].fetch(solr_field('contributor'))[0]).to eql('contributorcontributor')
       end
-      it "finds a file by publisher" do
-        xhr :get, :index, q: "publisherpublisher"
+      it 'finds a file by publisher' do
+        xhr :get, :index, q: 'publisherpublisher'
         expect(response).to be_success
         expect(response).to render_template('my/index')
         expect(assigns(:document_list).count).to eql(1)
-        expect(assigns(:document_list)[0].fetch(solr_field("publisher"))[0]).to eql('publisherpublisher')
+        expect(assigns(:document_list)[0].fetch(solr_field('publisher'))[0]).to eql('publisherpublisher')
       end
-      it "finds a file by based_near" do
-        xhr :get, :index, q: "based_nearbased_near"
+      it 'finds a file by based_near' do
+        xhr :get, :index, q: 'based_nearbased_near'
         expect(response).to be_success
         expect(response).to render_template('my/index')
         expect(assigns(:document_list).count).to eql(1)
-        expect(assigns(:document_list)[0].fetch(solr_field("based_near"))[0]).to eql('based_nearbased_near')
+        expect(assigns(:document_list)[0].fetch(solr_field('based_near'))[0]).to eql('based_nearbased_near')
       end
-      it "finds a file by language" do
-        xhr :get, :index, q: "languagelanguage"
+      it 'finds a file by language' do
+        xhr :get, :index, q: 'languagelanguage'
         expect(response).to be_success
         expect(response).to render_template('my/index')
         expect(assigns(:document_list).count).to eql(1)
-        expect(assigns(:document_list)[0].fetch(solr_field("language"))[0]).to eql('languagelanguage')
+        expect(assigns(:document_list)[0].fetch(solr_field('language'))[0]).to eql('languagelanguage')
       end
-      it "finds a file by resource_type" do
-        xhr :get, :index, q: "resource_typeresource_type"
+      it 'finds a file by resource_type' do
+        xhr :get, :index, q: 'resource_typeresource_type'
         expect(response).to be_success
         expect(response).to render_template('my/index')
         expect(assigns(:document_list).count).to eql(1)
-        expect(assigns(:document_list)[0].fetch(solr_field("resource_type"))[0]).to eql('resource_typeresource_type')
+        expect(assigns(:document_list)[0].fetch(solr_field('resource_type'))[0]).to eql('resource_typeresource_type')
       end
-      it "finds a file by format_label" do
-        xhr :get, :index, q: "format_labelformat_label"
+      it 'finds a file by format_label' do
+        xhr :get, :index, q: 'format_labelformat_label'
         expect(response).to be_success
         expect(response).to render_template('my/index')
         expect(assigns(:document_list).count).to eql(1)
-        expect(assigns(:document_list)[0].fetch(solr_field("file_format"))[0]).to eql('plain (format_labelformat_label)')
+        expect(assigns(:document_list)[0].fetch(solr_field('file_format'))[0]).to eql('plain (format_labelformat_label)')
       end
-      it "finds a file by description" do
-        xhr :get, :index, q: "descriptiondescription"
+      it 'finds a file by description' do
+        xhr :get, :index, q: 'descriptiondescription'
         expect(response).to be_success
         expect(response).to render_template('my/index')
         expect(assigns(:document_list).count).to eql(1)
-        expect(assigns(:document_list)[0].fetch(solr_field("description"))[0]).to eql('descriptiondescription')
+        expect(assigns(:document_list)[0].fetch(solr_field('description'))[0]).to eql('descriptiondescription')
       end
     end
   end
 
-  describe "not logged in as a user" do
-    describe "#index" do
-      it "returns an error" do
+  describe 'not logged in as a user' do
+    describe '#index' do
+      it 'returns an error' do
         xhr :post, :index
         expect(response).not_to be_success
       end

--- a/spec/controllers/qa/terms_controller_spec.rb
+++ b/spec/controllers/qa/terms_controller_spec.rb
@@ -6,29 +6,29 @@ describe Qa::TermsController do
   # local table-based language and subject authorities with Scholarsphere.
   routes { Qa::Engine.routes }
 
-  describe "#search" do
+  describe '#search' do
     subject { response }
 
-    context "with languages" do
-      let(:parameters) { { "q" => "Alu", "vocab" => "local", "subauthority" => "languages" } }
+    context 'with languages' do
+      let(:parameters) { { 'q' => 'Alu', 'vocab' => 'local', 'subauthority' => 'languages' } }
 
       before do
-        LanguageAuthorityImportJob.perform_now(File.join(fixture_path, "lexvo_snippet.rdf"))
+        LanguageAuthorityImportJob.perform_now(File.join(fixture_path, 'lexvo_snippet.rdf'))
         get :search, parameters
       end
 
-      its(:body) { is_expected.to eq("[{\"id\":\"http://lexvo.org/id/iso639-3/aab\",\"label\":\"Alumu-Tesu\"}]") }
+      its(:body) { is_expected.to eq('[{"id":"http://lexvo.org/id/iso639-3/aab","label":"Alumu-Tesu"}]') }
     end
 
-    context "with subjects" do
-      let(:parameters) { { "q" => "Rio", "vocab" => "local", "subauthority" => "subjects" } }
+    context 'with subjects' do
+      let(:parameters) { { 'q' => 'Rio', 'vocab' => 'local', 'subauthority' => 'subjects' } }
 
       before do
-        SubjectAuthorityImportJob.perform_now(File.join(fixture_path, "loc_subjects_snippet.rdfxml.skos"))
+        SubjectAuthorityImportJob.perform_now(File.join(fixture_path, 'loc_subjects_snippet.rdfxml.skos'))
         get :search, parameters
       end
 
-      its(:body) { is_expected.to eq("[{\"id\":\"http://id.loc.gov/authorities/subjects/sh00000024\",\"label\":\"Rio Oscuro (N.M.)\"}]") }
+      its(:body) { is_expected.to eq('[{"id":"http://id.loc.gov/authorities/subjects/sh00000024","label":"Rio Oscuro (N.M.)"}]') }
     end
   end
 end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -2,35 +2,35 @@
 require 'rails_helper'
 
 describe SessionsController, type: :controller do
-  describe "routing" do
-    it "sends /logout to sessions#destroy" do
+  describe 'routing' do
+    it 'sends /logout to sessions#destroy' do
       expect(get: '/logout').to route_to(controller: 'sessions', action: 'destroy')
       expect(destroy_user_session_path).to eq('/logout')
     end
-    it "sends /login to sessions#new" do
+    it 'sends /login to sessions#new' do
       expect(get: '/login_session').to route_to(controller: 'sessions', action: 'new')
       expect(new_user_session_path).to eq('/login_session')
     end
   end
-  describe "#destroy" do
-    it "redirects to the central logout page and destroy the cookie" do
+  describe '#destroy' do
+    it 'redirects to the central logout page and destroy the cookie' do
       request.env['COSIGN_SERVICE'] = 'cosign-gamma-ci.dlt.psu.edu'
       expect(cookies).to receive(:delete).with('cosign-gamma-ci.dlt.psu.edu')
       get :destroy
       expect(response).to redirect_to Sufia::Engine.config.logout_url
     end
   end
-  describe "#new" do
-    it "redirects to the central login page" do
+  describe '#new' do
+    it 'redirects to the central login page' do
       get :new
       expect(response).to redirect_to Sufia::Engine.config.login_url
     end
 
-    context "when user_return_to is set" do
-      it "does not redirect to the central login page" do
-        session["user_return_to"] = "http://return_to_me"
+    context 'when user_return_to is set' do
+      it 'does not redirect to the central login page' do
+        session['user_return_to'] = 'http://return_to_me'
         get :new
-        expect(response.redirect_url).to include "http://return_to_me"
+        expect(response.redirect_url).to include 'http://return_to_me'
       end
     end
   end

--- a/spec/controllers/sufia/batch_uploads_controller_spec.rb
+++ b/spec/controllers/sufia/batch_uploads_controller_spec.rb
@@ -4,13 +4,13 @@ require 'rails_helper'
 describe Sufia::BatchUploadsController do
   its(:form_class) { is_expected.to eq(::BatchUploadForm) }
 
-  describe "#create" do
+  describe '#create' do
     routes { Sufia::Engine.routes }
     let(:user) { create(:user) }
 
     before { sign_in user }
 
-    context "queuing a update job" do
+    context 'queuing a update job' do
       let(:expected_types)             { { '1' => 'Article' } }
       let(:expected_individual_params) { { '1' => 'foo' } }
 
@@ -23,11 +23,11 @@ describe Sufia::BatchUploadsController do
           title: { '1' => 'foo' },
           resource_type: { '1' => 'Article' },
           uploaded_files: ['1'],
-          batch_upload_item: { keyword: [""], visibility: 'open' }
+          batch_upload_item: { keyword: [''], visibility: 'open' }
         )
       end
 
-      it "is successful" do
+      it 'is successful' do
         expect(BatchCreateJob).to receive(:perform_later)
           .with(user,
                 expected_individual_params,
@@ -36,39 +36,39 @@ describe Sufia::BatchUploadsController do
                 Sufia::BatchCreateOperation)
         post :create, params
         expect(response).to redirect_to Sufia::Engine.routes.url_helpers.dashboard_works_path
-        expect(flash[:notice]).to include("Your files are being processed")
+        expect(flash[:notice]).to include('Your files are being processed')
       end
     end
 
-    context "when providing a collection" do
+    context 'when providing a collection' do
       let(:params) do
         ActionController::Parameters.new(
           title: { '1' => 'foo' },
           resource_type: { '1' => 'Article' },
           uploaded_files: ['1'],
-          batch_upload_item: { keyword: [""], visibility: 'open', collection_ids: ["collection-id"] }
+          batch_upload_item: { keyword: [''], visibility: 'open', collection_ids: ['collection-id'] }
         )
       end
 
       before { allow(BatchCreateJob).to receive(:perform_later) }
 
-      it "redirects to the collection show page" do
+      it 'redirects to the collection show page' do
         post :create, params
-        expect(response).to redirect_to("/collections/collection-id")
-        expect(flash[:notice]).to include("Your files are being processed")
+        expect(response).to redirect_to('/collections/collection-id')
+        expect(flash[:notice]).to include('Your files are being processed')
       end
     end
   end
 
-  describe "#uploading_on_behalf_of?" do
+  describe '#uploading_on_behalf_of?' do
     subject { described_class.new }
     before { allow(subject).to receive(:hash_key_for_curation_concern).and_return(:generic_work) }
-    context "without a proxy" do
+    context 'without a proxy' do
       before { allow(subject).to receive(:params).and_return(generic_work: {}) }
       its(:uploading_on_behalf_of?) { is_expected.to be false }
     end
-    context "with a proxy" do
-      before { allow(subject).to receive(:params).and_return(generic_work: { on_behalf_of: "joe" }) }
+    context 'with a proxy' do
+      before { allow(subject).to receive(:params).and_return(generic_work: { on_behalf_of: 'joe' }) }
       its(:uploading_on_behalf_of?) { is_expected.to be true }
     end
   end

--- a/spec/controllers/sufia/homepage_controller_spec.rb
+++ b/spec/controllers/sufia/homepage_controller_spec.rb
@@ -4,5 +4,5 @@ require 'rails_helper'
 describe Sufia::HomepageController do
   subject { described_class.new }
 
-  its(:sort_field) { is_expected.to eq("date_uploaded_dtsi desc") }
+  its(:sort_field) { is_expected.to eq('date_uploaded_dtsi desc') }
 end

--- a/spec/controllers/zotero_controller_spec.rb
+++ b/spec/controllers/zotero_controller_spec.rb
@@ -13,7 +13,7 @@ describe API::ZoteroController, type: :controller do
 
       specify do
         expect(subject).to have_http_status(302)
-        expect(subject).to redirect_to("https://webaccess.psu.edu/?cosign-localhost&https://localhost")
+        expect(subject).to redirect_to('https://webaccess.psu.edu/?cosign-localhost&https://localhost')
       end
     end
 
@@ -82,7 +82,7 @@ describe API::ZoteroController, type: :controller do
 
       specify do
         expect(subject).to have_http_status(302)
-        expect(subject).to redirect_to("https://webaccess.psu.edu/?cosign-localhost&https://localhost")
+        expect(subject).to redirect_to('https://webaccess.psu.edu/?cosign-localhost&https://localhost')
       end
     end
 

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -15,24 +15,24 @@ FactoryGirl.define do
     end
 
     factory :my_collection do
-      title ["My collection"]
-      description "My incredibly detailed description of the collection"
-      creator ["The Collector"]
+      title ['My collection']
+      description 'My incredibly detailed description of the collection'
+      creator ['The Collector']
     end
 
     trait :with_complete_metadata do
-      creator ["Joe Contributor"]
-      resource_type ["Dissertation aaa"]
-      publisher ["publisher bbb"]
-      contributor ["contrib ccc"]
-      subject ["subject ddd"]
-      language ["language fff"]
-      based_near ["based_near ggg"]
-      keyword ["keyword hhh"]
-      rights ["http://creativecommons.org/licenses/by/3.0/us/"]
-      date_created ["Once upon a time"]
-      identifier ["112243465"]
-      related_url ["http://test.com"]
+      creator ['Joe Contributor']
+      resource_type ['Dissertation aaa']
+      publisher ['publisher bbb']
+      contributor ['contrib ccc']
+      subject ['subject ddd']
+      language ['language fff']
+      based_near ['based_near ggg']
+      keyword ['keyword hhh']
+      rights ['http://creativecommons.org/licenses/by/3.0/us/']
+      date_created ['Once upon a time']
+      identifier ['112243465']
+      related_url ['http://test.com']
     end
   end
 end

--- a/spec/factories/file_sets.rb
+++ b/spec/factories/file_sets.rb
@@ -16,34 +16,34 @@ FactoryGirl.define do
     end
 
     trait :public do
-      read_groups ["public"]
+      read_groups ['public']
     end
 
     trait :registered do
-      read_groups ["registered"]
+      read_groups ['registered']
     end
 
     trait :with_png do
       transient do
-        id "fixturepng"
+        id 'fixturepng'
       end
       initialize_with { new(id: id) }
-      title ["fake_image.png"]
+      title ['fake_image.png']
       before(:create) do |fs|
-        fs.title = ["Sample PNG"]
+        fs.title = ['Sample PNG']
       end
     end
 
     trait :pdf do
-      title ["fake_document.pdf"]
+      title ['fake_document.pdf']
       before(:create) do |fs|
-        fs.title = ["Fake PDF Title"]
+        fs.title = ['Fake PDF Title']
       end
     end
 
     trait :with_file_size do
       after(:build) do |fs|
-        allow(fs).to receive(:file_size).and_return("1234")
+        allow(fs).to receive(:file_size).and_return('1234')
       end
     end
   end

--- a/spec/factories/operations.rb
+++ b/spec/factories/operations.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 FactoryGirl.define do
   factory :operation, class: CurationConcerns::Operation do
-    operation_type "Test operation"
+    operation_type 'Test operation'
 
     trait :failing do
       status CurationConcerns::Operation::FAILURE
@@ -16,7 +16,7 @@ FactoryGirl.define do
     end
 
     factory :batch_create_operation, class: Sufia::BatchCreateOperation do
-      operation_type "Batch Create"
+      operation_type 'Batch Create'
     end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -85,7 +85,7 @@ FactoryGirl.define do
 
     trait :with_two_groups do
       after(:create) do |u|
-        group_list_array = ["umg/up.dlt.scholarsphere-admin.admin1", "umg/up.dlt.scholarsphere-admin.admin2"]
+        group_list_array = ['umg/up.dlt.scholarsphere-admin.admin1', 'umg/up.dlt.scholarsphere-admin.admin2']
         u.update_attribute :group_list, group_list_array.join(';?;')
         u.update_attribute :groups_last_update, Time.now
       end

--- a/spec/factories/works.rb
+++ b/spec/factories/works.rb
@@ -8,9 +8,9 @@ FactoryGirl.define do
       file_name nil
     end
 
-    title ["Sample Title"]
+    title ['Sample Title']
     after(:build) do |file, attrs|
-      file.apply_depositor_metadata((attrs.depositor || "user"))
+      file.apply_depositor_metadata((attrs.depositor || 'user'))
     end
 
     after(:create) do |file, attrs|
@@ -23,9 +23,9 @@ FactoryGirl.define do
       visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
 
       factory :share_file do
-        title ["SHARE Document"]
-        creator ["Joe Contributor"]
-        resource_type ["Dissertation"]
+        title ['SHARE Document']
+        creator ['Joe Contributor']
+        resource_type ['Dissertation']
       end
 
       factory :featured_file do
@@ -55,7 +55,7 @@ FactoryGirl.define do
       after(:create) do |work, attributes|
         fs = FactoryGirl.create(:file_set,
                                 user: User.find_by_login(work.depositor),
-                                title: ["A contained PNG file"],
+                                title: ['A contained PNG file'],
                                 label: 'world.png',
                                 visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)
 
@@ -78,12 +78,12 @@ FactoryGirl.define do
       after(:create) do |work, attributes|
         fs = FactoryGirl.create(:file_set,
                                 user: attributes.user,
-                                title: ["A contained MP3 file"],
+                                title: ['A contained MP3 file'],
                                 label: 'scholarsphere_test5.mp3',
                                 visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)
 
         filename = "#{Rails.root}/spec/fixtures/scholarsphere/scholarsphere_test5.mp3"
-        local_file = File.open(filename, "rb")
+        local_file = File.open(filename, 'rb')
         Hydra::Works::AddFileToFileSet.call(fs, local_file, :original_file, versioning: false)
         fs.save!
         work.ordered_members << fs
@@ -95,7 +95,7 @@ FactoryGirl.define do
       before(:create) do |work, evaluator|
         fs = FactoryGirl.create(:file_set,
                                 user: evaluator.user,
-                                title: (evaluator.file_title || ["A Contained File"]),
+                                title: (evaluator.file_title || ['A Contained File']),
                                 label: (evaluator.file_name || 'filename.pdf'))
         work.ordered_members << fs
         work.thumbnail_id = fs.id
@@ -106,7 +106,7 @@ FactoryGirl.define do
       before(:create) do |work, evaluator|
         fs = FactoryGirl.create(:file_set, :with_file_size,
                                 user: evaluator.user,
-                                title: (evaluator.file_title || ["A Contained File"]),
+                                title: (evaluator.file_title || ['A Contained File']),
                                 label: (evaluator.file_name || 'filename.pdf'))
         work.ordered_members << fs
         work.thumbnail_id = fs.id
@@ -115,7 +115,7 @@ FactoryGirl.define do
 
     trait :with_full_text_content do
       after(:build) do |f|
-        f.full_text.content = "full_textfull_text"
+        f.full_text.content = 'full_textfull_text'
       end
     end
 

--- a/spec/features/authentication_spec.rb
+++ b/spec/features/authentication_spec.rb
@@ -18,9 +18,9 @@ describe 'Site authentication', type: :feature do
     end
     describe 'And I try to upload a file' do
       specify 'It should take me back to the upload page after I have logged in' do
-        pending("Need to apply configuration changes to login_url")
+        pending('Need to apply configuration changes to login_url')
         visit '/concern/generic_works/new'
-        expect(unescape(current_url)).to eq(centralized_login_url.gsub(/dashboard/, "concern/generic_works/new"))
+        expect(unescape(current_url)).to eq(centralized_login_url.gsub(/dashboard/, 'concern/generic_works/new'))
       end
     end
   end

--- a/spec/features/batch_edit_spec.rb
+++ b/spec/features/batch_edit_spec.rb
@@ -1,23 +1,23 @@
 # frozen_string_literal: true
-require "feature_spec_helper"
+require 'feature_spec_helper'
 
-describe "Batch management of works", type: :feature do
+describe 'Batch management of works', type: :feature do
   let(:current_user) { create(:user) }
   let!(:work1)       { create(:public_work, :with_complete_metadata, depositor: current_user.login) }
   let!(:work2)       { create(:public_work, :with_complete_metadata, depositor: current_user.login) }
 
   before do
     sign_in_with_named_js(:batch_edit, current_user, disable_animations: true)
-    visit "/dashboard/works"
+    visit '/dashboard/works'
   end
 
-  context "when editing and viewing multiple works" do
+  context 'when editing and viewing multiple works' do
     before do
-      check("check_all")
-      click_on("batch-edit")
+      check('check_all')
+      click_on('batch-edit')
     end
 
-    it "edits a field and displays the changes", js: true do
+    it 'edits a field and displays the changes', js: true do
       batch_edit_fields.each do |field|
         fill_in_batch_edit_field(field, with: "Updated batch #{field}")
       end
@@ -30,8 +30,8 @@ describe "Batch management of works", type: :feature do
     end
 
     it "displays the field's existing value" do
-      within("textarea#batch_edit_item_description") do
-        expect(page).to have_content("descriptiondescription")
+      within('textarea#batch_edit_item_description') do
+        expect(page).to have_content('descriptiondescription')
       end
       expect(page).to have_css "input#batch_edit_item_contributor[value*='contributorcontributor']"
       expect(page).to have_css "input#batch_edit_item_keyword[value*='tagtag']"
@@ -41,16 +41,16 @@ describe "Batch management of works", type: :feature do
       expect(page).to have_css "input#batch_edit_item_publisher[value*='publisherpublisher']"
       expect(page).to have_css "input#batch_edit_item_subject[value*='subjectsubject']"
       expect(page).to have_css "input#batch_edit_item_related_url[value*='http://example.org/TheRelatedURLLink/']"
-      expect(page).to have_no_checked_field("Private")
+      expect(page).to have_no_checked_field('Private')
       expect(page).to have_content(I18n.t('scholarsphere.batch_edit.permissions_warning'))
     end
   end
 
-  context "when selecting multiple works for deletion", js: true do
+  context 'when selecting multiple works for deletion', js: true do
     subject { GenericWork.count }
     before do
-      check "check_all"
-      click_button "Delete Selected"
+      check 'check_all'
+      click_button 'Delete Selected'
     end
     it { is_expected.to be_zero }
   end

--- a/spec/features/catalog_search_spec.rb
+++ b/spec/features/catalog_search_spec.rb
@@ -4,27 +4,27 @@ require 'feature_spec_helper'
 describe 'catalog searching', type: :feature do
   let(:user)   { create(:jill) }
 
-  let!(:work1) { build(:public_work, id: "pw1",
+  let!(:work1) { build(:public_work, id: 'pw1',
                                      depositor: user.login,
                                      title: ['title 1'],
                                      description: ['first work'],
                                      date_created: ['just now'],
-                                     keyword: ["tag1", "tag2"]) }
+                                     keyword: ['tag1', 'tag2']) }
 
-  let!(:work2) { build(:public_work, id: "pw2",
+  let!(:work2) { build(:public_work, id: 'pw2',
                                      depositor: user.login,
                                      title: ['title 2'],
                                      description: ['second work'],
                                      date_created: ['just now'],
-                                     keyword: ["tag2", "tag3"]) }
+                                     keyword: ['tag2', 'tag3']) }
 
-  let!(:work3) { build(:public_work, id: "pw3",
+  let!(:work3) { build(:public_work, id: 'pw3',
                                      depositor: user.login,
                                      title: ['title 3'],
                                      date_created: ['just now'],
-                                     keyword: ["tag3", "tag4"]) }
+                                     keyword: ['tag3', 'tag4']) }
 
-  let!(:collection) { build(:collection, id: "coll1", depositor: user.login, keyword: ["tag3", "tag4"]) }
+  let!(:collection) { build(:collection, id: 'coll1', depositor: user.login, keyword: ['tag3', 'tag4']) }
 
   before do
     index_works_and_collections(work1, work2, work3, collection)
@@ -32,36 +32,36 @@ describe 'catalog searching', type: :feature do
     visit '/'
   end
 
-  it "shows the facets" do
+  it 'shows the facets' do
     within('#search-form-header') do
-      click_button("Go")
+      click_button('Go')
     end
-    expect(page).to have_css "div#facets"
+    expect(page).to have_css 'div#facets'
   end
 
-  it "finds multiple files" do
+  it 'finds multiple files' do
     within('#search-form-header') do
-      fill_in('search-field-header', with: "tag2")
-      click_button("Go")
+      fill_in('search-field-header', with: 'tag2')
+      click_button('Go')
     end
 
     # All fields are displayed in the list view
-    expect(page).to have_selector('h1', text: "Search Results")
+    expect(page).to have_selector('h1', text: 'Search Results')
     expect(page).to have_selector('fieldset')
-    expect(page).to have_selector('legend', text: "Sort Results")
-    expect(page).to have_selector('legend', text: "Number of results to display per page")
-    expect(page).to have_selector('legend', text: "View results as:")
-    expect(page).to have_selector('h2', text: "Listing of Search Results")
-    within("#search-results") do
+    expect(page).to have_selector('legend', text: 'Sort Results')
+    expect(page).to have_selector('legend', text: 'Number of results to display per page')
+    expect(page).to have_selector('legend', text: 'View results as:')
+    expect(page).to have_selector('h2', text: 'Listing of Search Results')
+    within('#search-results') do
       expect(page).to have_link(work1.title.first)
       expect(page).to have_link(work2.title.first)
       expect(page).not_to have_content(collection.title)
-      expect(page).not_to have_content("Title:")
+      expect(page).not_to have_content('Title:')
     end
 
     # Not all fields should be displayed in the gallery view
-    click_link("Gallery")
-    within("#documents") do
+    click_link('Gallery')
+    within('#documents') do
       expect(page).to have_link(work1.title.first)
       expect(page).to have_link(work2.title.first)
       expect(page).not_to have_content(work1.keyword.first)
@@ -69,17 +69,17 @@ describe 'catalog searching', type: :feature do
       expect(page).not_to have_content(work2.keyword.first)
       expect(page).not_to have_content(work2.keyword.last)
       expect(page).not_to have_content(collection.title)
-      expect(page).not_to have_button("Bookmark")
+      expect(page).not_to have_button('Bookmark')
     end
 
-    expect(page).not_to have_selector("a.view-type-masonry")
-    expect(page).not_to have_selector("a.view-type-slideshow")
+    expect(page).not_to have_selector('a.view-type-masonry')
+    expect(page).not_to have_selector('a.view-type-slideshow')
   end
 
-  it "finds files and collections" do
+  it 'finds files and collections' do
     within('#search-form-header') do
-      fill_in('search-field-header', with: "tag3")
-      click_button("Go")
+      fill_in('search-field-header', with: 'tag3')
+      click_button('Go')
     end
     expect(page).to have_content('Search Results')
     expect(page).to have_content(collection.title.first)
@@ -87,10 +87,10 @@ describe 'catalog searching', type: :feature do
     expect(page).not_to have_content(work1.title.first)
   end
 
-  it "finds collections" do
+  it 'finds collections' do
     within('#search-form-header') do
-      fill_in('search-field-header', with: "tag4")
-      click_button("Go")
+      fill_in('search-field-header', with: 'tag4')
+      click_button('Go')
     end
     expect(page).to have_content('Search Results')
     expect(page).to have_content(collection.title.first)

--- a/spec/features/collection/create_spec.rb
+++ b/spec/features/collection/create_spec.rb
@@ -5,97 +5,97 @@ include Selectors::Dashboard
 
 describe Collection, type: :feature do
   let(:current_user) { create(:user) }
-  let(:title)        { "Test Collection Title" }
+  let(:title)        { 'Test Collection Title' }
 
   before { sign_in_with_js(current_user) }
 
-  describe "creating a new collection from the dashboard" do
-    it "displays the new collection page" do
+  describe 'creating a new collection from the dashboard' do
+    it 'displays the new collection page' do
       go_to_dashboard
       db_create_empty_collection_button.click
-      expect(page).to have_content("Create New Collection")
-      within("div#descriptions_display") do
-        expect(page).to have_selector("label", class: "required", text: "Title")
-        expect(page).to have_selector("label", class: "required", text: "Description")
-        expect(page).to have_selector("label", class: "required", text: "Keyword")
+      expect(page).to have_content('Create New Collection')
+      within('div#descriptions_display') do
+        expect(page).to have_selector('label', class: 'required', text: 'Title')
+        expect(page).to have_selector('label', class: 'required', text: 'Description')
+        expect(page).to have_selector('label', class: 'required', text: 'Keyword')
       end
-      within("div.collection_form_visibility") do
-        expect(find("input#visibility_open")).to be_checked
+      within('div.collection_form_visibility') do
+        expect(find('input#visibility_open')).to be_checked
       end
     end
   end
 
-  describe "creating new collections" do
+  describe 'creating new collections' do
     before do
       visit(new_collection_path)
-      fill_in "Title", with: title
-      fill_in "Description", with: "description"
-      fill_in "Keyword", with: "keyword"
+      fill_in 'Title', with: title
+      fill_in 'Description', with: 'description'
+      fill_in 'Keyword', with: 'keyword'
     end
 
-    context "without any files" do
-      it "creates an empty collection" do
-        click_button "Create Empty Collection"
-        expect(page).to have_content("Collection was successfully created.")
+    context 'without any files' do
+      it 'creates an empty collection' do
+        click_button 'Create Empty Collection'
+        expect(page).to have_content('Collection was successfully created.')
         expect(page).to have_content(title)
       end
     end
 
-    context "when adding existing works" do
-      let!(:file1) { create(:file, title: ["First file"], depositor: current_user.login) }
-      let!(:file2) { create(:file, title: ["Second file"], depositor: current_user.login) }
+    context 'when adding existing works' do
+      let!(:file1) { create(:file, title: ['First file'], depositor: current_user.login) }
+      let!(:file2) { create(:file, title: ['Second file'], depositor: current_user.login) }
 
-      it "adds existing works after the collection is created" do
-        click_button "Create Collection and Add Existing Works"
-        expect(page).to have_content("Collection was successfully created.")
-        check "check_all"
+      it 'adds existing works after the collection is created' do
+        click_button 'Create Collection and Add Existing Works'
+        expect(page).to have_content('Collection was successfully created.')
+        check 'check_all'
         click_button "Add to #{title}"
         expect(page).to have_content(title)
-        within("dl.metadata-collections") do
-          expect(page).to have_content("Total Items")
-          expect(page).to have_content("2")
+        within('dl.metadata-collections') do
+          expect(page).to have_content('Total Items')
+          expect(page).to have_content('2')
         end
-        within("table.table-striped") do
-          expect(page).to have_content("First file")
-          expect(page).to have_content("Second file")
+        within('table.table-striped') do
+          expect(page).to have_content('First file')
+          expect(page).to have_content('Second file')
         end
       end
     end
 
-    context "when adding new works" do
-      it "creates new works after the collection is created" do
-        click_button "Create Collection and Upload Works"
-        expect(page).to have_content("Collection was successfully created.")
-        expect(page).to have_content("Add Multiple New Works")
-        within("ul.nav-tabs") { click_link("Collections") }
-        expect(page).to have_select("batch_upload_item_collection_ids", selected: title)
+    context 'when adding new works' do
+      it 'creates new works after the collection is created' do
+        click_button 'Create Collection and Upload Works'
+        expect(page).to have_content('Collection was successfully created.')
+        expect(page).to have_content('Add Multiple New Works')
+        within('ul.nav-tabs') { click_link('Collections') }
+        expect(page).to have_select('batch_upload_item_collection_ids', selected: title)
       end
     end
   end
 
-  describe "selecting files from the dashboard" do
-    let!(:file1) { create(:file, title: ["First file"], depositor: current_user.login) }
-    let!(:file2) { create(:file, title: ["Second file"], depositor: current_user.login) }
+  describe 'selecting files from the dashboard' do
+    let!(:file1) { create(:file, title: ['First file'], depositor: current_user.login) }
+    let!(:file2) { create(:file, title: ['Second file'], depositor: current_user.login) }
 
-    it "creates a new collection using the selected files" do
+    it 'creates a new collection using the selected files' do
       go_to_dashboard_works
-      check "check_all"
-      click_button "Add to Collection"
+      check 'check_all'
+      click_button 'Add to Collection'
       db_create_populated_collection_button.click
-      fill_in "Title", with: title
-      fill_in "Description", with: "description"
-      fill_in "Keyword", with: "keyword"
-      within("div.primary-actions") do
-        expect(page).not_to have_button("Create Empty Collection")
-        expect(page).not_to have_button("Create Collection and Upload Works")
-        expect(page).not_to have_button("Create Collection and Add Existing Works")
+      fill_in 'Title', with: title
+      fill_in 'Description', with: 'description'
+      fill_in 'Keyword', with: 'keyword'
+      within('div.primary-actions') do
+        expect(page).not_to have_button('Create Empty Collection')
+        expect(page).not_to have_button('Create Collection and Upload Works')
+        expect(page).not_to have_button('Create Collection and Add Existing Works')
       end
-      within("table.table-striped") do
-        expect(page).to have_content("First file")
-        expect(page).to have_content("Second file")
+      within('table.table-striped') do
+        expect(page).to have_content('First file')
+        expect(page).to have_content('Second file')
       end
-      click_button("Create New Collection")
-      expect(page).to have_content "Collection was successfully created."
+      click_button('Create New Collection')
+      expect(page).to have_content 'Collection was successfully created.'
       expect(page).to have_content file1.title.first
       expect(page).to have_content file2.title.first
     end

--- a/spec/features/collection/delete_spec.rb
+++ b/spec/features/collection/delete_spec.rb
@@ -17,10 +17,10 @@ describe Collection, type: :feature do
       db_item_actions_toggle(collection).click
       click_link 'Delete Collection'
       expect(page).to have_content 'Collection was successfully deleted'
-      within("#my_nav") do
-        expect(page).to have_content("My Collections")
+      within('#my_nav') do
+        expect(page).to have_content('My Collections')
       end
-      within("#documents") do
+      within('#documents') do
         expect(page).not_to have_content title
       end
     end

--- a/spec/features/collection/edit_spec.rb
+++ b/spec/features/collection/edit_spec.rb
@@ -8,8 +8,8 @@ describe Collection, type: :feature do
   let(:work1)        { create(:work, depositor: current_user.login, title: ['world.png']) }
   let(:work2)        { create(:work, depositor: current_user.login, title: ['little_file.txt']) }
 
-  context "when the collection has files" do
-    let!(:collection) { create(:collection, depositor: current_user.login, members: [work1, work2], description: ["my description"]) }
+  context 'when the collection has files' do
+    let!(:collection) { create(:collection, depositor: current_user.login, members: [work1, work2], description: ['my description']) }
     let!(:work3)      { create(:work, title: ['scholarsphere_test5.txt'], depositor: current_user.login) }
 
     before { sign_in_with_js(current_user) }
@@ -20,7 +20,7 @@ describe Collection, type: :feature do
         db_file_checkbox(work3).click
         click_button 'Add to Collection'
         db_collection_radio_button(collection).click
-        within("#collection-list-container .modal-footer") do
+        within('#collection-list-container .modal-footer') do
           click_button 'Add to Collection'
         end
         expect(page).to have_content 'Collection was successfully updated.'
@@ -60,7 +60,7 @@ describe Collection, type: :feature do
   end
 
   describe "editing a collection's metadata" do
-    let!(:collection)           { create(:collection, depositor: current_user.login, description: ["original description"]) }
+    let!(:collection)           { create(:collection, depositor: current_user.login, description: ['original description']) }
     let!(:original_title)       { collection.title }
     let!(:original_description) { collection.description }
 
@@ -77,11 +77,11 @@ describe Collection, type: :feature do
       click_link 'Additional fields'
       expect(page).to have_field 'collection_title', with: original_title.first
       expect(page).to have_field 'collection_description', with: original_description.first
-      within("div.collection_date_created") do
-        expect(page).to have_content("Published Date")
+      within('div.collection_date_created') do
+        expect(page).to have_content('Published Date')
       end
-      expect(page).to have_checked_field("Public")
-      expect(page).to have_no_checked_field("Private")
+      expect(page).to have_checked_field('Public')
+      expect(page).to have_no_checked_field('Private')
       fill_in 'Title', with: updated_title
       fill_in 'Description', with: updated_description
       fill_in 'Creator', with: updated_creators.first
@@ -94,8 +94,8 @@ describe Collection, type: :feature do
     end
   end
 
-  context "when adding works" do
-    let(:collection) { create(:collection, depositor: current_user.login, title: ["Special collection"]) }
+  context 'when adding works' do
+    let(:collection) { create(:collection, depositor: current_user.login, title: ['Special collection']) }
 
     before do
       sign_in_with_js(current_user)
@@ -103,20 +103,20 @@ describe Collection, type: :feature do
     end
 
     describe 'adding existing works' do
-      let!(:work4) { create(:work, depositor: current_user.login, title: ["Work to add"]) }
+      let!(:work4) { create(:work, depositor: current_user.login, title: ['Work to add']) }
       specify do
-        click_link("Add existing works")
-        check "check_all"
+        click_link('Add existing works')
+        check 'check_all'
         expect(page).to have_button("Add to #{collection.title.first}")
       end
     end
 
     describe 'adding new works' do
       specify do
-        click_link("Add new works")
-        expect(page).to have_content("Add Multiple New Works")
-        within("ul.nav-tabs") { click_link("Collections") }
-        expect(page).to have_select("batch_upload_item_collection_ids", selected: collection.title.first)
+        click_link('Add new works')
+        expect(page).to have_content('Add Multiple New Works')
+        within('ul.nav-tabs') { click_link('Collections') }
+        expect(page).to have_select('batch_upload_item_collection_ids', selected: collection.title.first)
       end
     end
   end

--- a/spec/features/collection/view_and_search_spec.rb
+++ b/spec/features/collection/view_and_search_spec.rb
@@ -6,18 +6,18 @@ include Selectors::Dashboard
 
 describe Collection, type: :feature do
   let!(:collection)  { create(:public_collection, :with_complete_metadata,
-                              creator: ["somebody"],
+                              creator: ['somebody'],
                               depositor: current_user.login,
                               members: [file1, file2]) }
 
   let(:current_user) { create(:user) }
 
   let(:file1)        { create(:public_file, :with_one_file_and_size,
-                              title: ["world.png"],
+                              title: ['world.png'],
                               depositor: current_user.login) }
 
   let(:file2)        { create(:private_file, :with_one_file_and_size,
-                              title: ["little_file.txt"],
+                              title: ['little_file.txt'],
                               depositor: current_user.login) }
 
   context 'with a logged in user' do
@@ -33,11 +33,11 @@ describe Collection, type: :feature do
         expect(page).to have_content collection.creator.first
         expect(page).to have_content file1.title.first
         expect(page).to have_content file2.title.first
-        expect(page).to have_content "Total Items 2"
-        expect(page).to have_content "Size 2 Bytes"
+        expect(page).to have_content 'Total Items 2'
+        expect(page).to have_content 'Size 2 Bytes'
 
-        within("dl.metadata-collections") do
-          expect(page).to have_content("Published Date")
+        within('dl.metadata-collections') do
+          expect(page).to have_content('Published Date')
         end
         go_to_dashboard_works
 
@@ -45,8 +45,8 @@ describe Collection, type: :feature do
         # has been completed. Or totally remove the commented test if the ticket is closed.
         # expect(page).to have_content "Is part of: #{collection.title}"
 
-        expect(page).to have_link("My Works")
-        expect(page).to have_link("My Collections")
+        expect(page).to have_link('My Works')
+        expect(page).to have_link('My Collections')
       end
     end
 
@@ -68,24 +68,24 @@ describe Collection, type: :feature do
 
     describe 'adding existing works' do
       specify do
-        click_link("Add existing works")
-        check "check_all"
+        click_link('Add existing works')
+        check 'check_all'
         expect(page).to have_button("Add to #{collection.title.first}")
       end
     end
 
     describe 'adding new works' do
       specify do
-        click_link("Add new works")
-        expect(page).to have_content("Add Multiple New Works")
-        within("ul.nav-tabs") { click_link("Collections") }
-        expect(page).to have_select("batch_upload_item_collection_ids", selected: collection.title.first)
+        click_link('Add new works')
+        expect(page).to have_content('Add Multiple New Works')
+        within('ul.nav-tabs') { click_link('Collections') }
+        expect(page).to have_select('batch_upload_item_collection_ids', selected: collection.title.first)
       end
     end
   end
 
   context 'with a public user' do
-    it "displays the collection and only public files" do
+    it 'displays the collection and only public files' do
       visit "/collections/#{collection.id}"
       expect(page.status_code).to eql(200)
       expect(page).to have_content collection.title.first

--- a/spec/features/contact_form_spec.rb
+++ b/spec/features/contact_form_spec.rb
@@ -2,13 +2,13 @@
 require 'feature_spec_helper'
 
 describe 'Contact form:', type: :feature do
-  let(:email)         { "archivist1@example.com" }
-  let(:email_subject) { "My Subject is Cool" }
+  let(:email)         { 'archivist1@example.com' }
+  let(:email_subject) { 'My Subject is Cool' }
   let(:user)          { create(:user, email: email) }
   let(:sent_messages) { ActionMailer::Base.deliveries }
   let(:admin_message) {
     sent_messages.detect do |message|
-      message.to == ["scholarsphere@servicedesk.css.psu.edu", "umg-up.its.scholarsphere-support@groups.ucs.psu.edu"]
+      message.to == ['scholarsphere@servicedesk.css.psu.edu', 'umg-up.its.scholarsphere-support@groups.ucs.psu.edu']
     end
   }
   let(:thank_you_message) {
@@ -29,17 +29,17 @@ describe 'Contact form:', type: :feature do
 
   before { sign_in(user) }
 
-  it "sends emails to the service desk and confirmations to the user" do
+  it 'sends emails to the service desk and confirmations to the user' do
     visit '/'
-    click_link "Contact"
-    expect(page).to have_content "Contact Form"
-    expect(find_field("sufia_contact_form_name").value).to eq(user.name)
-    expect(find_field("sufia_contact_form_email").value).to eq(email)
-    fill_in "sufia_contact_form_message", with: "I am contacting you regarding ScholarSphere."
-    fill_in "sufia_contact_form_subject", with: email_subject
-    select "Depositing content", from: "sufia_contact_form_category"
-    click_button "Send"
-    expect(page).to have_content("Thank you for your message!")
+    click_link 'Contact'
+    expect(page).to have_content 'Contact Form'
+    expect(find_field('sufia_contact_form_name').value).to eq(user.name)
+    expect(find_field('sufia_contact_form_email').value).to eq(email)
+    fill_in 'sufia_contact_form_message', with: 'I am contacting you regarding ScholarSphere.'
+    fill_in 'sufia_contact_form_subject', with: email_subject
+    select 'Depositing content', from: 'sufia_contact_form_category'
+    click_button 'Send'
+    expect(page).to have_content('Thank you for your message!')
     expect(admin_message.subject).to eq("ScholarSphere Contact Form - #{email_subject}")
     expect(thank_you_message.to).to contain_exactly(email)
     expect(thank_you_message.subject).to eq("ScholarSphere Contact Form - #{email_subject}")

--- a/spec/features/dashboard/dashboard_collections_spec.rb
+++ b/spec/features/dashboard/dashboard_collections_spec.rb
@@ -16,9 +16,9 @@ describe 'Dashboard Collections:', type: :feature do
   end
 
   specify 'tab title and buttons' do
-    expect(page).to have_content("My Collections")
-    expect(page).to have_link("New Work", visible: false) # link is there (even if collapsed)
-    expect(page).to have_link("New Collection", visible: false) # link is there (even if collapsed)
+    expect(page).to have_content('My Collections')
+    expect(page).to have_link('New Work', visible: false) # link is there (even if collapsed)
+    expect(page).to have_link('New Collection', visible: false) # link is there (even if collapsed)
     expect(page).not_to have_selector(".batch-toggle input[value='Delete Selected']")
   end
 
@@ -31,25 +31,25 @@ describe 'Dashboard Collections:', type: :feature do
     first('span.glyphicon-chevron-right').click
     expect(page).to have_content(collection.creator.first)
     expect(page).to have_content(collection.depositor)
-    expect(page).to have_content "Edit Access"
+    expect(page).to have_content 'Edit Access'
     expect(page).to have_content(current_user)
   end
 
   specify 'additional information is hidden' do
     expect(page).not_to have_content(collection.creator.first)
     expect(page).not_to have_content(collection.depositor)
-    expect(page).not_to have_content "Edit Access"
+    expect(page).not_to have_content 'Edit Access'
     expect(page).not_to have_content(current_user)
   end
 
-  specify "toggle addtitional actions" do
-    expect(page).not_to have_content("Edit Collection")
-    expect(page).not_to have_content("Delete Collection")
+  specify 'toggle addtitional actions' do
+    expect(page).not_to have_content('Edit Collection')
+    expect(page).not_to have_content('Delete Collection')
     within('#documents') do
       first('.btn.dropdown-toggle').click
     end
-    expect(page).to have_content("Edit Collection")
-    expect(page).to have_content("Delete Collection")
+    expect(page).to have_content('Edit Collection')
+    expect(page).to have_content('Delete Collection')
   end
 
   specify 'collections are not displayed in the Works list' do
@@ -58,8 +58,8 @@ describe 'Dashboard Collections:', type: :feature do
   end
 
   describe 'facets,' do
-    specify "displays the correct totals for each facet" do
-      within("#facets") do
+    specify 'displays the correct totals for each facet' do
+      within('#facets') do
         click_link('Object Type')
         expect(page).to have_content('Collection (1)')
         click_link('Creator')

--- a/spec/features/dashboard/dashboard_highlights_spec.rb
+++ b/spec/features/dashboard/dashboard_highlights_spec.rb
@@ -12,9 +12,9 @@ describe 'Dashboard Highlights', type: :feature do
   end
 
   specify 'tab title and buttons' do
-    expect(page).to have_content("My Highlights")
-    expect(page).to have_content("New Work")
-    expect(page).to have_content("Create Collection")
+    expect(page).to have_content('My Highlights')
+    expect(page).to have_content('New Work')
+    expect(page).to have_content('Create Collection')
     expect(page).not_to have_selector(".batch-toggle input[value='Delete Selected']")
   end
 end

--- a/spec/features/dashboard/dashboard_shares_spec.rb
+++ b/spec/features/dashboard/dashboard_shares_spec.rb
@@ -8,10 +8,10 @@ describe 'Dashboard Shares', type: :feature do
   let(:jill)         { create(:jill) }
 
   let!(:collection) { create(:collection, depositor: current_user.user_key) }
-  let!(:gf)         { create(:public_file, title: ["Public, unshared file"], depositor: jill.user_key) }
+  let!(:gf)         { create(:public_file, title: ['Public, unshared file'], depositor: jill.user_key) }
 
   let!(:gf2) do
-    create(:private_file, title: ["Private, shared filed"],
+    create(:private_file, title: ['Private, shared filed'],
                           depositor: jill.user_key,
                           edit_users: [current_user.user_key])
   end
@@ -21,16 +21,16 @@ describe 'Dashboard Shares', type: :feature do
     go_to_dashboard_shares
   end
 
-  it "displays only shared files" do
-    expect(page).to have_content("Shared with Me")
-    expect(page).to have_link("New Work", visible: false)
-    expect(page).to have_link("New Collection", visible: false)
+  it 'displays only shared files' do
+    expect(page).to have_content('Shared with Me')
+    expect(page).to have_link('New Work', visible: false)
+    expect(page).to have_link('New Collection', visible: false)
     expect(page).not_to have_selector(".batch-toggle input[value='Delete Selected']")
     expect(page).not_to have_content(collection.title)
     expect(page).not_to have_content(gf.title.first)
     expect(page).to have_content(gf2.title.first)
     within("tr#document_#{gf2.id}") do
-      expect(page).to have_link("Edit Work")
+      expect(page).to have_link('Edit Work')
     end
   end
 end

--- a/spec/features/dashboard/dashboard_spec.rb
+++ b/spec/features/dashboard/dashboard_spec.rb
@@ -6,7 +6,7 @@ include Selectors::Dashboard
 describe 'The Dashboard', type: :feature do
   let(:user) { create(:user) }
 
-  describe "a user who has files and collections" do
+  describe 'a user who has files and collections' do
     let!(:work)         { create(:public_work, :with_one_file, depositor: user.user_key) }
     let!(:collection)   { create(:collection, depositor: user.user_key) }
 
@@ -17,31 +17,31 @@ describe 'The Dashboard', type: :feature do
 
     it "shows the user's statistics" do
       expect(page).to have_content(user.display_name)
-      expect(page).to have_content("1 Works created")
-      expect(page).to have_content("1 Collections created 1")
+      expect(page).to have_content('1 Works created')
+      expect(page).to have_content('1 Collections created 1')
     end
   end
 
-  describe "a user without files and collections" do
+  describe 'a user without files and collections' do
     before do
       sign_in(user)
       go_to_dashboard
     end
-    it "displays information correctly" do
+    it 'displays information correctly' do
       # displays information about the user
-      expect(page).to have_content "Joe Example"
-      expect(page).to have_link "View Profile"
-      expect(page).to have_link "Edit Profile"
-      expect(page).to have_content("0 Works created")
-      expect(page).to have_content("0 Collections created")
+      expect(page).to have_content 'Joe Example'
+      expect(page).to have_link 'View Profile'
+      expect(page).to have_link 'Edit Profile'
+      expect(page).to have_content('0 Works created')
+      expect(page).to have_content('0 Collections created')
 
       # shows recent activity
-      expect(page).to have_content "User Activity"
-      expect(page).to have_content "User has no recent activity"
+      expect(page).to have_content 'User Activity'
+      expect(page).to have_content 'User has no recent activity'
     end
   end
 
-  describe "a user with multiple current proxies" do
+  describe 'a user with multiple current proxies' do
     let!(:first_proxy)  { create(:first_proxy) }
     let!(:second_proxy) { create(:second_proxy) }
 
@@ -51,47 +51,47 @@ describe 'The Dashboard', type: :feature do
       create_proxy_using_partial(first_proxy, second_proxy)
     end
 
-    it "lists each proxy if both are authorized" do
-      within("#authorizedProxies") do
+    it 'lists each proxy if both are authorized' do
+      within('#authorizedProxies') do
         expect(page).to have_content(first_proxy.display_name)
         expect(page).to have_content(second_proxy.display_name)
       end
       go_to_dashboard
-      within("#authorizedProxies") do
+      within('#authorizedProxies') do
         expect(page).to have_content(first_proxy.display_name)
         expect(page).to have_content(second_proxy.display_name)
       end
 
       # should remove a proxy
-      first(".remove-proxy-button").click
+      first('.remove-proxy-button').click
       sleep(1.second)
       go_to_dashboard
-      within("#authorizedProxies") do
+      within('#authorizedProxies') do
         expect(page).to have_content(second_proxy.display_name)
         expect(page).not_to have_content(first_proxy.display_name)
       end
     end
   end
 
-  describe "a user with transfers" do
+  describe 'a user with transfers' do
     let(:another_user) { create(:jill) }
 
-    context "with no transfers" do
+    context 'with no transfers' do
       before do
         sign_in(user)
         go_to_dashboard
       end
 
-      it "shows no transfers" do
-        within("div#transfers") do
-          expect(page).to have_link("Select works to transfer")
+      it 'shows no transfers' do
+        within('div#transfers') do
+          expect(page).to have_link('Select works to transfer')
           expect(page).to have_content "You haven't transferred any work"
           expect(page).to have_content "You haven't received any work transfer requests"
         end
       end
     end
 
-    context "with one incoming" do
+    context 'with one incoming' do
       let!(:incoming_file) { create(:file, depositor: another_user.user_key, transfer_to: user) }
 
       before do
@@ -99,16 +99,16 @@ describe 'The Dashboard', type: :feature do
         go_to_dashboard
       end
 
-      it "displays received files" do
-        within("#incoming-transfers") do
+      it 'displays received files' do
+        within('#incoming-transfers') do
           expect(page).to have_link another_user.name
-          expect(page).to have_content "less than a minute ago"
-          expect(page).to have_button "Accept"
+          expect(page).to have_content 'less than a minute ago'
+          expect(page).to have_button 'Accept'
         end
       end
     end
 
-    context "with one outgoing" do
+    context 'with one outgoing' do
       let!(:outgoing_file) { create(:file, depositor: user.user_key, transfer_to: another_user) }
 
       before do
@@ -116,11 +116,11 @@ describe 'The Dashboard', type: :feature do
         go_to_dashboard
       end
 
-      it "displays files sent to another user" do
-        within("#outgoing-transfers") do
+      it 'displays files sent to another user' do
+        within('#outgoing-transfers') do
           expect(page).to have_link another_user.name
-          expect(page).to have_content "less than a minute ago"
-          expect(page).to have_button "Cancel"
+          expect(page).to have_content 'less than a minute ago'
+          expect(page).to have_button 'Cancel'
         end
       end
     end

--- a/spec/features/dashboard/dashboard_works_spec.rb
+++ b/spec/features/dashboard/dashboard_works_spec.rb
@@ -34,36 +34,36 @@ describe 'Dashboard Works', type: :feature do
   context 'with two works' do
     specify 'interactions are wired correctly' do
       # tab title and buttons
-      expect(page).to have_content("My Works")
-      expect(page).to have_selector("h2.sr-only", text: "Works listing")
-      expect(page).to have_link("New Work", visible: false) # link is there (even if collapsed)
-      expect(page).to have_link("New Collection", visible: false) # link is there (even if collapsed)
+      expect(page).to have_content('My Works')
+      expect(page).to have_selector('h2.sr-only', text: 'Works listing')
+      expect(page).to have_link('New Work', visible: false) # link is there (even if collapsed)
+      expect(page).to have_link('New Collection', visible: false) # link is there (even if collapsed)
 
       # Additional metadata about the work1 is hidden
-      expect(page).not_to have_content "Edit Access"
+      expect(page).not_to have_content 'Edit Access'
       expect(page).not_to have_content work1.creator.first
 
       # A return controller is specified
-      expect(page).to have_css("input#return_controller", visible: false)
+      expect(page).to have_css('input#return_controller', visible: false)
 
       # Displays visibility information about my works
       within("#document_#{work1.id}") do
-        expect(page).to have_selector("span.label-success", text: "Public")
+        expect(page).to have_selector('span.label-success', text: 'Public')
       end
       within("#document_#{work2.id}") do
-        expect(page).to have_selector("span.label-info", text: "Penn State")
+        expect(page).to have_selector('span.label-info', text: 'Penn State')
       end
 
       # Displays additional metadata about that work1
       first('span.glyphicon-chevron-right').click
       expect(page).to have_content work1.creator.first
       expect(page).to have_content work1.depositor
-      expect(page).to have_content "Edit Access"
+      expect(page).to have_content 'Edit Access'
 
       db_item_actions_toggle(work1).click
       click_link 'Edit Work'
-      expect(page).to have_content("Edit Work")
-      expect(page).to have_field("generic_work[title]", with: filename)
+      expect(page).to have_content('Edit Work')
+      expect(page).to have_field('generic_work[title]', with: filename)
       expect(page).to have_content 'Visibility'
 
       # TODO: This part of the test won't pass until this Sufia
@@ -84,13 +84,13 @@ describe 'Dashboard Works', type: :feature do
         db_item_actions_toggle(work1).click
         click_link 'Highlight Work on Profile'
         db_item_actions_toggle(work1).click
-        expect(page).to have_content "Unhighlight Work"
+        expect(page).to have_content 'Unhighlight Work'
         db_item_actions_toggle(work1).trigger('click')
       end
       specify 'It is highlighted' do
         # It is highlighted on my profile
         visit "/users/#{current_user.login}\#contributions"
-        expect(page).to have_css '.active a', text: "Highlighted"
+        expect(page).to have_css '.active a', text: 'Highlighted'
         within '#contributions' do
           expect(page).to have_link work1.title.first
         end
@@ -139,7 +139,7 @@ describe 'Dashboard Works', type: :feature do
     end
 
     describe 'Search:' do
-      it "shows the correct results" do
+      it 'shows the correct results' do
         # When I search by partial title it does not display any results
         search_my_files_by_term('title')
         expect(page).to have_content 'You searched for: title'
@@ -163,7 +163,7 @@ describe 'Dashboard Works', type: :feature do
 
         # allows me to remove constraints
         find('span.glyphicon-remove').click
-        expect(page).not_to have_content "You searched for:"
+        expect(page).not_to have_content 'You searched for:'
 
         # When I search by Creator it displays the correct results
         search_my_files_by_term(work1.creator.first.to_s)
@@ -173,7 +173,7 @@ describe 'Dashboard Works', type: :feature do
     end
 
     describe 'Facets:' do
-      specify "Displays the correct totals for facet" do
+      specify 'Displays the correct totals for facet' do
         {
           'Resource Type' => 'Video (10)',
           'Creator'       => 'Creator1 (10)',
@@ -184,7 +184,7 @@ describe 'Dashboard Works', type: :feature do
           'Publisher'     => 'Publisher1 (10)',
           'Format'        => 'plain () (10)'
         }.each do |facet, value|
-          within("#facets") do
+          within('#facets') do
             # open facet
             click_link(facet)
             expect(page).to have_content(value, wait: Capybara.default_max_wait_time * 2)
@@ -198,16 +198,16 @@ describe 'Dashboard Works', type: :feature do
 
     describe 'Sorting:' do
       specify 'Items are sorted correctly' do
-        select("date uploaded ▼", from: "sort")
-        click_button("Refresh")
+        select("date uploaded ▼", from: 'sort')
+        click_button('Refresh')
         expect(page).to have_content(work1.title.first)
-        select("date uploaded ▲", from: "sort")
-        click_button("Refresh")
+        select("date uploaded ▲", from: 'sort')
+        click_button('Refresh')
         expect(page).not_to have_content(work1.title.first)
       end
     end
 
-    context "with collection of other users" do
+    context 'with collection of other users' do
       it "does not show other user's collection" do
         first('input.batch_document_selector').click
         click_button 'Add to Collection'
@@ -217,7 +217,7 @@ describe 'Dashboard Works', type: :feature do
     end
   end
 
-  context "Many works (more than max_batch, which is currently set to 80)" do
+  context 'Many works (more than max_batch, which is currently set to 80)' do
     before do
       create_works(current_user, 90)
       go_to_dashboard_works
@@ -230,36 +230,36 @@ describe 'Dashboard Works', type: :feature do
       conn.commit
     end
 
-    it "allows pagination and sorting to be toggeled" do
+    it 'allows pagination and sorting to be toggeled' do
       select('100', from: 'per_page')
       find_button('Refresh').click
       first('input.batch_document_selector').click
-      within(".batch-info") do
-        expect(page).to have_content "Add to Collection"
-        expect(page).not_to have_content "Sort By"
+      within('.batch-info') do
+        expect(page).to have_content 'Add to Collection'
+        expect(page).not_to have_content 'Sort By'
       end
       first('input.batch_document_selector').click
-      within(".batch-info") do
-        expect(page).to have_content "Sort By"
-        expect(page).not_to have_content "Add to Collection"
+      within('.batch-info') do
+        expect(page).to have_content 'Sort By'
+        expect(page).not_to have_content 'Add to Collection'
       end
     end
   end
 
   def search_my_files_by_term(term)
     within('#search-form-header') do
-      expect(page).to have_content("My Works")
+      expect(page).to have_content('My Works')
       fill_in('search-field-header', with: term)
-      click_button("Go")
+      click_button('Go')
     end
   end
 
-  let(:title_field) { Solrizer.solr_name("title", :stored_searchable, type: :string) }
-  let(:resp) { ActiveFedora::SolrService.instance.conn.get "select", params: { fl: ['id', title_field] } }
+  let(:title_field) { Solrizer.solr_name('title', :stored_searchable, type: :string) }
+  let(:resp) { ActiveFedora::SolrService.instance.conn.get 'select', params: { fl: ['id', title_field] } }
   def page_should_only_list(work1)
-    expect(page).to have_selector('li.active', text: "My Works")
+    expect(page).to have_selector('li.active', text: 'My Works')
     expect(page).to have_content work1.title.first
-    resp["response"]["docs"].each do |gf|
+    resp['response']['docs'].each do |gf|
       unless gf[title_field].nil?
         title = gf[title_field].first
         expect(page).not_to have_content title unless title == work1.title.first
@@ -268,7 +268,7 @@ describe 'Dashboard Works', type: :feature do
   end
 
   def page_should_not_list_any_files
-    resp["response"]["docs"].each do |gf|
+    resp['response']['docs'].each do |gf|
       unless gf[title_field].nil?
         expect(page).not_to have_content gf[title_field].first
       end
@@ -288,14 +288,14 @@ describe 'Dashboard Works', type: :feature do
       work = build(:public_work, id: "199#{t}",
                                  title: ["Sample Work #{t}"],
                                  date_uploaded: (Time.now - (t + 1).hours),
-                                 depositor: current_user.login, resource_type: ["Video"],
-                                 creator: ["Creator1"], keyword: ["Keyword1"],
-                                 subject: ["Subject1"], language: ["Language1"],
-                                 based_near: ["Location1"], publisher: ["Publisher1"])
+                                 depositor: current_user.login, resource_type: ['Video'],
+                                 creator: ['Creator1'], keyword: ['Keyword1'],
+                                 subject: ['Subject1'], language: ['Language1'],
+                                 based_near: ['Location1'], publisher: ['Publisher1'])
 
       # TODO: how to do we set the work1 format in the objects with build
       hash = work.to_solr
-      hash[Solrizer.solr_name("file_format", :facetable)] = "plain ()"
+      hash[Solrizer.solr_name('file_format', :facetable)] = 'plain ()'
       conn.add hash
     end
     conn.commit

--- a/spec/features/facet_spec.rb
+++ b/spec/features/facet_spec.rb
@@ -1,34 +1,34 @@
 # frozen_string_literal: true
 require 'feature_spec_helper'
 
-describe "Catalog facets" do
-  let(:work1) { build(:public_work, id: "1",
-                                    contributor: ["Contri B. Utor"],
-                                    publisher: ["Pu B. Lisher"],
-                                    keyword: ["Key. Word."],
-                                    creator: ["Patricia M. Hswe"]) }
-  let(:work2) { build(:public_work, id: "2",
-                                    contributor: ["CONTRI B. UTOR"],
-                                    publisher: ["PU B. LISHER"],
-                                    keyword: ["KEY. WORD."],
-                                    creator: ["PATRICIA M. HSWE"]) }
-  let(:work3) { build(:public_work, id: "3",
-                                    contributor: ["Contri B Utor"],
-                                    publisher: ["Pu B Lisher"],
-                                    keyword: ["Key Word"],
-                                    creator: ["Patricia M Hswe"]) }
+describe 'Catalog facets' do
+  let(:work1) { build(:public_work, id: '1',
+                                    contributor: ['Contri B. Utor'],
+                                    publisher: ['Pu B. Lisher'],
+                                    keyword: ['Key. Word.'],
+                                    creator: ['Patricia M. Hswe']) }
+  let(:work2) { build(:public_work, id: '2',
+                                    contributor: ['CONTRI B. UTOR'],
+                                    publisher: ['PU B. LISHER'],
+                                    keyword: ['KEY. WORD.'],
+                                    creator: ['PATRICIA M. HSWE']) }
+  let(:work3) { build(:public_work, id: '3',
+                                    contributor: ['Contri B Utor'],
+                                    publisher: ['Pu B Lisher'],
+                                    keyword: ['Key Word'],
+                                    creator: ['Patricia M Hswe']) }
 
   before do
     index_works_and_collections(work1, work2, work3)
     visit '/catalog'
-    click_link("Creator")
+    click_link('Creator')
   end
 
-  it "displays case and punctuation-corrected facets" do
-    within("div#facet-creator_sim") do
-      expect(page).not_to have_content("Patricia M. Hswe")
-      expect(page).to have_content("Patricia M Hswe")
-      expect(page).to have_selector("span.facet-count", text: "(3)")
+  it 'displays case and punctuation-corrected facets' do
+    within('div#facet-creator_sim') do
+      expect(page).not_to have_content('Patricia M. Hswe')
+      expect(page).to have_content('Patricia M Hswe')
+      expect(page).to have_selector('span.facet-count', text: '(3)')
     end
 
     # Pending: #659
@@ -38,40 +38,40 @@ describe "Catalog facets" do
     #   expect(page).to have_selector("span.facet-count", text: "(3)")
     # end
 
-    within("div#facet-publisher_sim") do
-      expect(page).not_to have_content("Pu B. Lisher")
-      expect(page).to have_content("Pu B Lisher")
-      expect(page).to have_selector("span.facet-count", text: "(3)")
+    within('div#facet-publisher_sim') do
+      expect(page).not_to have_content('Pu B. Lisher')
+      expect(page).to have_content('Pu B Lisher')
+      expect(page).to have_selector('span.facet-count', text: '(3)')
     end
-    within("div#facet-keyword_sim") do
-      expect(page).not_to have_content("Key. Word.")
-      expect(page).to have_content("key word")
-      expect(page).to have_selector("span.facet-count", text: "(3)")
-    end
-
-    visit("/concern/generic_works/#{work2.id}")
-
-    click_link("PATRICIA M. HSWE")
-    within("div#search-results") do
-      expect(page).to have_content("Patricia M. Hswe")
-      expect(page).to have_content("Patricia M Hswe")
-      expect(page).to have_content("PATRICIA M. HSWE")
+    within('div#facet-keyword_sim') do
+      expect(page).not_to have_content('Key. Word.')
+      expect(page).to have_content('key word')
+      expect(page).to have_selector('span.facet-count', text: '(3)')
     end
 
     visit("/concern/generic_works/#{work2.id}")
-    click_link("PU B. LISHER")
-    within("div#search-results") do
-      expect(page).to have_content("Pu B. Lisher")
-      expect(page).to have_content("Pu B Lisher")
-      expect(page).to have_content("PU B. LISHER")
+
+    click_link('PATRICIA M. HSWE')
+    within('div#search-results') do
+      expect(page).to have_content('Patricia M. Hswe')
+      expect(page).to have_content('Patricia M Hswe')
+      expect(page).to have_content('PATRICIA M. HSWE')
     end
 
     visit("/concern/generic_works/#{work2.id}")
-    click_link("KEY. WORD.")
-    within("div#search-results") do
-      expect(page).to have_content("Key Word")
-      expect(page).to have_content("Key. Word.")
-      expect(page).to have_content("KEY. WORD.")
+    click_link('PU B. LISHER')
+    within('div#search-results') do
+      expect(page).to have_content('Pu B. Lisher')
+      expect(page).to have_content('Pu B Lisher')
+      expect(page).to have_content('PU B. LISHER')
+    end
+
+    visit("/concern/generic_works/#{work2.id}")
+    click_link('KEY. WORD.')
+    within('div#search-results') do
+      expect(page).to have_content('Key Word')
+      expect(page).to have_content('Key. Word.')
+      expect(page).to have_content('KEY. WORD.')
     end
 
     # Pending: #659?

--- a/spec/features/featured_work_spec.rb
+++ b/spec/features/featured_work_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'feature_spec_helper'
 
-describe "Featured works on the home page", type: :feature do
+describe 'Featured works on the home page', type: :feature do
   let!(:user)         { create(:user) }
   let!(:jill_user)    { create(:jill) }
   let!(:file1)        { create(:featured_file, depositor: user.login, title: ['file title']) }
@@ -10,32 +10,32 @@ describe "Featured works on the home page", type: :feature do
 
   let(:admin_user) { create(:administrator) }
 
-  context "as a normal user" do
+  context 'as a normal user' do
     before do
       sign_in_with_js(user)
-      visit("/")
+      visit('/')
     end
 
-    it "appears as a featured work", js: true do
-      expect(page).to have_content "Featured Works"
-      within("#featured_container") do
+    it 'appears as a featured work', js: true do
+      expect(page).to have_content 'Featured Works'
+      within('#featured_container') do
         expect(page).to have_content(file1.title[0])
       end
     end
 
-    it "only public documents appear as recently uploaded files" do
-      click_link "Recent Additions"
-      within("#recently_uploaded") do
+    it 'only public documents appear as recently uploaded files' do
+      click_link 'Recent Additions'
+      within('#recently_uploaded') do
         expect(page).to have_content(file1.title[0])
         expect(page).to have_no_content(private_file.title[0])
       end
     end
   end
 
-  context "as an administrator" do
+  context 'as an administrator' do
     before do
       sign_in_with_js(admin_user)
-      visit("/")
+      visit('/')
     end
     it 'allows the user to remove it as a featured work' do
       document = find('li.dd-item:nth-of-type(1)')

--- a/spec/features/file_set/analytics_spec.rb
+++ b/spec/features/file_set/analytics_spec.rb
@@ -4,7 +4,7 @@ require 'feature_spec_helper'
 # Notice that with Sufia 7 we generate thumbnails at the FileSets level
 # in a similar way to what we did in Sufia 6 for GenericFiles.
 describe 'FileSet Thumbnail Creation:', type: :feature do
-  let(:work)           { create(:public_work_with_png, file_title: ["Some work"], depositor: current_user.login) }
+  let(:work)           { create(:public_work_with_png, file_title: ['Some work'], depositor: current_user.login) }
   let(:current_user)   { create(:user) }
   let(:file_set)       { work.file_sets.first }
   let(:thumbnail_path) { main_app.download_path(file_set, file: 'thumbnail') }
@@ -19,17 +19,17 @@ describe 'FileSet Thumbnail Creation:', type: :feature do
 
   let(:date_strs) do
     ldate_strs = []
-    dates.each { |date| ldate_strs << date.strftime("%Y%m%d") }
+    dates.each { |date| ldate_strs << date.strftime('%Y%m%d') }
     ldate_strs
   end
 
   let(:sample_download_statistics) do
     [
-      OpenStruct.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "sufia:x920fw85p", date: date_strs[0], totalEvents: "1"),
-      OpenStruct.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "sufia:x920fw85p", date: date_strs[1], totalEvents: "1"),
-      OpenStruct.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "sufia:x920fw85p", date: date_strs[2], totalEvents: "2"),
-      OpenStruct.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "sufia:x920fw85p", date: date_strs[3], totalEvents: "3"),
-      OpenStruct.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "sufia:x920fw85p", date: date_strs[4], totalEvents: "5")
+      OpenStruct.new(eventCategory: 'Files', eventAction: 'Downloaded', eventLabel: 'sufia:x920fw85p', date: date_strs[0], totalEvents: '1'),
+      OpenStruct.new(eventCategory: 'Files', eventAction: 'Downloaded', eventLabel: 'sufia:x920fw85p', date: date_strs[1], totalEvents: '1'),
+      OpenStruct.new(eventCategory: 'Files', eventAction: 'Downloaded', eventLabel: 'sufia:x920fw85p', date: date_strs[2], totalEvents: '2'),
+      OpenStruct.new(eventCategory: 'Files', eventAction: 'Downloaded', eventLabel: 'sufia:x920fw85p', date: date_strs[3], totalEvents: '3'),
+      OpenStruct.new(eventCategory: 'Files', eventAction: 'Downloaded', eventLabel: 'sufia:x920fw85p', date: date_strs[4], totalEvents: '5')
     ]
   end
 
@@ -52,11 +52,11 @@ describe 'FileSet Thumbnail Creation:', type: :feature do
     visit "/concern/file_sets/#{file_set.id}"
   end
 
-  it "renders without error" do
+  it 'renders without error' do
     pending("Passes when run individually, but raises:
       Routing Error uninitialized constant Sufia::SingularSubresourceController::DenyAccessOverrideBehavior
       when run in the suite. See #379")
-    click_on "Analytics"
+    click_on 'Analytics'
     expect(page).to have_text("30 views and 12 downloads since #{four_days_ago.strftime('%B %-d, %Y')}")
   end
 end

--- a/spec/features/file_set/thumbnail_spec.rb
+++ b/spec/features/file_set/thumbnail_spec.rb
@@ -13,16 +13,16 @@ describe 'FileSet Thumbnail Creation:', type: :feature do
     visit "/concern/file_sets/#{file_set.id}"
   end
 
-  context "When FileSet has a thumbnail" do
-    let(:work) { create(:public_work_with_png, file_title: ["Some work"], depositor: current_user.login) }
-    it "renders the thumbnail" do
+  context 'When FileSet has a thumbnail' do
+    let(:work) { create(:public_work_with_png, file_title: ['Some work'], depositor: current_user.login) }
+    it 'renders the thumbnail' do
       expect(page).to have_css("img[src*='#{thumbnail_path}']")
     end
   end
 
-  context "When fileset does not have a thumbnail" do
-    let(:work)  { create(:public_work_with_mp3, file_title: ["Some work"], depositor: current_user.login) }
-    it "does not render a thumbnail" do
+  context 'When fileset does not have a thumbnail' do
+    let(:work)  { create(:public_work_with_mp3, file_title: ['Some work'], depositor: current_user.login) }
+    it 'does not render a thumbnail' do
       expect(page).not_to have_css("img[src*='#{thumbnail_path}']")
     end
   end

--- a/spec/features/file_set/versioning_spec.rb
+++ b/spec/features/file_set/versioning_spec.rb
@@ -2,35 +2,35 @@
 require 'feature_spec_helper'
 
 describe 'FileSet versioning:', type: :feature do
-  let(:work)         { create(:public_work_with_png, file_title: ["Some work"], depositor: current_user.login) }
+  let(:work)         { create(:public_work_with_png, file_title: ['Some work'], depositor: current_user.login) }
   let(:current_user) { create(:user) }
   let(:file_set)     { work.file_sets.first }
-  let(:filename)     { "4-20-small.png" }
+  let(:filename)     { '4-20-small.png' }
 
   before do
     sign_in(current_user)
     visit "/concern/file_sets/#{file_set.id}"
   end
 
-  it "sets the file set title and label to new and reverted file versions" do
-    click_link("Edit This File")
-    expect(page).to have_field("Title", with: "world.png")
-    expect(page).to have_button("Save")
-    click_link("Versions")
-    expect(page).not_to have_content("A PDF is preferred")
+  it 'sets the file set title and label to new and reverted file versions' do
+    click_link('Edit This File')
+    expect(page).to have_field('Title', with: 'world.png')
+    expect(page).to have_button('Save')
+    click_link('Versions')
+    expect(page).not_to have_content('A PDF is preferred')
     attach_file('file_set[files][]', test_file_path(filename), visible: false)
-    click_button("Upload New Version")
-    expect(page).to have_selector("h1", text: filename)
-    within(".file-show-details") do
-      expect(page).to have_selector("dd", filename)
+    click_button('Upload New Version')
+    expect(page).to have_selector('h1', text: filename)
+    within('.file-show-details') do
+      expect(page).to have_selector('dd', filename)
     end
-    click_link("Edit This File")
-    click_link("Versions")
-    find("#revision_version1").set(true)
-    click_button("Save Revision")
-    expect(page).to have_selector("h1", text: "world.png")
-    within(".file-show-details") do
-      expect(page).to have_selector("dd", "world.png")
+    click_link('Edit This File')
+    click_link('Versions')
+    find('#revision_version1').set(true)
+    click_button('Save Revision')
+    expect(page).to have_selector('h1', text: 'world.png')
+    within('.file-show-details') do
+      expect(page).to have_selector('dd', 'world.png')
     end
   end
 end

--- a/spec/features/generic_work/edit_permissions_spec.rb
+++ b/spec/features/generic_work/edit_permissions_spec.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 require 'feature_spec_helper'
 
-describe "Editing permissions on a work" do
-  context "when removing permissions from a work with files" do
-    let(:user1) { create(:user, display_name: "First User") }
-    let(:user2) { create(:user, display_name: "Second User") }
+describe 'Editing permissions on a work' do
+  context 'when removing permissions from a work with files' do
+    let(:user1) { create(:user, display_name: 'First User') }
+    let(:user2) { create(:user, display_name: 'Second User') }
 
     let(:work) do
       create(:public_work, :with_required_metadata, depositor: user1.user_key,
@@ -19,19 +19,19 @@ describe "Editing permissions on a work" do
       sign_in_with_js(user1)
     end
 
-    it "copies the permissions to the file set" do
+    it 'copies the permissions to the file set' do
       visit("/concern/generic_works/#{work.id}/edit")
-      within("ul.nav-tabs") do
-        click_link("Collaborators")
+      within('ul.nav-tabs') do
+        click_link('Collaborators')
       end
-      within("#share") do
-        expect(page).to have_content("First User")
-        expect(page).to have_content("Second User")
+      within('#share') do
+        expect(page).to have_content('First User')
+        expect(page).to have_content('Second User')
       end
-      find(".remove_perm").click
-      click_button("Save")
-      expect(page).to have_content("Apply changes to contents?")
-      click_button("Yes please.")
+      find('.remove_perm').click
+      click_button('Save')
+      expect(page).to have_content('Apply changes to contents?')
+      click_button('Yes please.')
       expect(page).to have_content(work.title.first)
       expect(work.reload.edit_users).to contain_exactly(user1.user_key)
       expect(work.file_sets.first.edit_users).to contain_exactly(user1.user_key)

--- a/spec/features/generic_work/edit_work_spec.rb
+++ b/spec/features/generic_work/edit_work_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'feature_spec_helper'
 
-describe "Editing a work" do
+describe 'Editing a work' do
   let(:proxy) { create(:first_proxy) }
   let(:user)  { create(:user, :with_proxy, proxy_for: proxy) }
   let(:work)  { create(:public_work, :with_required_metadata, depositor: user.user_key) }
@@ -10,21 +10,21 @@ describe "Editing a work" do
 
   # Tests the basic outline of the form. This can be expanded later with more detail including
   # refactoring it to incorporate other tests.
-  it "displays the edit form" do
+  it 'displays the edit form' do
     visit("/concern/generic_works/#{work.id}/edit")
-    within(".base-terms") do
-      expect(page).to have_selector("h2", text: "Basic Metadata")
-      expect(page).to have_selector("label", text: "Subtitle")
+    within('.base-terms') do
+      expect(page).to have_selector('h2', text: 'Basic Metadata')
+      expect(page).to have_selector('label', text: 'Subtitle')
     end
 
-    within("#work-media") do
-      expect(page).to have_selector("h2", text: "Media")
+    within('#work-media') do
+      expect(page).to have_selector('h2', text: 'Media')
     end
 
-    within("#extended-terms") do
-      expect(page).to have_selector("h2", text: "Additional Metadata", visible: false)
+    within('#extended-terms') do
+      expect(page).to have_selector('h2', text: 'Additional Metadata', visible: false)
     end
 
-    expect(page).not_to have_selector("#generic_work_on_behalf_of")
+    expect(page).not_to have_selector('#generic_work_on_behalf_of')
   end
 end

--- a/spec/features/generic_work/featured_work_spec.rb
+++ b/spec/features/generic_work/featured_work_spec.rb
@@ -1,27 +1,27 @@
 # frozen_string_literal: true
 require 'feature_spec_helper'
 
-describe "Showing the Generic File", type: :feature do
+describe 'Showing the Generic File', type: :feature do
   let(:current_user) { create(:administrator) }
   let!(:gf)          { create(:public_file, depositor: current_user.login) }
 
-  it "allows a feature to be marked and deleted" do
+  it 'allows a feature to be marked and deleted' do
     sign_in_with_js(current_user)
-    visit "/"
-    click_link "Recent Additions"
+    visit '/'
+    click_link 'Recent Additions'
     expect(page).to have_content(gf.title.first)
     click_link gf.title.first
-    expect(page).to have_content("Metadata")
-    expect(page).to have_link "Feature"
-    click_link "Feature"
+    expect(page).to have_content('Metadata')
+    expect(page).to have_link 'Feature'
+    click_link 'Feature'
     visit "/concern/generic_works/#{gf.id}" # force a page refresh
-    expect(page).to have_content("Unfeature")
+    expect(page).to have_content('Unfeature')
     visit '/'
-    within(".new_featured_work_list") do
+    within('.new_featured_work_list') do
       expect(page).to have_content(gf.title[0])
-      find(".glyphicon-remove").click
+      find('.glyphicon-remove').click
     end
-    within(".new_featured_work_list") do
+    within('.new_featured_work_list') do
       expect(page).not_to have_content(gf.title[0])
     end
   end

--- a/spec/features/generic_work/show_public_work_spec.rb
+++ b/spec/features/generic_work/show_public_work_spec.rb
@@ -4,42 +4,42 @@ require 'feature_spec_helper'
 describe GenericWork do
   let(:current_user) { create(:user) }
 
-  context "without files" do
+  context 'without files' do
     let(:work) do
-      build(:public_work, :with_complete_metadata, id: "public-work", depositor: current_user.login)
+      build(:public_work, :with_complete_metadata, id: 'public-work', depositor: current_user.login)
     end
 
-    let(:thumbnail_source) { page.find(".canonical-image")["src"] }
+    let(:thumbnail_source) { page.find('.canonical-image')['src'] }
 
     before do
       index_work(work)
-      visit("/concern/generic_works/public-work")
+      visit('/concern/generic_works/public-work')
     end
 
-    it "displays properly" do
+    it 'displays properly' do
       expect(page).to have_content(work.title.first)
       expect(thumbnail_source).to match(/nope/)
       sign_in(current_user)
       go_to_dashboard_works
-      within("#document_public-work") do
+      within('#document_public-work') do
         expect(page).to have_css("img[aria-hidden='true']")
         expect(page).to have_css("img[alt='']")
       end
     end
   end
 
-  context "with files" do
+  context 'with files' do
     let(:public_file_set) do
       build(:file_set, :with_file_size, :public,
-            id: "public-fileset",
-            title: ["Public File"],
+            id: 'public-fileset',
+            title: ['Public File'],
             user: current_user)
     end
 
     let(:registered_file_set) do
       build(:file_set, :with_file_size, :registered,
-            id: "registered-fileset",
-            title: ["Registered File"],
+            id: 'registered-fileset',
+            title: ['Registered File'],
             user: current_user)
     end
 
@@ -50,78 +50,78 @@ describe GenericWork do
                                .merge(ordered_targets_ssim: file_sets.map(&:id))
     end
 
-    let(:thumbnail_source) { page.find(".representative-media")["src"] }
+    let(:thumbnail_source) { page.find('.representative-media')['src'] }
 
     before do
       file_sets.each { |fs| index_file_set(fs) }
       index_document(list_source)
       index_work(work)
-      visit("/concern/generic_works/public-work")
+      visit('/concern/generic_works/public-work')
     end
 
-    context "using a public file as representative" do
+    context 'using a public file as representative' do
       let(:file_sets) { [public_file_set] }
       let(:work) do
         build(:public_work, :with_complete_metadata,
-              id: "public-work",
+              id: 'public-work',
               depositor: current_user.login,
-              representative_id: "public-fileset",
+              representative_id: 'public-fileset',
               members: file_sets)
       end
 
-      it "displays properly" do
+      it 'displays properly' do
         expect(page).to have_content(work.title.first)
-        expect(page).to have_link("Download file")
+        expect(page).to have_link('Download file')
         expect(thumbnail_source).to eq(CurationConcerns::ThumbnailPathService.send(:default_image))
         sign_in(current_user)
         go_to_dashboard_works
-        within("#document_public-work") do
+        within('#document_public-work') do
           expect(page).to have_css("img[aria-hidden='true']")
           expect(page).to have_css("img[alt='']")
         end
       end
     end
 
-    context "using a registered file as representative" do
+    context 'using a registered file as representative' do
       let(:file_sets) { [registered_file_set] }
       let(:work) do
         build(:public_work, :with_complete_metadata,
-              id: "public-work",
+              id: 'public-work',
               depositor: current_user.login,
-              representative_id: "registered-fileset",
+              representative_id: 'registered-fileset',
               members: file_sets)
       end
 
-      it "displays properly" do
+      it 'displays properly' do
         expect(page).to have_content(work.title.first)
-        expect(page).not_to have_link("Download file")
+        expect(page).not_to have_link('Download file')
         expect(thumbnail_source).to eq(CurationConcerns::ThumbnailPathService.send(:default_image))
         sign_in(current_user)
         go_to_dashboard_works
-        within("#document_public-work") do
+        within('#document_public-work') do
           expect(page).to have_css("img[aria-hidden='true']")
           expect(page).to have_css("img[alt='']")
         end
       end
     end
 
-    context "having a public file and a registered file, with the registered file as representative" do
+    context 'having a public file and a registered file, with the registered file as representative' do
       let(:file_sets) { [registered_file_set, public_file_set] }
       let(:work) do
         build(:public_work, :with_complete_metadata,
-              id: "public-work",
+              id: 'public-work',
               depositor: current_user.login,
-              representative_id: "registered-fileset",
+              representative_id: 'registered-fileset',
               members: file_sets)
       end
 
-      it "displays properly" do
+      it 'displays properly' do
         expect(page).to have_content(work.title.first)
-        expect(page).not_to have_link("Download file")
+        expect(page).not_to have_link('Download file')
         expect(thumbnail_source).to eq(CurationConcerns::ThumbnailPathService.send(:default_image))
         sign_in(current_user)
         go_to_dashboard_works
-        within("#document_public-work") do
+        within('#document_public-work') do
           expect(page).to have_css("img[aria-hidden='true']")
           expect(page).to have_css("img[alt='']")
         end
@@ -129,29 +129,29 @@ describe GenericWork do
     end
   end
 
-  context "with a public work and a restricted thumbnail" do
+  context 'with a public work and a restricted thumbnail' do
     let(:work) do
       build(:public_work, :with_complete_metadata,
-            id: "public-work",
-            title: ["Restricted thumbnail"],
+            id: 'public-work',
+            title: ['Restricted thumbnail'],
             depositor: current_user.login)
     end
 
     before do
       doc = work.to_solr
-      doc["thumbnail_path_ss"] = "/downloads/restricted-id?file=thumbnail"
+      doc['thumbnail_path_ss'] = '/downloads/restricted-id?file=thumbnail'
       index_document(doc)
       sign_in_with_named_js(:thumbnail)
       visit(root_path)
     end
 
-    it "displays the default work image for the thumbnail" do
+    it 'displays the default work image for the thumbnail' do
       within('#search-form-header') do
         fill_in('search-field-header', with: work.title.first)
-        click_button("Go")
+        click_button('Go')
       end
-      within("#document_public-work") do
-        expect(page.find("img")["src"]).to end_with(ActionController::Base.helpers.image_path("work.png"))
+      within('#document_public-work') do
+        expect(page.find('img')['src']).to end_with(ActionController::Base.helpers.image_path('work.png'))
       end
     end
   end

--- a/spec/features/generic_work/upload_and_delete_spec.rb
+++ b/spec/features/generic_work/upload_and_delete_spec.rb
@@ -11,26 +11,26 @@ describe 'Generic File uploading and deletion:', type: :feature do
     let(:filename)              { 'little_file.txt' }
     let(:batch)                 { ['little_file.txt', 'little_file.txt'] }
     let(:file)                  { work }
-    let(:work)                  { find_work_by_title "little_file.txt_title" }
+    let(:work)                  { find_work_by_title 'little_file.txt_title' }
 
     before { sign_in_with_named_js(:upload_and_delete, current_user, disable_animations: true) }
 
     describe "Sufia's default user agreement" do
       before { visit new_generic_work_path }
-      it "is not shown" do
+      it 'is not shown' do
         expect(page).not_to have_content("Sufia's Deposit Agreement")
       end
     end
 
-    describe "uploading a new work" do
+    describe 'uploading a new work' do
       before { visit new_generic_work_path }
 
-      it "enforces a workflow" do
-        within("div#savewidget") do
-          expect(page).to have_link "deposit agreement"
-          expect(page).to have_content "I have read and agree to the deposit agreement"
-          expect(page).to have_link("Enter required metadata")
-          expect(page).to have_link("Add files")
+      it 'enforces a workflow' do
+        within('div#savewidget') do
+          expect(page).to have_link 'deposit agreement'
+          expect(page).to have_content 'I have read and agree to the deposit agreement'
+          expect(page).to have_link('Enter required metadata')
+          expect(page).to have_link('Add files')
         end
 
         # Add files
@@ -38,21 +38,21 @@ describe 'Generic File uploading and deletion:', type: :feature do
         check 'agreement'
 
         # Check visibility
-        within("#savewidget") do
-          expect(page).to have_content("Visibility")
-          expect(page).to have_content("Public")
-          expect(page).to have_content("Embargo")
-          expect(page).not_to have_content("Private")
-          expect(page).to have_content("Penn State")
-          expect(page).to have_checked_field("Public")
-          expect(page).to have_content("marking this as Public")
+        within('#savewidget') do
+          expect(page).to have_content('Visibility')
+          expect(page).to have_content('Public')
+          expect(page).to have_content('Embargo')
+          expect(page).not_to have_content('Private')
+          expect(page).to have_content('Penn State')
+          expect(page).to have_checked_field('Public')
+          expect(page).to have_content('marking this as Public')
           sleep(1.second)
           choose 'generic_work_visibility_authenticated'
-          expect(page).not_to have_content("marking this as Public")
+          expect(page).not_to have_content('marking this as Public')
         end
 
         # Enter required metadata
-        click_link("Metadata")
+        click_link('Metadata')
         fill_in 'generic_work_title', with: 'Upload test'
         fill_in 'generic_work_keyword', with: 'keyword'
         fill_in 'generic_work_creator', with: 'creator'
@@ -60,43 +60,43 @@ describe 'Generic File uploading and deletion:', type: :feature do
         fill_in 'generic_work_description', with: 'My description'
         select 'Audio', from: 'generic_work_resource_type'
 
-        within("#metadata")      { expect(page).to have_link("Licenses") }
-        within("#metadata")      { expect(page).not_to have_css("#work-media") }
-        within("div#savewidget") { expect(page).to have_link("Required metadata complete") }
+        within('#metadata')      { expect(page).to have_link('Licenses') }
+        within('#metadata')      { expect(page).not_to have_css('#work-media') }
+        within('div#savewidget') { expect(page).to have_link('Required metadata complete') }
 
         # Check for additional fields
-        expect(page).to have_no_css("#generic_work_contributor")
-        click_link("Additional fields")
-        expect(page).to have_css("#generic_work_contributor")
-        expect(page).to have_css(".collapse.in") # wait for JavaScript to collapse fields
-        expect(page).to have_content("Published Date")
-        click_link("Additional fields")
-        expect(page).to have_no_css("#generic_work_contributor")
+        expect(page).to have_no_css('#generic_work_contributor')
+        click_link('Additional fields')
+        expect(page).to have_css('#generic_work_contributor')
+        expect(page).to have_css('.collapse.in') # wait for JavaScript to collapse fields
+        expect(page).to have_content('Published Date')
+        click_link('Additional fields')
+        expect(page).to have_no_css('#generic_work_contributor')
 
         # Check for optional metadata
-        within("#form-progress") { click_link("Collections") }
-        within("#form-progress") { click_link("Collaborators") }
+        within('#form-progress') { click_link('Collections') }
+        within('#form-progress') { click_link('Collaborators') }
 
         # Test sharing tab
         expect(User).to receive(:query_ldap_by_name_or_id).and_return([{ id: other_user.user_key, text: "#{other_user.display_name} (#{other_user.user_key})" }])
-        within("ul.nav-tabs") { click_link("Collaborators") }
+        within('ul.nav-tabs') { click_link('Collaborators') }
         expect(page).to have_css('a.select2-choice')
         first('a.select2-choice').click
-        find(".select2-input").set(other_user.user_key)
+        find('.select2-input').set(other_user.user_key)
         expect(page).to have_css('div.select2-result-label')
         first('div.select2-result-label').click
         find('#new_user_permission_skel').find(:xpath, 'option[2]').select_option
         click_on('add_new_user_skel')
-        within("#share") { expect(page).to have_content(other_user.user_key) }
+        within('#share') { expect(page).to have_content(other_user.user_key) }
       end
     end
 
     context 'cloud providers' do
       before do
-        allow(BrowseEverything).to receive(:config) { { "dropbox" => { app_key: "fakekey189274942347", app_secret: "fakesecret489289472347298", max_upload_file_size: 20 * 1024 } } }
-        allow(Sufia.config).to receive(:browse_everything) { { "dropbox" => { app_key: "fakekey189274942347", app_secret: "fakesecret489289472347298" } } }
+        allow(BrowseEverything).to receive(:config) { { 'dropbox' => { app_key: 'fakekey189274942347', app_secret: 'fakesecret489289472347298', max_upload_file_size: 20 * 1024 } } }
+        allow(Sufia.config).to receive(:browse_everything) { { 'dropbox' => { app_key: 'fakekey189274942347', app_secret: 'fakesecret489289472347298' } } }
         allow_any_instance_of(BrowseEverything::Driver::Dropbox).to receive(:authorized?) { true }
-        allow_any_instance_of(BrowseEverything::Driver::Dropbox).to receive(:token) { "FakeDropboxAccessToken01234567890ABCDEF_AAAAAAA987654321" }
+        allow_any_instance_of(BrowseEverything::Driver::Dropbox).to receive(:token) { 'FakeDropboxAccessToken01234567890ABCDEF_AAAAAAA987654321' }
         allow_any_instance_of(GenericWork).to receive(:share_notified?).and_return(false)
         visit(new_curation_concerns_generic_work_path)
         WebMock.enable!
@@ -108,24 +108,24 @@ describe 'Generic File uploading and deletion:', type: :feature do
       specify 'I can click on cloud providers' do
         expect(ShareNotifyJob).to receive(:perform_later)
         VCR.use_cassette('dropbox', record: :none) do
-          click_link "Files"
-          expect(page).to have_content "Add cloud files"
-          click_on "Add cloud files"
+          click_link 'Files'
+          expect(page).to have_content 'Add cloud files'
+          click_on 'Add cloud files'
           expect(page).to have_css '#provider-select'
           select 'Dropbox', from: 'provider-select'
           sleep 10
-          expect(page).to have_content "Getting Started.pdf"
-          click_on("Writer")
-          expect(page).to have_content "Writer FAQ.txt"
-          expect(page).not_to have_css "a", text: "Writer FAQ.txt"
-          expect(page).to have_content "Markdown Test.txt"
-          check("writer-markdown-test-txt")
-          expect(page).to have_content "1 file selected"
-          click_on("Submit")
-          within "tr.template-download" do
-            expect(page).to have_content "Markdown Test.txt"
+          expect(page).to have_content 'Getting Started.pdf'
+          click_on('Writer')
+          expect(page).to have_content 'Writer FAQ.txt'
+          expect(page).not_to have_css 'a', text: 'Writer FAQ.txt'
+          expect(page).to have_content 'Markdown Test.txt'
+          check('writer-markdown-test-txt')
+          expect(page).to have_content '1 file selected'
+          click_on('Submit')
+          within 'tr.template-download' do
+            expect(page).to have_content 'Markdown Test.txt'
           end
-          within("#savewidget") do
+          within('#savewidget') do
             choose 'generic_work_visibility_authenticated'
           end
           sleep(1.second)
@@ -140,12 +140,12 @@ describe 'Generic File uploading and deletion:', type: :feature do
           sleep(1.second)
           click_on 'Save'
           expect(page).to have_content 'Your files are being processed'
-          within("#activity_log") do
+          within('#activity_log') do
             expect(page).to have_content("User #{current_user.display_name} has deposited Markdown Test")
           end
           expect(page).to have_css('h1', 'Markdown Test')
-          click_on "Notifications"
-          expect(page).to have_content "The file (Markdown Test.txt) was successfully imported"
+          click_on 'Notifications'
+          expect(page).to have_content 'The file (Markdown Test.txt) was successfully imported'
         end
       end
     end
@@ -166,7 +166,7 @@ describe 'Generic File uploading and deletion:', type: :feature do
           fill_in 'generic_work_description', with: filename + '_description'
           select 'Audio', from: 'generic_work_resource_type'
           select 'Attribution-NonCommercial-NoDerivatives 4.0 International', from: 'generic_work_rights'
-          within("#savewidget") do
+          within('#savewidget') do
             choose 'generic_work_visibility_authenticated'
           end
           sleep(1.second)
@@ -174,13 +174,13 @@ describe 'Generic File uploading and deletion:', type: :feature do
           sleep(1.second)
           click_on 'Save'
           expect(page).to have_css('h1', filename + '_title')
-          click_link "My Dashboard"
-          expect(page).to have_css "table#activity"
-          within("table#activity") do
+          click_link 'My Dashboard'
+          expect(page).to have_css 'table#activity'
+          within('table#activity') do
             expect(page).to have_content filename
           end
-          within("#notifications") do
-            expect(page).to have_content "little_file.txt was successfully added"
+          within('#notifications') do
+            expect(page).to have_content 'little_file.txt was successfully added'
           end
           go_to_dashboard_works
           expect(page).to have_content file.title.first

--- a/spec/features/generic_work/view_and_download_spec.rb
+++ b/spec/features/generic_work/view_and_download_spec.rb
@@ -4,34 +4,34 @@ require 'feature_spec_helper'
 include Selectors::Dashboard
 
 describe GenericWork, type: :feature do
-  context "as a standard user" do
+  context 'as a standard user' do
     let(:current_user) { create(:user) }
 
     before { sign_in_with_js(current_user) }
 
-    context "with a public work" do
+    context 'with a public work' do
       let!(:work1) do
         create(:public_work, :with_one_file_and_size, :with_complete_metadata,
                depositor: current_user.login,
-               description: ["Description http://example.org/TheDescriptionLink/"]
+               description: ['Description http://example.org/TheDescriptionLink/']
               )
       end
 
-      specify "I can see all the correct information" do
+      specify 'I can see all the correct information' do
         visit(root_path)
 
         # Work is listed under Recently Uploaded
-        click_link("Recent Additions")
-        within("#recent_docs") do
+        click_link('Recent Additions')
+        within('#recent_docs') do
           expect(page).to have_link(work1.keyword.first)
           click_link(work1.title.first)
         end
 
         # View the work's show page
         expect(page).to have_content work1.title.first
-        expect(page).not_to have_link "Feature"
-        within("h1 span") do
-          expect(page).to have_content("Public")
+        expect(page).not_to have_link 'Feature'
+        within('h1 span') do
+          expect(page).to have_content('Public')
         end
 
         # Meta tag information for Google Scholar
@@ -39,16 +39,16 @@ describe GenericWork, type: :feature do
         expect(page).to have_css('meta[name="citation_author"]', visible: false)
         expect(page).to have_css('meta[name="citation_publication_date"]', visible: false)
 
-        within("ul.breadcrumb") do
-          expect(page).to have_link("My Dashboard")
-          expect(page).to have_link("My Works")
+        within('ul.breadcrumb') do
+          expect(page).to have_link('My Dashboard')
+          expect(page).to have_link('My Works')
         end
 
-        within("p.work_description") do
+        within('p.work_description') do
           expect(page).to have_link 'http://example.org/TheDescriptionLink/'
         end
 
-        within("dl.generic_work") do
+        within('dl.generic_work') do
           expect(page).to have_link work1.related_url.first
           expect(page).to have_link work1.creator.first
           expect(page).to have_link work1.contributor.first
@@ -59,19 +59,19 @@ describe GenericWork, type: :feature do
           expect(page).to have_link work1.based_near.first
           expect(page).to have_link work1.resource_type.first
           expect(page).to have_link work1.related_url.first
-          expect(page).to have_link("Attribution 3.0 United States")
-          expect(page).to have_content("1 Byte")
-          within("dd.total_items") do
-            expect(page).to have_content("1")
+          expect(page).to have_link('Attribution 3.0 United States')
+          expect(page).to have_content('1 Byte')
+          within('dd.total_items') do
+            expect(page).to have_content('1')
           end
-          expect(page).to have_content("Published Date")
+          expect(page).to have_content('Published Date')
         end
       end
 
-      describe "external services" do
+      describe 'external services' do
         before { visit(curation_concerns_generic_work_path(work1)) }
 
-        specify "I can download an Endnote reference" do
+        specify 'I can download an Endnote reference' do
           visit(find_link('EndNote')[:href])
           expect(page.response_headers['Content-Type']).to eq('application/x-endnote-refer')
         end
@@ -88,31 +88,31 @@ describe GenericWork, type: :feature do
       end
     end
 
-    context "with a registered work" do
+    context 'with a registered work' do
       let(:registered_user)  { create(:user) }
-      let!(:registered_work) { create(:registered_work, title: ["Reg. work"], depositor: registered_user.login) }
+      let!(:registered_work) { create(:registered_work, title: ['Reg. work'], depositor: registered_user.login) }
 
-      specify "I can see all the correct information" do
+      specify 'I can see all the correct information' do
         visit(root_path)
 
         # Work is listed under Recently Uploaded
-        click_link("Recent Additions")
-        within("#recent_docs") do
+        click_link('Recent Additions')
+        within('#recent_docs') do
           expect(page).to have_link(registered_work.keyword.first)
           click_link(registered_work.title.first)
         end
 
         # View the work's show page
         expect(page).to have_content registered_work.title.first
-        expect(page).not_to have_link "Feature"
-        within("h1 span") do
-          expect(page).to have_content("Penn State")
+        expect(page).not_to have_link 'Feature'
+        within('h1 span') do
+          expect(page).to have_content('Penn State')
         end
       end
     end
   end
 
-  context "administrator user" do
+  context 'administrator user' do
     let(:admin_user)    { create(:administrator) }
     let!(:public_file)  { create(:public_file, depositor: admin_user.login) }
     let!(:private_file) { create(:private_file, depositor: admin_user.login) }
@@ -124,12 +124,12 @@ describe GenericWork, type: :feature do
 
     context 'When viewing a public file' do
       before  { db_item_title(public_file).click }
-      specify { expect(page).to have_link "Feature" }
+      specify { expect(page).to have_link 'Feature' }
     end
 
     context 'When viewing a private file' do
       before  { db_item_title(private_file).click }
-      specify { expect(page).not_to have_link "Feature" }
+      specify { expect(page).not_to have_link 'Feature' }
     end
   end
 end

--- a/spec/features/generic_work/work_with_many_files_spec.rb
+++ b/spec/features/generic_work/work_with_many_files_spec.rb
@@ -2,7 +2,7 @@
 require 'feature_spec_helper'
 
 describe GenericWork, type: :feature do
-  context "when viewing a work with many files" do
+  context 'when viewing a work with many files' do
     let(:current_user) { create(:user) }
 
     # Build 100 file sets
@@ -18,9 +18,9 @@ describe GenericWork, type: :feature do
     # Build a work that contains the 100 file sets
     let(:work) do
       build(:work, :with_complete_metadata,
-            id: "bigwork",
+            id: 'bigwork',
             depositor: current_user.login,
-            representative_id: "multifile50",
+            representative_id: 'multifile50',
             members: file_sets)
     end
 
@@ -38,14 +38,14 @@ describe GenericWork, type: :feature do
       index_document(list_source)
       index_work(work)
       sign_in_with_js(current_user)
-      visit("/concern/generic_works/bigwork")
+      visit('/concern/generic_works/bigwork')
     end
 
-    it "displays the work page with all the files" do
-      within("dl.attributes") do
-        expect(page).to have_selector('dd.total_items', text: "100")
+    it 'displays the work page with all the files' do
+      within('dl.attributes') do
+        expect(page).to have_selector('dd.total_items', text: '100')
       end
-      within("table.related-files") do
+      within('table.related-files') do
         (1..100).each do |id|
           expect(page).to have_link("File #{id}")
         end

--- a/spec/features/static_pages_spec.rb
+++ b/spec/features/static_pages_spec.rb
@@ -1,44 +1,44 @@
 # frozen_string_literal: true
 require 'feature_spec_helper'
 
-describe "Static pages" do
-  it "displays the About page" do
-    visit("/about")
-    expect(page).to have_content("About")
+describe 'Static pages' do
+  it 'displays the About page' do
+    visit('/about')
+    expect(page).to have_content('About')
   end
 
-  it "displays the Help page" do
-    visit("/help")
-    expect(page).to have_content("Frequently Asked Questions")
-    expect(page).to have_content("User Support")
-    expect(page).to have_content("Support Hours")
-    expect(page).to have_link("Contact Form")
-    expect(page).to have_link("Publishing and Curation Services")
-    expect(page).to have_link("University Libraries")
+  it 'displays the Help page' do
+    visit('/help')
+    expect(page).to have_content('Frequently Asked Questions')
+    expect(page).to have_content('User Support')
+    expect(page).to have_content('Support Hours')
+    expect(page).to have_link('Contact Form')
+    expect(page).to have_link('Publishing and Curation Services')
+    expect(page).to have_link('University Libraries')
   end
 
-  it "displays the Zotero page" do
-    visit("/zotero")
-    expect(page).to have_content("Export to Zotero")
+  it 'displays the Zotero page' do
+    visit('/zotero')
+    expect(page).to have_content('Export to Zotero')
   end
 
-  it "displays the Mendeley page" do
-    visit("/mendeley")
-    expect(page).to have_content("Export to Mendeley")
+  it 'displays the Mendeley page' do
+    visit('/mendeley')
+    expect(page).to have_content('Export to Mendeley')
   end
 
-  it "displays the Licenses page" do
-    visit("/licenses")
-    expect(page).to have_content("ScholarSphere License Descriptions")
+  it 'displays the Licenses page' do
+    visit('/licenses')
+    expect(page).to have_content('ScholarSphere License Descriptions')
   end
 
-  it "displays the Versions page" do
-    visit("/versions")
-    expect(page).to have_content("Versions")
+  it 'displays the Versions page' do
+    visit('/versions')
+    expect(page).to have_content('Versions')
   end
 
-  it "displays the Terms of Use page" do
-    visit("/terms")
-    expect(page).to have_content("Terms of Use for ScholarSphere")
+  it 'displays the Terms of Use page' do
+    visit('/terms')
+    expect(page).to have_content('Terms of Use for ScholarSphere')
   end
 end

--- a/spec/features/support/batch_edit_actions.rb
+++ b/spec/features/support/batch_edit_actions.rb
@@ -14,8 +14,8 @@ module Features
 
     def batch_edit_fields
       [
-        "contributor", "description", "keyword", "publisher", "date_created", "subject",
-        "language", "identifier", "related_url"
+        'contributor', 'description', 'keyword', 'publisher', 'date_created', 'subject',
+        'language', 'identifier', 'related_url'
       ]
     end
   end

--- a/spec/features/support/feature_sessions.rb
+++ b/spec/features/support/feature_sessions.rb
@@ -43,7 +43,7 @@ module Features
         if user
           "rack_test_authenticated_header_#{user.login}"
         else
-          "rack_test_authenticated_header_anonymous"
+          'rack_test_authenticated_header_anonymous'
         end
       end
 

--- a/spec/features/unified_search_spec.rb
+++ b/spec/features/unified_search_spec.rb
@@ -18,21 +18,21 @@ describe 'unified search', type: :feature do
           )
   end
 
-  context "anonymous user" do
-    it "only searches all" do
+  context 'anonymous user' do
+    it 'only searches all' do
       sign_in
       visit '/'
-      expect(page).to have_content("All")
-      expect(page).to have_css("a[data-search-label*=All]", visible: false)
+      expect(page).to have_content('All')
+      expect(page).to have_css('a[data-search-label*=All]', visible: false)
       expect(page).not_to have_css("a[data-search-label*='My Works']", visible: false)
       expect(page).not_to have_css("a[data-search-label*='My Collections']", visible: false)
       expect(page).not_to have_css("a[data-search-label*='My Highlights']", visible: false)
       expect(page).not_to have_css("a[data-search-label*='My Shares']", visible: false)
       within('#search-form-header') do
-        click_button("All")
-        expect(page).to have_content("All of ScholarSphere")
+        click_button('All')
+        expect(page).to have_content('All of ScholarSphere')
         fill_in('search-field-header', with: subject_value)
-        find("#search-submit-header").click
+        find('#search-submit-header').click
       end
       expect(page).to have_content('Search Results')
       expect(page).to have_content(file1.title.first)
@@ -40,23 +40,23 @@ describe 'unified search', type: :feature do
       expect(page).to have_content(collection.title.first)
       expect(page).not_to have_content(file2.title.first)
       click_link(file1.title.first)
-      expect(page).to have_link("Back to search results")
+      expect(page).to have_link('Back to search results')
     end
   end
-  context "known user" do
+  context 'known user' do
     before do
       sign_in_with_js(user)
       visit('/')
     end
-    it "searches all" do
-      expect(page).to have_content("All")
-      expect(page).to have_css("a[data-search-label*=All]", visible: false)
+    it 'searches all' do
+      expect(page).to have_content('All')
+      expect(page).to have_css('a[data-search-label*=All]', visible: false)
       expect(page).to have_css("a[data-search-label*='My Works']", visible: false)
       expect(page).to have_css("a[data-search-label*='My Collections']", visible: false)
       expect(page).to have_css("a[data-search-label*='My Shares']", visible: false)
       within('#search-form-header') do
         fill_in('search-field-header', with: subject_value)
-        click_button("Go")
+        click_button('Go')
       end
       expect(page).to have_content('Search Results')
       expect(page).to have_content(file1.title.first)
@@ -64,7 +64,7 @@ describe 'unified search', type: :feature do
       expect(page).to have_content(file3.title.first)
       expect(page).to have_content(collection.title.first)
 
-      find("a[title=Gallery]").click
+      find('a[title=Gallery]').click
       expect(page).to have_content(file1.title.first)
       expect(page).to have_content(file2.title.first)
       expect(page).to have_content(file3.title.first)
@@ -72,31 +72,31 @@ describe 'unified search', type: :feature do
       # TODO: Collection icon? see #284
       # expect(page).to have_css("img.collection-icon")
       click_link(file1.title.first)
-      expect(page).to have_link("Back to search results")
+      expect(page).to have_link('Back to search results')
     end
-    it "searches My Works" do
-      expect(page).to have_content("All")
-      click_on("All")
-      click_on("My Works")
+    it 'searches My Works' do
+      expect(page).to have_content('All')
+      click_on('All')
+      click_on('My Works')
       within('#search-form-header') do
         fill_in('search-field-header', with: subject_value)
-        click_button("Go")
+        click_button('Go')
       end
-      expect(page).to have_selector('li.active', text: "Works")
+      expect(page).to have_selector('li.active', text: 'Works')
       expect(page).to have_content(file1.title.first)
       expect(page).to have_content(file2.title.first)
       expect(page).not_to have_content(file3.title.first)
       expect(page).not_to have_css('#src_copy_link' + collection.id)
     end
-    it "searches My Collections" do
-      expect(page).to have_content("All")
-      click_on("All")
-      click_on("My Collections")
+    it 'searches My Collections' do
+      expect(page).to have_content('All')
+      click_on('All')
+      click_on('My Collections')
       within('#search-form-header') do
         fill_in('search-field-header', with: subject_value)
-        click_button("Go")
+        click_button('Go')
       end
-      expect(page).to have_selector('li.active', text: "Collections")
+      expect(page).to have_selector('li.active', text: 'Collections')
       expect(page).to have_content(collection.title.first)
       expect(page).not_to have_content(file1.title.first)
       expect(page).not_to have_content(file2.title.first)

--- a/spec/features/user_stats_spec.rb
+++ b/spec/features/user_stats_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'feature_spec_helper'
 
-describe "User Statistics", type: :feature do
+describe 'User Statistics', type: :feature do
   let!(:user) { create(:user) }
 
   before do
@@ -10,9 +10,9 @@ describe "User Statistics", type: :feature do
     12.times { create(:work, depositor: user.login) }
     UserStat.create!(user_id: user.id, date: Date.today, file_views: 11, file_downloads: 6)
   end
-  it "includes file deposited, viewed, and downloaded, as well as followers" do
-    visit "/dashboard"
-    expect(page).to have_selector('span.badge', text: "12")
+  it 'includes file deposited, viewed, and downloaded, as well as followers' do
+    visit '/dashboard'
+    expect(page).to have_selector('span.badge', text: '12')
     expect(page).to have_content('11 Views')
     expect(page).to have_content('6 Downloads')
   end

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -1,50 +1,50 @@
 # frozen_string_literal: true
 require 'feature_spec_helper'
 
-describe "User Profile", type: :feature do
+describe 'User Profile', type: :feature do
   let!(:admin_user) { create(:administrator, :with_event, event: event_text) }
   let!(:archivist)  { create(:archivist) }
   let!(:file1)      { create(:trophy_file, depositor: admin_user.login) }
   let!(:u2)         { create(:random_user, :with_proxy, proxy_for: admin_user) }
 
-  let(:event_text)  { "Text profile event" }
+  let(:event_text)  { 'Text profile event' }
 
-  context "with any user" do
+  context 'with any user' do
     specify do
       sign_in_with_js(admin_user)
       visit("/users/#{admin_user}\#contributions")
 
       # allows to view profile with highlighted works
-      expect(page).to have_css '.active a', text: "Highlighted"
+      expect(page).to have_css '.active a', text: 'Highlighted'
       expect(page).to have_content file1.title.first
 
       # allows clicking on activity tab
-      click_link "Activity"
-      expect(page).to have_selector('li.active', text: "Activity")
+      click_link 'Activity'
+      expect(page).to have_selector('li.active', text: 'Activity')
       expect(page).to have_content(event_text)
 
       # allows clicking on User Info tab
-      click_link "User Info"
-      expect(page).to have_selector('h3', text: "Directory Information")
-      expect(page).to have_selector('dt', text: "Title")
+      click_link 'User Info'
+      expect(page).to have_selector('h3', text: 'Directory Information')
+      expect(page).to have_selector('dt', text: 'Title')
 
       # allows editing the user's profile
-      click_link "Edit Profile"
+      click_link 'Edit Profile'
       fill_in 'user_twitter_handle', with: 'curatorOfData'
       fill_in 'user_orcid', with: '0000-0000-0000-0000'
       click_button 'Save Profile'
-      expect(page).to have_content "Your profile has been updated"
-      expect(page).to have_content "curatorOfData"
-      expect(page).to have_content "0000-0000-0000-0000"
+      expect(page).to have_content 'Your profile has been updated'
+      expect(page).to have_content 'curatorOfData'
+      expect(page).to have_content '0000-0000-0000-0000'
 
       # displays other users
-      click_link "View Users"
+      click_link 'View Users'
       expect(page).to have_xpath("//td/a[@href='/users/#{admin_user.login}']")
 
       # should allow searching through all users
       expect(page).to have_xpath("//td/a[@href='/users/archivist1']")
       fill_in 'user_search', with: 'archivist1'
-      click_button "user_submit"
+      click_button 'user_submit'
       expect(page).not_to have_xpath("//td/a[@href='/users/#{admin_user.login}']")
       expect(page).to have_xpath("//td/a[@href='/users/archivist1']")
     end

--- a/spec/forms/batch_edit_form_spec.rb
+++ b/spec/forms/batch_edit_form_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 describe BatchEditForm do
-  describe "::build_permitted_params" do
+  describe '::build_permitted_params' do
     subject { described_class }
     its(:build_permitted_params) { is_expected.to include(:visibility) }
   end

--- a/spec/forms/batch_upload_form_spec.rb
+++ b/spec/forms/batch_upload_form_spec.rb
@@ -2,11 +2,11 @@
 require 'rails_helper'
 
 describe BatchUploadForm do
-  let(:user)    { create(:user, display_name: "Test A User") }
+  let(:user)    { create(:user, display_name: 'Test A User') }
   let(:ability) { Ability.new(user) }
   let(:form)    { described_class.new(BatchUploadItem.new, ability) }
 
-  describe "::required_fields" do
+  describe '::required_fields' do
     subject { described_class }
 
     its(:required_fields) { is_expected.to contain_exactly(:title,
@@ -16,21 +16,21 @@ describe BatchUploadForm do
                                                            :description) }
   end
 
-  describe "#initialize_field" do
+  describe '#initialize_field' do
     subject { form[:creator] }
-    it { is_expected.to eq(["User, Test A"]) }
+    it { is_expected.to eq(['User, Test A']) }
   end
 
-  describe "#model_attributes" do
+  describe '#model_attributes' do
     subject { described_class.model_attributes(raw_attrs) }
-    let(:raw_attrs) { ActionController::Parameters.new("creator" => ["Santy, Lorraine C", ""], "keyword" => ["hhh"], "rights" => "https://creativecommons.org/licenses/by/4.0/", "description" => ["ghjg"], "contributor" => [""], "publisher" => [""], "date_created" => [""], "subject" => [""], "language" => [""], "identifier" => [""], "based_near" => [""], "related_url" => [""], "source" => [""], "admin_set_id" => "", "collection_ids" => [""], "visibility_during_embargo" => "restricted", "embargo_release_date" => "2017-01-24", "visibility_after_embargo" => "open", "visibility_during_lease" => "open", "lease_expiration_date" => "2017-01-24", "visibility_after_lease" => "restricted", "visibility" => "restricted") }
-    it { is_expected.to eq("creator" => ["Santy, Lorraine C"], "keyword" => ["hhh"], "rights" => "https://creativecommons.org/licenses/by/4.0/", "description" => ["ghjg"], "contributor" => [], "publisher" => [], "date_created" => [], "subject" => [], "language" => [], "identifier" => [], "based_near" => [], "related_url" => [], "source" => [], "admin_set_id" => "", "collection_ids" => [], "visibility_during_embargo" => "restricted", "embargo_release_date" => "2017-01-24", "visibility_after_embargo" => "open", "visibility_during_lease" => "open", "lease_expiration_date" => "2017-01-24", "visibility_after_lease" => "restricted", "visibility" => "restricted") }
+    let(:raw_attrs) { ActionController::Parameters.new('creator' => ['Santy, Lorraine C', ''], 'keyword' => ['hhh'], 'rights' => 'https://creativecommons.org/licenses/by/4.0/', 'description' => ['ghjg'], 'contributor' => [''], 'publisher' => [''], 'date_created' => [''], 'subject' => [''], 'language' => [''], 'identifier' => [''], 'based_near' => [''], 'related_url' => [''], 'source' => [''], 'admin_set_id' => '', 'collection_ids' => [''], 'visibility_during_embargo' => 'restricted', 'embargo_release_date' => '2017-01-24', 'visibility_after_embargo' => 'open', 'visibility_during_lease' => 'open', 'lease_expiration_date' => '2017-01-24', 'visibility_after_lease' => 'restricted', 'visibility' => 'restricted') }
+    it { is_expected.to eq('creator' => ['Santy, Lorraine C'], 'keyword' => ['hhh'], 'rights' => 'https://creativecommons.org/licenses/by/4.0/', 'description' => ['ghjg'], 'contributor' => [], 'publisher' => [], 'date_created' => [], 'subject' => [], 'language' => [], 'identifier' => [], 'based_near' => [], 'related_url' => [], 'source' => [], 'admin_set_id' => '', 'collection_ids' => [], 'visibility_during_embargo' => 'restricted', 'embargo_release_date' => '2017-01-24', 'visibility_after_embargo' => 'open', 'visibility_during_lease' => 'open', 'lease_expiration_date' => '2017-01-24', 'visibility_after_lease' => 'restricted', 'visibility' => 'restricted') }
   end
 
-  describe "#target_selector" do
+  describe '#target_selector' do
     subject { form.target_selector }
-    it { is_expected.to eq("#new_batch_upload_item") }
+    it { is_expected.to eq('#new_batch_upload_item') }
   end
 
-  it_behaves_like "a standard work form"
+  it_behaves_like 'a standard work form'
 end

--- a/spec/forms/collection_form_spec.rb
+++ b/spec/forms/collection_form_spec.rb
@@ -3,28 +3,28 @@ require 'rails_helper'
 
 describe CollectionForm do
   let(:ability)    { Ability.new(nil) }
-  let(:collection) { build(:collection, id: "collection-id") }
+  let(:collection) { build(:collection, id: 'collection-id') }
   let(:form)       { described_class.new(collection, ability, nil) }
   let(:work)       { create(:work) }
 
   before { allow(form).to receive(:batch_document_ids).and_return([work.id]) }
 
-  describe "#incorporated_work_presenters" do
+  describe '#incorporated_work_presenters' do
     subject { form.incorporated_work_presenters }
     it { is_expected.to contain_exactly(kind_of(WorkShowPresenter)) }
   end
 
-  describe "#incorporated_member_docs" do
+  describe '#incorporated_member_docs' do
     subject { form.incorporated_member_docs }
     it { is_expected.to contain_exactly(kind_of(SolrDocument)) }
   end
 
-  describe "#primary_terms" do
+  describe '#primary_terms' do
     subject { form.primary_terms }
     it { is_expected.to contain_exactly(:title, :description, :keyword) }
   end
 
-  describe "#secondary_terms" do
+  describe '#secondary_terms' do
     subject { form.secondary_terms }
     it { is_expected.to contain_exactly(:creator,
                                         :contributor,
@@ -39,7 +39,7 @@ describe CollectionForm do
                                         :resource_type) }
   end
 
-  describe "::required_fields" do
+  describe '::required_fields' do
     subject { described_class.required_fields }
     it { is_expected.to contain_exactly(:title, :description, :keyword) }
   end

--- a/spec/forms/generic_work_form_spec.rb
+++ b/spec/forms/generic_work_form_spec.rb
@@ -2,19 +2,19 @@
 require 'rails_helper'
 
 describe CurationConcerns::GenericWorkForm do
-  let(:user)    { create(:user, display_name: "Test A User") }
+  let(:user)    { create(:user, display_name: 'Test A User') }
   let(:ability) { Ability.new(user) }
   let(:work)    { build(:work) }
   let(:form)    { described_class.new(work, ability) }
-  describe "#initialize_field" do
+  describe '#initialize_field' do
     subject { form[:creator] }
-    it { is_expected.to eq(["User, Test A"]) }
+    it { is_expected.to eq(['User, Test A']) }
   end
 
-  describe "::model_attributes" do
+  describe '::model_attributes' do
     subject { described_class.model_attributes(params) }
-    context "when attributes have multiple spaces" do
-      let(:params) { ActionController::Parameters.new(title: " I am  in a  space ", rights: " url ") }
+    context 'when attributes have multiple spaces' do
+      let(:params) { ActionController::Parameters.new(title: ' I am  in a  space ', rights: ' url ') }
 
       it 'checks that title parameter does not have extra spaces' do
         expect(subject['title']).to eq ['I am in a space']
@@ -26,39 +26,39 @@ describe CurationConcerns::GenericWorkForm do
     end
   end
 
-  it_behaves_like "a standard work form"
+  it_behaves_like 'a standard work form'
 
-  describe "#visibility" do
+  describe '#visibility' do
     subject { work }
-    context "with an existing work" do
+    context 'with an existing work' do
       let(:work) { build(:private_work) }
       before { allow(work).to receive(:new_record?).and_return(false) }
-      its(:visibility) { is_expected.to eq("restricted") }
+      its(:visibility) { is_expected.to eq('restricted') }
     end
   end
 
-  describe "#target_selector" do
+  describe '#target_selector' do
     subject { form.target_selector }
-    context "with a new work" do
-      it { is_expected.to eq("#new_generic_work") }
+    context 'with a new work' do
+      it { is_expected.to eq('#new_generic_work') }
     end
 
-    context "when editing an existing work" do
-      let(:work) { build(:work, id: "1234") }
+    context 'when editing an existing work' do
+      let(:work) { build(:work, id: '1234') }
       before { allow(work).to receive(:persisted?).and_return(true) }
-      it { is_expected.to eq("#edit_generic_work_1234") }
+      it { is_expected.to eq('#edit_generic_work_1234') }
     end
   end
 
-  describe "#select_files" do
+  describe '#select_files' do
     let(:work) { build(:public_work) }
 
     let(:public_file_set) do
-      build(:file_set, :with_file_size, :public, id: "public-fileset", title: ["Public File"])
+      build(:file_set, :with_file_size, :public, id: 'public-fileset', title: ['Public File'])
     end
 
     let(:registered_file_set) do
-      build(:file_set, :with_file_size, :registered, id: "registered-fileset", title: ["Registered File"])
+      build(:file_set, :with_file_size, :registered, id: 'registered-fileset', title: ['Registered File'])
     end
 
     let(:file_presenters) do
@@ -71,6 +71,6 @@ describe CurationConcerns::GenericWorkForm do
     before { allow(form).to receive(:file_presenters).and_return(file_presenters) }
 
     subject { form }
-    its(:select_files) { is_expected.to eq("Public File" => "public-fileset") }
+    its(:select_files) { is_expected.to eq('Public File' => 'public-fileset') }
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -2,20 +2,20 @@
 require 'rails_helper'
 
 describe ApplicationHelper do
-  describe "#more_facets_link_path" do
-    context "with the shares controller" do
-      before { allow(helper).to receive(:controller_name).and_return("shares") }
+  describe '#more_facets_link_path' do
+    context 'with the shares controller' do
+      before { allow(helper).to receive(:controller_name).and_return('shares') }
 
-      it "returns the path" do
-        expect(helper.more_facets_link_path("solr_field")).to eq("/dashboard/shares/facet/solr_field")
+      it 'returns the path' do
+        expect(helper.more_facets_link_path('solr_field')).to eq('/dashboard/shares/facet/solr_field')
       end
     end
 
-    context "with the works controller" do
-      before { allow(helper).to receive(:controller_name).and_return("works") }
+    context 'with the works controller' do
+      before { allow(helper).to receive(:controller_name).and_return('works') }
 
-      it "returns the path" do
-        expect(helper.more_facets_link_path("solr_field")).to eq("/dashboard/works/facet/solr_field")
+      it 'returns the path' do
+        expect(helper.more_facets_link_path('solr_field')).to eq('/dashboard/works/facet/solr_field')
       end
     end
   end

--- a/spec/indexers/collection_indexer_spec.rb
+++ b/spec/indexers/collection_indexer_spec.rb
@@ -2,12 +2,12 @@
 require 'rails_helper'
 
 describe CollectionIndexer do
-  describe "fontawesome default icon" do
-    let(:collection) { build(:collection, id: "1234") }
+  describe 'fontawesome default icon' do
+    let(:collection) { build(:collection, id: '1234') }
     let(:solr_doc) { described_class.new(collection).generate_solr_document }
 
-    it "indexes thumbnail" do
-      expect(solr_doc["thumbnail_path_ss"]).to start_with("/assets/collection")
+    it 'indexes thumbnail' do
+      expect(solr_doc['thumbnail_path_ss']).to start_with('/assets/collection')
     end
   end
 end

--- a/spec/indexers/file_set_indexer_spec.rb
+++ b/spec/indexers/file_set_indexer_spec.rb
@@ -17,19 +17,19 @@ describe FileSetIndexer do
     )
   end
 
-  describe "#generate_solr_document" do
+  describe '#generate_solr_document' do
     let(:solr_doc) { indexer.generate_solr_document }
     subject { solr_doc }
 
-    context "with a file containing technical metadata" do
+    context 'with a file containing technical metadata' do
       before { allow(file_set).to receive(:original_file).and_return(file) }
-      it { is_expected.to include("file_size_lts" => "12") }
-      its(:keys) { is_expected.not_to include("file_size_is") }
+      it { is_expected.to include('file_size_lts' => '12') }
+      its(:keys) { is_expected.not_to include('file_size_is') }
     end
 
-    context "without a file" do
-      it { is_expected.to include("file_size_lts" => nil) }
-      its(:keys) { is_expected.not_to include("file_size_is") }
+    context 'without a file' do
+      it { is_expected.to include('file_size_lts' => nil) }
+      its(:keys) { is_expected.not_to include('file_size_is') }
     end
   end
 end

--- a/spec/indexers/work_indexer_spec.rb
+++ b/spec/indexers/work_indexer_spec.rb
@@ -6,8 +6,8 @@ describe WorkIndexer do
 
   let(:file_set) { build(:file_set) }
   let(:work)     { build(:work, representative: file_set,
-                                creator: ["BIG. Name"],
-                                keyword: ["Bird"]) }
+                                creator: ['BIG. Name'],
+                                keyword: ['Bird']) }
   let(:indexer)  { described_class.new(work) }
 
   let(:file) do
@@ -20,35 +20,35 @@ describe WorkIndexer do
     )
   end
 
-  describe "#generate_solr_document" do
+  describe '#generate_solr_document' do
     let(:solr_doc) { indexer.generate_solr_document }
 
     subject { solr_doc }
-    it { is_expected.to include("bytes_lts" => 0) }
+    it { is_expected.to include('bytes_lts' => 0) }
 
-    describe "file_format" do
-      subject { solr_doc[Solrizer.solr_name("file_format", :facetable)] }
+    describe 'file_format' do
+      subject { solr_doc[Solrizer.solr_name('file_format', :facetable)] }
 
-      context "with a file containing technical metadata" do
+      context 'with a file containing technical metadata' do
         before { allow(file_set).to receive(:original_file).and_return(file) }
-        it { is_expected.to eq("jpeg (JPEG Image)") }
+        it { is_expected.to eq('jpeg (JPEG Image)') }
       end
 
-      context "without a file" do
+      context 'without a file' do
         it { is_expected.to be_nil }
       end
 
-      context "without a representative" do
+      context 'without a representative' do
         before { allow(work).to receive(:representative).and_return(nil) }
         it { is_expected.to be_nil }
       end
     end
 
-    describe "a groomed document" do
-      it { is_expected.to include("creator_sim" => ["Big Name"]) }
-      it { is_expected.to include("creator_tesim" => ["BIG. Name"]) }
-      it { is_expected.to include("keyword_sim" => ["bird"]) }
-      it { is_expected.to include("keyword_tesim" => ["Bird"]) }
+    describe 'a groomed document' do
+      it { is_expected.to include('creator_sim' => ['Big Name']) }
+      it { is_expected.to include('creator_tesim' => ['BIG. Name']) }
+      it { is_expected.to include('keyword_sim' => ['bird']) }
+      it { is_expected.to include('keyword_tesim' => ['Bird']) }
     end
   end
 end

--- a/spec/jobs/attach_files_to_work_job_spec.rb
+++ b/spec/jobs/attach_files_to_work_job_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 describe AttachFilesToWorkJob do
   let(:user)          { create(:user) }
   let(:work)          { create(:work, depositor: user.login) }
-  let(:file)          { File.open(File.join(fixture_path, "world.png")) }
+  let(:file)          { File.open(File.join(fixture_path, 'world.png')) }
   let(:uploaded_file) { Sufia::UploadedFile.create(file: file, user: user) }
   let(:job)           { described_class.new(work, [uploaded_file]) }
 
@@ -13,21 +13,21 @@ describe AttachFilesToWorkJob do
     allow(Hydra::Works::VirusCheckerService).to receive(:file_has_virus?).and_return(false)
   end
 
-  context "when the file is successfully added" do
-    it "sends a success message" do
+  context 'when the file is successfully added' do
+    it 'sends a success message' do
       expect(AttachFilesToWorkSuccessService).to receive(:new).with(user, kind_of(File)).and_call_original
       expect(CharacterizeJob).to receive(:perform_later).once
       expect { job.perform_now }.to change { QueuedFile.count }.by(-1)
     end
   end
 
-  context "when the file is not successfully added" do
+  context 'when the file is not successfully added' do
     let(:bad_actor) { double(CurationConcerns::Actors::FileSetActor) }
     before do
       allow(bad_actor).to receive(:create_content).with(file).and_return(false)
       allow(bad_actor).to receive(:user).and_return(user)
     end
-    it "sends a success message" do
+    it 'sends a success message' do
       expect(AttachFilesToWorkFailureService).to receive(:new).with(user, kind_of(File)).and_call_original
       job.send(:add_file, bad_actor, file)
     end

--- a/spec/jobs/batch_create_job_spec.rb
+++ b/spec/jobs/batch_create_job_spec.rb
@@ -5,49 +5,49 @@ describe BatchCreateJob do
   let(:user) { create(:user) }
   let(:log)  { create(:batch_create_operation, user: user) }
 
-  describe "#perform" do
-    context "with local files" do
+  describe '#perform' do
+    context 'with local files' do
       let(:uploaded_files) { ['1', '2'] }
       let(:titles)         { { '1' => 'File One', '2' => 'File Two' } }
       let(:resource_types) { { '1' => 'Article', '2' => 'Image' } }
       let(:attributes)     { { keyword: [], 'remote_files' => [], 'uploaded_files' => uploaded_files } }
-      let(:uploaded_file1) { { keyword: [], uploaded_files: ["1"], title: ["File One"], resource_type: ["Article"] } }
-      let(:uploaded_file2) { { keyword: [], uploaded_files: ["2"], title: ["File Two"], resource_type: ["Image"] } }
+      let(:uploaded_file1) { { keyword: [], uploaded_files: ['1'], title: ['File One'], resource_type: ['Article'] } }
+      let(:uploaded_file2) { { keyword: [], uploaded_files: ['2'], title: ['File Two'], resource_type: ['Image'] } }
 
-      it "creates works" do
-        expect(CreateWorkJob).to receive(:perform_later).with(user, "GenericWork", uploaded_file1, CurationConcerns::Operation)
-        expect(CreateWorkJob).to receive(:perform_later).with(user, "GenericWork", uploaded_file2, CurationConcerns::Operation)
+      it 'creates works' do
+        expect(CreateWorkJob).to receive(:perform_later).with(user, 'GenericWork', uploaded_file1, CurationConcerns::Operation)
+        expect(CreateWorkJob).to receive(:perform_later).with(user, 'GenericWork', uploaded_file2, CurationConcerns::Operation)
         described_class.perform_now(user, titles, resource_types, attributes, log)
       end
     end
 
-    context "with remote files" do
+    context 'with remote files' do
       let(:remote_file)    { { 'url' => 'file:///remote.txt', 'file_name' => 'remote.txt', 'file_size' => '100' } }
       let(:titles)         { { 'file:///remote.txt' => 'remote.txt' } }
       let(:resource_types) { { 'file:///remote.txt' => 'Article' } }
       let(:attributes)     { { keyword: [], 'remote_files' => [remote_file], 'uploaded_files' => [] } }
 
-      let(:expected_remote_file) { { keyword: [], remote_files: [remote_file], title: ["remote.txt"], resource_type: ["Article"] } }
+      let(:expected_remote_file) { { keyword: [], remote_files: [remote_file], title: ['remote.txt'], resource_type: ['Article'] } }
 
-      it "creates works" do
-        expect(CreateWorkJob).to receive(:perform_later).with(user, "GenericWork", expected_remote_file, CurationConcerns::Operation)
+      it 'creates works' do
+        expect(CreateWorkJob).to receive(:perform_later).with(user, 'GenericWork', expected_remote_file, CurationConcerns::Operation)
         described_class.perform_now(user, titles, resource_types, attributes, log)
       end
     end
 
-    context "with both remote and local files" do
+    context 'with both remote and local files' do
       let(:uploaded_files) { ['1'] }
       let(:remote_file)    { { 'url' => 'file:///remote.txt', 'file_name' => 'remote.txt', 'file_size' => '100' } }
       let(:titles)         { { '1' => 'File One', 'file:///remote.txt' => 'remote.txt' } }
       let(:resource_types) { { '1' => 'Article', 'file:///remote.txt' => 'Article' } }
       let(:attributes)     { { keyword: [], 'remote_files' => [remote_file], 'uploaded_files' => uploaded_files } }
 
-      let(:uploaded_file1)       { { keyword: [], uploaded_files: ["1"], title: ["File One"], resource_type: ["Article"] } }
-      let(:expected_remote_file) { { keyword: [], remote_files: [remote_file], title: ["remote.txt"], resource_type: ["Article"] } }
+      let(:uploaded_file1)       { { keyword: [], uploaded_files: ['1'], title: ['File One'], resource_type: ['Article'] } }
+      let(:expected_remote_file) { { keyword: [], remote_files: [remote_file], title: ['remote.txt'], resource_type: ['Article'] } }
 
-      it "creates works" do
-        expect(CreateWorkJob).to receive(:perform_later).with(user, "GenericWork", uploaded_file1, CurationConcerns::Operation)
-        expect(CreateWorkJob).to receive(:perform_later).with(user, "GenericWork", expected_remote_file, CurationConcerns::Operation)
+      it 'creates works' do
+        expect(CreateWorkJob).to receive(:perform_later).with(user, 'GenericWork', uploaded_file1, CurationConcerns::Operation)
+        expect(CreateWorkJob).to receive(:perform_later).with(user, 'GenericWork', expected_remote_file, CurationConcerns::Operation)
         described_class.perform_now(user, titles, resource_types, attributes, log)
       end
     end

--- a/spec/jobs/copy_permissions_job_spec.rb
+++ b/spec/jobs/copy_permissions_job_spec.rb
@@ -2,8 +2,8 @@
 require 'rails_helper'
 
 describe CopyPermissionsJob do
-  context "when changing visibility" do
-    let(:work)     { create(:public_work, edit_users: ["user1"]) }
+  context 'when changing visibility' do
+    let(:work)     { create(:public_work, edit_users: ['user1']) }
     let(:file_set) { create(:file_set) }
 
     subject { file_set }
@@ -14,12 +14,12 @@ describe CopyPermissionsJob do
       described_class.perform_now(work)
     end
 
-    its(:visibility) { is_expected.to eq("open") }
+    its(:visibility) { is_expected.to eq('open') }
   end
 
   # This duplicates Sufia's InheritPermissionsJob spec tests
-  context "when changing permissions" do
-    let(:user) { create(:user, login: "user") }
+  context 'when changing permissions' do
+    let(:user) { create(:user, login: 'user') }
     let(:work) { create(:work, :with_one_file, user: user) }
 
     before do
@@ -27,7 +27,7 @@ describe CopyPermissionsJob do
       work.save
     end
 
-    context "when edit people change" do
+    context 'when edit people change' do
       let(:name) { 'abc@123.com' }
       let(:type) { 'person' }
       let(:access) { 'edit' }
@@ -38,30 +38,30 @@ describe CopyPermissionsJob do
 
         described_class.perform_now(work)
         work.reload.file_sets.each do |file|
-          expect(file.edit_users).to match_array [user.to_s, "abc@123.com"]
+          expect(file.edit_users).to match_array [user.to_s, 'abc@123.com']
         end
       end
 
-      context "when people should be removed" do
+      context 'when people should be removed' do
         before do
           file_set = work.file_sets.first
-          file_set.permissions.build(name: "remove_me", type: type, access: access)
+          file_set.permissions.build(name: 'remove_me', type: type, access: access)
           file_set.save
         end
 
         it 'copies permissions to its contained files' do
           # files have the depositor as the edit user to begin with
-          expect(work.file_sets.first.edit_users).to eq [user.to_s, "remove_me"]
+          expect(work.file_sets.first.edit_users).to eq [user.to_s, 'remove_me']
 
           described_class.perform_now(work)
           work.reload.file_sets.each do |file|
-            expect(file.edit_users).to match_array [user.to_s, "abc@123.com"]
+            expect(file.edit_users).to match_array [user.to_s, 'abc@123.com']
           end
         end
       end
     end
 
-    context "when read people change" do
+    context 'when read people change' do
       let(:name) { 'abc@123.com' }
       let(:type) { 'person' }
       let(:access) { 'read' }
@@ -72,13 +72,13 @@ describe CopyPermissionsJob do
 
         described_class.perform_now(work)
         work.reload.file_sets.each do |file|
-          expect(file.read_users).to match_array ["abc@123.com"]
+          expect(file.read_users).to match_array ['abc@123.com']
           expect(file.edit_users).to match_array [user.to_s]
         end
       end
     end
 
-    context "when read groups change" do
+    context 'when read groups change' do
       let(:name) { 'my_read_group' }
       let(:type) { 'group' }
       let(:access) { 'read' }
@@ -89,13 +89,13 @@ describe CopyPermissionsJob do
 
         described_class.perform_now(work)
         work.reload.file_sets.each do |file|
-          expect(file.read_groups).to match_array ["my_read_group"]
+          expect(file.read_groups).to match_array ['my_read_group']
           expect(file.edit_users).to match_array [user.to_s]
         end
       end
     end
 
-    context "when edit groups change" do
+    context 'when edit groups change' do
       let(:name) { 'my_edit_group' }
       let(:type) { 'group' }
       let(:access) { 'edit' }
@@ -106,7 +106,7 @@ describe CopyPermissionsJob do
 
         described_class.perform_now(work)
         work.reload.file_sets.each do |file|
-          expect(file.edit_groups).to match_array ["my_edit_group"]
+          expect(file.edit_groups).to match_array ['my_edit_group']
           expect(file.edit_users).to match_array [user.to_s]
         end
       end

--- a/spec/jobs/create_derivatives_job_spec.rb
+++ b/spec/jobs/create_derivatives_job_spec.rb
@@ -4,15 +4,15 @@ require 'rails_helper'
 describe CreateDerivativesJob do
   let(:file_set) { build(:file_set) }
 
-  context "when the job fails" do
+  context 'when the job fails' do
     before do
-      allow(CurationConcerns::WorkingDirectory).to receive(:find_or_retrieve).and_return("filename")
-      allow(file_set).to receive(:create_derivatives).and_raise(StandardError, "failed to create derivatives")
+      allow(CurationConcerns::WorkingDirectory).to receive(:find_or_retrieve).and_return('filename')
+      allow(file_set).to receive(:create_derivatives).and_raise(StandardError, 'failed to create derivatives')
     end
 
-    it "sends a message to the user" do
+    it 'sends a message to the user' do
       expect(FileSetDerivativeFailureJob).to receive(:perform_later).with(file_set, kind_of(User))
-      expect { described_class.perform_now(file_set, "file-id") }.to raise_error(StandardError)
+      expect { described_class.perform_now(file_set, 'file-id') }.to raise_error(StandardError)
     end
   end
 end

--- a/spec/jobs/file_set_derivative_failure_job_spec.rb
+++ b/spec/jobs/file_set_derivative_failure_job_spec.rb
@@ -7,7 +7,7 @@ describe FileSetDerivativeFailureJob do
 
   let!(:work)    { create(:work, :with_one_file, user: user) }
 
-  it "sends an failed derivative message on a file set" do
+  it 'sends an failed derivative message on a file set' do
     expect {
       described_class.perform_now(file_set, user)
     }.to change { file_set.events.length }.by(1)

--- a/spec/jobs/import_url_job_spec.rb
+++ b/spec/jobs/import_url_job_spec.rb
@@ -4,12 +4,12 @@ require 'rails_helper'
 
 describe ImportUrlJob do
   let(:user)           { create(:user) }
-  let(:file_set)       { create(:file_set, user: user, import_url: "import_url") }
+  let(:file_set)       { create(:file_set, user: user, import_url: 'import_url') }
   let(:log)            { double }
   let(:mock_retriever) { double }
   let(:http_status) { true }
-  let(:mock_http_result) { instance_double("HTTParty::Response", success?: http_status) }
-  let(:file_name) { "Development Team Projects and Milestones (not downloaded).xlsx" }
+  let(:mock_http_result) { instance_double('HTTParty::Response', success?: http_status) }
+  let(:file_name) { 'Development Team Projects and Milestones (not downloaded).xlsx' }
 
   before do
     allow(log).to receive(:performing!)
@@ -19,18 +19,18 @@ describe ImportUrlJob do
     allow(HTTParty).to receive(:head).and_return(mock_http_result)
   end
 
-  it "sanitizes the file name" do
+  it 'sanitizes the file name' do
     expect(CurationConcerns.config.callback).to receive(:run).with(:after_import_url_success, file_set, user)
     expect(log).to receive(:success!)
     described_class.perform_now(file_set, file_name, log)
-    expect(file_set.label).to eq("Development_Team_Projects_and_Milestones__not_downloaded_.xlsx")
+    expect(file_set.label).to eq('Development_Team_Projects_and_Milestones__not_downloaded_.xlsx')
   end
 
-  context "http head fails" do
+  context 'http head fails' do
     let(:http_status) { false }
     let(:inbox) { user.mailbox.inbox }
 
-    it "fails to add the content" do
+    it 'fails to add the content' do
       expect(log).to receive(:fail!)
       expect(file_set.original_file).to be_nil
       described_class.perform_now(file_set, file_name, log)

--- a/spec/jobs/import_version_job_spec.rb
+++ b/spec/jobs/import_version_job_spec.rb
@@ -4,8 +4,8 @@ require 'rails_helper'
 describe ImportVersionJob do
   let(:user)         { create(:user) }
   let(:work)         { create(:public_work_with_png, depositor: user.login) }
-  let(:file)         { File.join(Dir.tmpdir, "world.png") }
-  let(:fixture_file) { File.join(fixture_path, "world.png") }
+  let(:file)         { File.join(Dir.tmpdir, 'world.png') }
+  let(:fixture_file) { File.join(fixture_path, 'world.png') }
   let(:file_set)     { work.file_sets.first }
 
   before do
@@ -13,7 +13,7 @@ describe ImportVersionJob do
     FileUtils.cp fixture_file, file
   end
 
-  it "characterizes the file and then deletes it" do
+  it 'characterizes the file and then deletes it' do
     expect(CharacterizeJob).to receive(:perform_now).once
     described_class.perform_now(file_set, file)
     expect(File.exist?(file)).to be_falsey

--- a/spec/jobs/ingest_file_job_spec.rb
+++ b/spec/jobs/ingest_file_job_spec.rb
@@ -4,15 +4,15 @@ require 'rails_helper'
 describe IngestFileJob do
   let(:user)     { create(:user) }
   let(:file_set) { create(:file_set, :with_png, depositor: user.login) }
-  let(:filepath) { File.join(fixture_path, "world.png") }
+  let(:filepath) { File.join(fixture_path, 'world.png') }
 
-  context "when adding a new version" do
+  context 'when adding a new version' do
     before { allow(CharacterizeJob).to receive(:perform_later) }
 
     it "updates the file set's title with the file name" do
-      expect(file_set.title).to contain_exactly("Sample PNG")
+      expect(file_set.title).to contain_exactly('Sample PNG')
       described_class.perform_now(file_set, filepath, user)
-      expect(file_set.title).to contain_exactly("world.png")
+      expect(file_set.title).to contain_exactly('world.png')
     end
   end
 end

--- a/spec/jobs/ingest_local_file_job_spec.rb
+++ b/spec/jobs/ingest_local_file_job_spec.rb
@@ -5,7 +5,7 @@ describe IngestLocalFileJob do
   let(:user)     { create(:user) }
   let(:file_set) { FileSet.new }
   let(:actor)    { double }
-  let(:path)     { File.join(fixture_path, "world.png") }
+  let(:path)     { File.join(fixture_path, 'world.png') }
   let(:mock_upload_directory) { 'spec/mock_upload_directory' }
 
   before do

--- a/spec/jobs/rdf_import_authority_job_spec.rb
+++ b/spec/jobs/rdf_import_authority_job_spec.rb
@@ -4,17 +4,17 @@ require 'rails_helper'
 describe RDFAuthorityImportJob do
   let(:file) { double }
 
-  context "with no authority" do
-    it "raises and error" do
-      expect { described_class.perform_now(file) }.to raise_error(NotImplementedError, "No authority defined")
+  context 'with no authority' do
+    it 'raises and error' do
+      expect { described_class.perform_now(file) }.to raise_error(NotImplementedError, 'No authority defined')
     end
   end
 
-  context "with an authority" do
-    before { allow(described_class).to receive(:authority).and_return("the law") }
-    it "imports the authority from a file using Questioning Authority" do
-      expect(Qa::LocalAuthority).to receive(:find_or_create_by).with(name: "the law")
-      expect(Qa::Services::RDFAuthorityParser).to receive(:import_rdf).with("the law", [file], {})
+  context 'with an authority' do
+    before { allow(described_class).to receive(:authority).and_return('the law') }
+    it 'imports the authority from a file using Questioning Authority' do
+      expect(Qa::LocalAuthority).to receive(:find_or_create_by).with(name: 'the law')
+      expect(Qa::Services::RDFAuthorityParser).to receive(:import_rdf).with('the law', [file], {})
       described_class.perform_now(file)
     end
   end

--- a/spec/jobs/register_queued_file_job_spec.rb
+++ b/spec/jobs/register_queued_file_job_spec.rb
@@ -2,17 +2,17 @@
 require 'rails_helper'
 
 describe RegisterQueuedFileJob do
-  let(:work) { build(:work, id: "1234") }
+  let(:work) { build(:work, id: '1234') }
 
-  context "without existing queued files" do
-    it "adds a record" do
+  context 'without existing queued files' do
+    it 'adds a record' do
       expect { described_class.perform_now(work) }.to change { QueuedFile.count }.by(1)
     end
   end
 
-  context "with an existing queued file" do
+  context 'with an existing queued file' do
     before { QueuedFile.create(work_id: work.id) }
-    it "does not add a record" do
+    it 'does not add a record' do
       expect { described_class.perform_now(work) }.to change { QueuedFile.count }.by(0)
     end
   end

--- a/spec/jobs/resolrize_job_spec.rb
+++ b/spec/jobs/resolrize_job_spec.rb
@@ -6,8 +6,8 @@ describe ResolrizeJob, :clean do
   let!(:file_set) { create(:file_set, :with_png, id: "abc#{(Random.rand * 10_000).to_i}", depositor: user.login) }
   let(:job) { described_class.new }
 
-  describe "#perform" do
-    it "Updates the index for all parts of the records" do
+  describe '#perform' do
+    it 'Updates the index for all parts of the records' do
       expect(ActiveFedora::Base).to receive(:find).with(file_set.access_control_id).and_return(file_set.access_control).ordered
       expect(file_set.access_control).to receive(:update_index)
       file_set.permissions.each do |perm|

--- a/spec/jobs/share_notify_delete_job_spec.rb
+++ b/spec/jobs/share_notify_delete_job_spec.rb
@@ -6,13 +6,13 @@ describe ShareNotifyDeleteJob do
   let(:user) { create(:jill) }
   let(:work) { create(:share_file, depositor: user.login) }
 
-  context "when the file has been sent to SHARE" do
+  context 'when the file has been sent to SHARE' do
     before do
       allow_any_instance_of(GenericWork).to receive(:share_notified?).and_return(true)
-      allow(ShareNotify).to receive(:config) { { "token" => "SECRET_TOKEN" } }
+      allow(ShareNotify).to receive(:config) { { 'token' => 'SECRET_TOKEN' } }
       allow_any_instance_of(GenericWorkToShareJSONService)
         .to receive(:email_for_name)
-        .and_return("kermit@muppets.org")
+        .and_return('kermit@muppets.org')
       WebMock.enable!
     end
 
@@ -20,7 +20,7 @@ describe ShareNotifyDeleteJob do
       WebMock.disable!
     end
 
-    it "sends a notification" do
+    it 'sends a notification' do
       VCR.use_cassette('share_notify_success_job', record: :none) do
         expect(ShareNotifyDeleteEventJob).to receive(:perform_now)
         described_class.perform_now(work)

--- a/spec/jobs/share_notify_event_jobs_spec.rb
+++ b/spec/jobs/share_notify_event_jobs_spec.rb
@@ -5,8 +5,8 @@ describe ShareNotify do
   let(:user) { create(:jill) }
   let(:file) { create(:work) }
 
-  shared_examples "a SHARE Notify event job" do
-    it "sends an event to the file activity stream" do
+  shared_examples 'a SHARE Notify event job' do
+    it 'sends an event to the file activity stream' do
       expect {
         described_class.perform_now(file, user)
       }.to change { file.events.length }.by(1)
@@ -14,18 +14,18 @@ describe ShareNotify do
   end
 
   describe ShareNotifySuccessEventJob do
-    it_behaves_like "a SHARE Notify event job"
+    it_behaves_like 'a SHARE Notify event job'
   end
 
   describe ShareNotifyFailureEventJob do
-    it_behaves_like "a SHARE Notify event job"
+    it_behaves_like 'a SHARE Notify event job'
   end
 
   describe ShareNotifyDeleteEventJob do
-    it_behaves_like "a SHARE Notify event job"
+    it_behaves_like 'a SHARE Notify event job'
   end
 
   describe ShareNotifyDeleteFailureEventJob do
-    it_behaves_like "a SHARE Notify event job"
+    it_behaves_like 'a SHARE Notify event job'
   end
 end

--- a/spec/jobs/share_notify_job_spec.rb
+++ b/spec/jobs/share_notify_job_spec.rb
@@ -8,21 +8,21 @@ describe ShareNotifyJob do
 
   before { allow_any_instance_of(GenericWork).to receive(:share_notified?).and_return(false) }
 
-  context "with a shareable file" do
+  context 'with a shareable file' do
     before do
       allow_any_instance_of(GenericWorkToShareJSONService)
         .to receive(:email_for_name)
-        .and_return("kermit@muppets.org")
+        .and_return('kermit@muppets.org')
       WebMock.enable!
     end
 
     after { WebMock.disable! }
 
-    describe "a successful outcome" do
-      context "when it has not been sent to SHARE Notify" do
-        before { allow(ShareNotify).to receive(:config) { { "token" => "SECRET_TOKEN" } } }
+    describe 'a successful outcome' do
+      context 'when it has not been sent to SHARE Notify' do
+        before { allow(ShareNotify).to receive(:config) { { 'token' => 'SECRET_TOKEN' } } }
 
-        it "sends a notification" do
+        it 'sends a notification' do
           VCR.use_cassette('share_notify_success_job', record: :none) do
             expect(ShareNotifySuccessEventJob).to receive(:perform_now)
             described_class.perform_now(work)
@@ -30,24 +30,24 @@ describe ShareNotifyJob do
         end
       end
 
-      context "when it has already been sent to SHARE Notify" do
+      context 'when it has already been sent to SHARE Notify' do
         before { allow_any_instance_of(GenericWork).to receive(:share_notified?).and_return(true) }
         subject { described_class.perform_now(work) }
         it { is_expected.to be_nil }
       end
     end
 
-    describe "an unsuccessful outcome" do
+    describe 'an unsuccessful outcome' do
       let(:error_message) do
         "Posting file #{work.id} to SHARE Notify failed with 400. Response was {\"detail\"=>\"Invalid token.\"}"
       end
 
       before do
-        allow(ShareNotify).to receive(:config) { { "token" => "BAD_TOKEN" } }
+        allow(ShareNotify).to receive(:config) { { 'token' => 'BAD_TOKEN' } }
         allow_any_instance_of(ShareNotify::SearchResponse).to receive(:status).and_return(400)
       end
 
-      it "logs the error" do
+      it 'logs the error' do
         VCR.use_cassette('share_notify_failed_job', record: :none) do
           expect(Rails.logger).to receive(:error).once.with(error_message)
           expect(ShareNotifyFailureEventJob).to receive(:perform_now)
@@ -57,7 +57,7 @@ describe ShareNotifyJob do
     end
   end
 
-  context "with a file that cannot be shared" do
+  context 'with a file that cannot be shared' do
     let(:work) { create(:private_work) }
     subject { described_class.perform_now(work) }
     it { is_expected.to be_nil }

--- a/spec/lib/devise/http_header_authenticatable_spec.rb
+++ b/spec/lib/devise/http_header_authenticatable_spec.rb
@@ -5,54 +5,54 @@ describe Devise::Strategies::HttpHeaderAuthenticatable do
   subject { described_class.new(nil) }
   before { allow(subject).to receive(:request).and_return(request) }
 
-  describe "#valid_user?" do
-    context "in a production environment" do
+  describe '#valid_user?' do
+    context 'in a production environment' do
       let(:production) { ActiveSupport::StringInquirer.new('production') }
       before { allow(Rails).to receive(:env).and_return(production) }
-      context "using REMOTE_USER" do
-        let(:request) { double(headers: { "REMOTE_USER" => "abc123" }) }
+      context 'using REMOTE_USER' do
+        let(:request) { double(headers: { 'REMOTE_USER' => 'abc123' }) }
         it { is_expected.to be_valid }
       end
-      context "using HTTP_REMOTE_USER" do
-        let(:request) { double(headers: { "HTTP_REMOTE_USER" => "abc123" }) }
+      context 'using HTTP_REMOTE_USER' do
+        let(:request) { double(headers: { 'HTTP_REMOTE_USER' => 'abc123' }) }
         it { is_expected.not_to be_valid }
       end
-      context "using no header" do
+      context 'using no header' do
         let(:request) { double(headers: {}) }
         it { is_expected.not_to be_valid }
       end
     end
-    context "in a development or test environment" do
-      context "using REMOTE_USER" do
-        let(:request) { double(headers: { "REMOTE_USER" => "abc123" }) }
+    context 'in a development or test environment' do
+      context 'using REMOTE_USER' do
+        let(:request) { double(headers: { 'REMOTE_USER' => 'abc123' }) }
         it { is_expected.to be_valid }
       end
-      context "using HTTP_REMOTE_USER" do
-        let(:request) { double(headers: { "HTTP_REMOTE_USER" => "abc123" }) }
+      context 'using HTTP_REMOTE_USER' do
+        let(:request) { double(headers: { 'HTTP_REMOTE_USER' => 'abc123' }) }
         it { is_expected.to be_valid }
       end
-      context "using no header" do
+      context 'using no header' do
         let(:request) { double(headers: {}) }
         it { is_expected.not_to be_valid }
       end
     end
   end
 
-  describe "authenticate!" do
+  describe 'authenticate!' do
     let(:user) { create(:archivist) }
-    let(:request) { double(headers: { "HTTP_REMOTE_USER" => user.login }) }
-    context "with a new user" do
+    let(:request) { double(headers: { 'HTTP_REMOTE_USER' => user.login }) }
+    context 'with a new user' do
       before { allow(User).to receive(:find_by_login).with(user.login).and_return(nil) }
-      it "populates LDAP attrs" do
+      it 'populates LDAP attrs' do
         expect(User).to receive(:create).with(login: user.login, email: user.login).once.and_return(user)
         expect_any_instance_of(User).to receive(:populate_attributes).once
         expect(subject).to be_valid
         expect(subject.authenticate!).to eq(:success)
       end
     end
-    context "with an existing user" do
+    context 'with an existing user' do
       before { allow(User).to receive(:find_by_login).with(user.login).and_return(user) }
-      it "does not populate LDAP attrs" do
+      it 'does not populate LDAP attrs' do
         expect(User).to receive(:create).with(login: user.login).never
         expect_any_instance_of(User).to receive(:populate_attributes).never
         expect(subject).to be_valid

--- a/spec/lib/hydra/derivatives/document_spec.rb
+++ b/spec/lib/hydra/derivatives/document_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe Hydra::Derivatives::Processors::Document do
-  let(:source_path)    { File.join(fixture_path, "test.doc") }
+  let(:source_path)    { File.join(fixture_path, 'test.doc') }
   let(:output_service) { Hydra::Derivatives::PersistBasicContainedOutputFileService }
 
   before { allow(subject).to receive(:output_file_service).and_return(output_service) }
@@ -11,35 +11,35 @@ describe Hydra::Derivatives::Processors::Document do
 
   subject { described_class.new(source_path, directives) }
 
-  describe "#encode_file" do
-    context "when converting to jpg" do
-      let(:directives) { { format: "jpg" } }
-      let(:convert_directive) { "png" }
-      let(:converted_file) { "path/to/pdf/created/from/original" }
+  describe '#encode_file' do
+    context 'when converting to jpg' do
+      let(:directives) { { format: 'jpg' } }
+      let(:convert_directive) { 'png' }
+      let(:converted_file) { 'path/to/pdf/created/from/original' }
       let(:mock_processor) { double }
 
       before do
         allow(Hydra::Derivatives::Processors::Image).to receive(:new).with(converted_file, directives).and_return(mock_processor)
       end
 
-      it "creates a thumbnail of the document using a pdf created from the original" do
+      it 'creates a thumbnail of the document using a pdf created from the original' do
         expect(mock_processor).to receive(:process)
         expect(File).to receive(:unlink).with(converted_file)
-        subject.encode_file("jpg")
+        subject.encode_file('jpg')
       end
     end
 
-    context "when converting to another format" do
-      let(:directives) { { format: "png" } }
-      let(:convert_directive) { "png" }
-      let(:converted_file) { "path/to/converted.png" }
-      let(:mock_content)   { "mocked png content" }
+    context 'when converting to another format' do
+      let(:directives) { { format: 'png' } }
+      let(:convert_directive) { 'png' }
+      let(:converted_file) { 'path/to/converted.png' }
+      let(:mock_content)   { 'mocked png content' }
 
       before { allow(File).to receive(:read).with(converted_file).and_return(mock_content) }
-      it "creates a thumbnail of the document" do
+      it 'creates a thumbnail of the document' do
         expect(output_service).to receive(:call).with(mock_content, directives)
         expect(File).to receive(:unlink).with(converted_file)
-        subject.encode_file("png")
+        subject.encode_file('png')
       end
     end
   end

--- a/spec/lib/redirect_to_web_access_failure_spec.rb
+++ b/spec/lib/redirect_to_web_access_failure_spec.rb
@@ -10,15 +10,15 @@ describe RedirectToWebAccessFailure do
       'warden.options' => { scope: :user },
       'rack.session' => {},
       'action_dispatch.request.formats' => Array(env_params.delete('formats') || Mime::HTML),
-      'rack.input' => "",
+      'rack.input' => '',
       'warden' => OpenStruct.new(message: nil)
     }.merge!(env_params)
 
     @response = RedirectToWebAccessFailure.call(env).to_a
     @request  = ActionDispatch::Request.new(env)
   end
-  describe "when http_auth? is false" do
-    it "does not set flash" do
+  describe 'when http_auth? is false' do
+    it 'does not set flash' do
       call_failure
       expect(@response.first).to eq 302
       expect(@response.second['Location']).to eq 'https://webaccess.psu.edu/?cosign-localhost&https://localhost'

--- a/spec/lib/scholarsphere/config_spec.rb
+++ b/spec/lib/scholarsphere/config_spec.rb
@@ -2,19 +2,19 @@
 require 'rails_helper'
 
 describe Scholarsphere::Config do
-  describe "::check" do
-    context "with our current configuration files" do
-      it "checks the contents of our production configuration files" do
+  describe '::check' do
+    context 'with our current configuration files' do
+      it 'checks the contents of our production configuration files' do
         expect { described_class.check }.not_to raise_error(Scholarsphere::Config::Error)
-        expect(FileSet.image_mime_types).to eq(["image/png", "image/jpeg", "image/jpg", "image/jp2", "image/bmp", "image/gif"])
+        expect(FileSet.image_mime_types).to eq(['image/png', 'image/jpeg', 'image/jpg', 'image/jp2', 'image/bmp', 'image/gif'])
       end
     end
 
-    context "with a sample config file" do
-      before { allow(Dir).to receive(:glob).and_return([File.join(fixture_path, "application.yml")]) }
+    context 'with a sample config file' do
+      before { allow(Dir).to receive(:glob).and_return([File.join(fixture_path, 'application.yml')]) }
 
-      it "raises an error" do
-        expect { described_class.check }.to raise_error(Scholarsphere::Config::Error, start_with("Config file"))
+      it 'raises an error' do
+        expect { described_class.check }.to raise_error(Scholarsphere::Config::Error, start_with('Config file'))
       end
     end
   end

--- a/spec/lib/scholarsphere/import/batch_translator_spec.rb
+++ b/spec/lib/scholarsphere/import/batch_translator_spec.rb
@@ -2,13 +2,13 @@
 require 'rails_helper'
 
 describe Import::BatchTranslator do
-  describe "default_prefix" do
-    it "default prefix is batch" do
-      expect(described_class.new({}).send(:default_prefix)).to eq("batch_")
+  describe 'default_prefix' do
+    it 'default prefix is batch' do
+      expect(described_class.new({}).send(:default_prefix)).to eq('batch_')
     end
   end
 
-  describe "#import" do
+  describe '#import' do
     let!(:work1) { create :work, id: 'x920fw89s' }
     let(:translator) { described_class.new(import_dir: import_directory, import_binary: false) }
     let(:import_directory) { Rails.root.join('tmp', 'import_test') }
@@ -26,12 +26,12 @@ describe Import::BatchTranslator do
       work1.destroy(eradicate: true)
     end
 
-    context "with multiple works" do
+    context 'with multiple works' do
       let!(:work2) { create :work, id: 'tm70mv24n' }
       let!(:work3) { create :work, id: 'g445cd26c' }
       let(:batch_id) { 'zg64tk99d' }
       it 'Creates related Work Links' do
-        expect(Rails.logger).to receive(:debug).with("Importing batch_zg64tk99d.json")
+        expect(Rails.logger).to receive(:debug).with('Importing batch_zg64tk99d.json')
         translator.import
         expect(work1.reload.upload_set).to eq batch_id
         expect(work2.reload.upload_set).to eq batch_id
@@ -39,10 +39,10 @@ describe Import::BatchTranslator do
       end
     end
 
-    context "with one work" do
+    context 'with one work' do
       let(:batch_id) { 'zg64tkabc' }
       it 'Creates no links' do
-        expect(Rails.logger).to receive(:debug).with("Importing batch_zg64tkabc.json")
+        expect(Rails.logger).to receive(:debug).with('Importing batch_zg64tkabc.json')
         translator.import
         expect(work1.reload.related_object_ids).to eq []
       end

--- a/spec/lib/scholarsphere/import/file_set_builder_spec.rb
+++ b/spec/lib/scholarsphere/import/file_set_builder_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 describe Import::FileSetBuilder do
-  it "creates the ScholarSphere version builder" do
+  it 'creates the ScholarSphere version builder' do
     expect(described_class.new(false).version_builder.class).to eq(Import::VersionBuilder)
   end
 end

--- a/spec/lib/scholarsphere/import/generic_file_translator_spec.rb
+++ b/spec/lib/scholarsphere/import/generic_file_translator_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 describe Import::GenericFileTranslator do
-  it "creates the ScholarSphere FileSet builder" do
+  it 'creates the ScholarSphere FileSet builder' do
     expect(described_class.new({}).instance_variable_get(:@file_set_builder).class).to eq(Import::FileSetBuilder)
   end
 end

--- a/spec/lib/scholarsphere/import/version_builder_spec.rb
+++ b/spec/lib/scholarsphere/import/version_builder_spec.rb
@@ -5,54 +5,54 @@ describe Import::VersionBuilder do
   subject { file_set }
 
   let(:user) { create(:user) }
-  let(:sufia6_user) { "s6user" }
-  let(:sufia6_password) { "s6password" }
+  let(:sufia6_user) { 's6user' }
+  let(:sufia6_password) { 's6password' }
   let(:builder) { described_class.new }
   let(:file_set) { create(:file_set, user: user, label: 'my label.txt') }
 
-  let(:version1_uri) { "http://127.0.0.1:8983/fedora/rest/dev/44/55/8d/49/44558d49x/content/fcr:versions/version1" }
-  let(:version2_uri) { "http://127.0.0.1:8983/fedora/rest/dev/44/55/8d/49/44558d49x/content/fcr:versions/version2" }
+  let(:version1_uri) { 'http://127.0.0.1:8983/fedora/rest/dev/44/55/8d/49/44558d49x/content/fcr:versions/version1' }
+  let(:version2_uri) { 'http://127.0.0.1:8983/fedora/rest/dev/44/55/8d/49/44558d49x/content/fcr:versions/version2' }
   let(:versions) do
     [
       { uri: version1_uri,
-        created: "2016-09-28T20:00:14.658Z",
-        label: "version1" },
+        created: '2016-09-28T20:00:14.658Z',
+        label: 'version1' },
       { uri: version2_uri,
-        created: "2016-09-29T15:58:00.639Z",
-        label: "version2" }
+        created: '2016-09-29T15:58:00.639Z',
+        label: 'version2' }
     ]
   end
   let(:version1) do
     file = Tempfile.new('version1')
-    file.write("hello world! version1")
+    file.write('hello world! version1')
     file.rewind
     file
   end
   let(:version2) do
     file = Tempfile.new('version2')
-    file.write("hello world! version2")
+    file.write('hello world! version2')
     file.rewind
     file
   end
 
   let(:version_committers) { VersionCommitter.where("version_id like \"%#{output_file.id}%\"") }
 
-  let(:http) { class_double("Net:HTTP") }
-  let(:request) { class_double("Net::HTTP::Get") }
+  let(:http) { class_double('Net:HTTP') }
+  let(:request) { class_double('Net::HTTP::Get') }
 
   let(:output_file) { Hydra::PCDM::File.find file_set.original_file.id }
 
-  context "when username / password have not been configured" do
+  context 'when username / password have not been configured' do
     before do
       # this code is needed if the system has the correct sufia_6 paswords set to make this test fail
       ScholarSphere::Application.config.fedora_sufia6_user = 'abc'
       allow(ScholarSphere::Application.config).to receive(:fedora_sufia6_user).and_raise(NoMethodError)
     end
-    it "raises runtime error" do
+    it 'raises runtime error' do
       expect { builder.build(file_set, versions) }.to raise_error RuntimeError
     end
   end
-  context "when username / password are provided" do
+  context 'when username / password are provided' do
     before do
       allow(builder).to receive(:sufia6_user).and_return(sufia6_user)
       allow(builder).to receive(:sufia6_password).and_return(sufia6_password)
@@ -65,39 +65,39 @@ describe Import::VersionBuilder do
       version2.close
       version2.unlink
     end
-    context "good http" do
+    context 'good http' do
       before do
         allow(Hydra::Works::VirusCheckerService).to receive(:file_has_virus?).and_return(false)
         copy_version(version1, 'version1', file_set)
         copy_version(version2, 'version2', file_set)
       end
-      it "creates versions" do
+      it 'creates versions' do
         expect(Net::HTTP).to receive(:start).twice
         expect(CharacterizeJob).to receive(:perform_now).with(file_set, anything, /.*version2_my_label.txt/).and_return(true)
         builder.build(file_set, versions)
-        expect(output_file.versions.all.map(&:label)).to contain_exactly("version1", "version2")
-        expect(output_file.content).to eq("hello world! version2")
-        expect(output_file.date_created).to eq(["2016-09-29T15:58:00.639Z"])
-        expect(output_file.versions.all.map { |v| Hydra::PCDM::File.new(v.uri).date_created.first }).to contain_exactly("2016-09-28T20:00:14.658Z".to_datetime, "2016-09-29T15:58:00.639Z".to_datetime)
-        expect(output_file.file_name).to eq ["my label.txt"]
+        expect(output_file.versions.all.map(&:label)).to contain_exactly('version1', 'version2')
+        expect(output_file.content).to eq('hello world! version2')
+        expect(output_file.date_created).to eq(['2016-09-29T15:58:00.639Z'])
+        expect(output_file.versions.all.map { |v| Hydra::PCDM::File.new(v.uri).date_created.first }).to contain_exactly('2016-09-28T20:00:14.658Z'.to_datetime, '2016-09-29T15:58:00.639Z'.to_datetime)
+        expect(output_file.file_name).to eq ['my label.txt']
         expect(version_committers.map(&:committer_login)).to contain_exactly(user.login, user.login)
       end
 
-      context "when a creator is supplied" do
+      context 'when a creator is supplied' do
         let(:jill) { create(:jill) }
         let(:versions) do
           [
             { uri: version1_uri,
-              created: "2016-09-28T20:00:14.658Z",
-              label: "version1",
+              created: '2016-09-28T20:00:14.658Z',
+              label: 'version1',
               created_by: nil },
             { uri: version2_uri,
-              created: "2016-09-29T15:58:00.639Z",
-              label: "version2",
+              created: '2016-09-29T15:58:00.639Z',
+              label: 'version2',
               created_by:  jill.login }
           ]
         end
-        it "creates versions with specified committers" do
+        it 'creates versions with specified committers' do
           expect(Net::HTTP).to receive(:start).twice
           expect(CharacterizeJob).to receive(:perform_now).with(file_set, anything, /.*version2_my_label.txt/).and_return(true)
           builder.build(file_set, versions)
@@ -105,54 +105,54 @@ describe Import::VersionBuilder do
         end
       end
     end
-    context "bad http" do
-      let(:bad_http_response) { Net::HTTPInternalServerError.new("1.1", "500", "Internal Error") }
+    context 'bad http' do
+      let(:bad_http_response) { Net::HTTPInternalServerError.new('1.1', '500', 'Internal Error') }
       before do
-        allow(bad_http_response).to receive(:body).and_return("Bad error")
+        allow(bad_http_response).to receive(:body).and_return('Bad error')
         allow(Net::HTTP).to receive(:start).and_yield http
         allow(http).to receive(:request).with(an_instance_of(Net::HTTP::Get)).and_yield(bad_http_response)
       end
-      it "raises an error" do
+      it 'raises an error' do
         expect { builder.build(file_set, versions) }.to raise_error(Net::HTTPFatalError)
       end
-      context "one bad version" do
+      context 'one bad version' do
         let(:versions) do
           [
             { uri: version1_uri,
-              created: "2016-09-28T20:00:14.658Z",
-              label: "version1",
+              created: '2016-09-28T20:00:14.658Z',
+              label: 'version1',
               created_by: user.login },
             { uri: version2_uri,
-              created: "2016-09-29T15:58:00.639Z",
-              label: "version2",
+              created: '2016-09-29T15:58:00.639Z',
+              label: 'version2',
               created_by: 'cam156' }
           ]
         end
-        let(:good_http_response) { Net::HTTPSuccess.new("1.1", "200", "Yeah it worked") }
+        let(:good_http_response) { Net::HTTPSuccess.new('1.1', '200', 'Yeah it worked') }
         before do
-          allow(good_http_response).to receive(:read_body).and_yield("abc123").and_yield(nil)
+          allow(good_http_response).to receive(:read_body).and_yield('abc123').and_yield(nil)
         end
         it "to process the good version with the bad version's metdata" do
           expect(http).to receive(:request).once.with(an_instance_of(Net::HTTP::Get)).and_yield(bad_http_response)
           expect(http).to receive(:request).once.with(an_instance_of(Net::HTTP::Get)).and_yield(good_http_response)
           expect(CharacterizeJob).to receive(:perform_now).with(file_set, anything, /.*version1_my_label.txt/).and_return(true)
           builder.build(file_set, versions)
-          expect(output_file.versions.all.map(&:label)).to contain_exactly("version1")
-          expect(output_file.content).to eq("abc123")
-          expect(output_file.date_created).to eq([DateTime.parse("2016-09-28T20:00:14.658Z")])
-          expect(output_file.versions.all.map { |v| Hydra::PCDM::File.new(v.uri).date_created.first }).to contain_exactly("2016-09-28T20:00:14.658Z".to_datetime)
-          expect(output_file.file_name).to eq ["my label.txt"]
+          expect(output_file.versions.all.map(&:label)).to contain_exactly('version1')
+          expect(output_file.content).to eq('abc123')
+          expect(output_file.date_created).to eq([DateTime.parse('2016-09-28T20:00:14.658Z')])
+          expect(output_file.versions.all.map { |v| Hydra::PCDM::File.new(v.uri).date_created.first }).to contain_exactly('2016-09-28T20:00:14.658Z'.to_datetime)
+          expect(output_file.file_name).to eq ['my label.txt']
           expect(version_committers.map(&:committer_login)).to contain_exactly(user.login)
         end
       end
     end
-    context "when fileset has nil id" do
-      it "raises runtime error" do
-        expect { builder.build(FileSet.new, versions) }.to raise_error("FileSet must have an id before importing any versions")
+    context 'when fileset has nil id' do
+      it 'raises runtime error' do
+        expect { builder.build(FileSet.new, versions) }.to raise_error('FileSet must have an id before importing any versions')
       end
     end
 
-    context "when version date should be translated" do
+    context 'when version date should be translated' do
       let(:generic_file_id) { 'zk51vg948' }
       let(:import_directory) { File.join(fixture_path, 'import') }
       let(:json_file_name) { File.join(import_directory, "generic_file_#{generic_file_id}.json") }
@@ -165,24 +165,24 @@ describe Import::VersionBuilder do
         allow(Hydra::Works::VirusCheckerService).to receive(:file_has_virus?).and_return(false)
         copy_version(version1, 'version1', file_set)
         copy_version(version2, 'version2', file_set)
-        file_set.date_uploaded = DateTime.parse("2013-03-09T20:43:36.592+00:00")
+        file_set.date_uploaded = DateTime.parse('2013-03-09T20:43:36.592+00:00')
       end
 
-      it "changes the date" do
+      it 'changes the date' do
         expect(Net::HTTP).to receive(:start).twice
         expect(CharacterizeJob).to receive(:perform_now).with(file_set, anything, /.*version2_my_label.txt/).and_return(true)
         builder.build(file_set, versions)
-        expect(output_file.versions.all.map(&:label)).to contain_exactly("version1", "version2")
-        expect(output_file.content).to eq("hello world! version2")
-        expect(output_file.date_created).to eq(["2013-03-09T20:43:36.592+00:00"])
+        expect(output_file.versions.all.map(&:label)).to contain_exactly('version1', 'version2')
+        expect(output_file.content).to eq('hello world! version2')
+        expect(output_file.date_created).to eq(['2013-03-09T20:43:36.592+00:00'])
         expect(output_file.versions.all.map { |v| Hydra::PCDM::File.new(v.uri).date_created.first }).to contain_exactly(file_set.date_uploaded, file_set.date_uploaded)
-        expect(output_file.file_name).to eq ["my label.txt"]
+        expect(output_file.file_name).to eq ['my label.txt']
       end
     end
   end
 
   def copy_version(version, version_label, file_set)
-    to_path = File.join(Rails.root, "tmp/uploads", "#{file_set.id}_#{version_label}_#{file_set.label.tr(' ', '_')}")
+    to_path = File.join(Rails.root, 'tmp/uploads', "#{file_set.id}_#{version_label}_#{file_set.label.tr(' ', '_')}")
     FileUtils.copy version.to_path, to_path
   end
 end

--- a/spec/lib/scholarsphere/import/work_builder_spec.rb
+++ b/spec/lib/scholarsphere/import/work_builder_spec.rb
@@ -2,21 +2,21 @@
 require 'rails_helper'
 
 describe Import::WorkBuilder do
-  let(:sufia6_user) { "s6user" }
-  let(:sufia6_password) { "s6password" }
+  let(:sufia6_user) { 's6user' }
+  let(:sufia6_password) { 's6password' }
   let(:builder) { described_class.new }
 
   let(:gf_metadata) { JSON.parse(json, symbolize_names: true) }
   let(:gf_metadata2) { JSON.parse(json2, symbolize_names: true) }
 
   let(:json) do
-    generic_file_json(id: "th83kz34n",
-                      date_uploaded: "2016-06-21T09:08:00.000+00:00",
-                      date_modified: "2016-06-21T09:08:00.000+00:00",
+    generic_file_json(id: 'th83kz34n',
+                      date_uploaded: '2016-06-21T09:08:00.000+00:00',
+                      date_modified: '2016-06-21T09:08:00.000+00:00',
                       rights: 'All rights reserved')
   end
   let(:import_directory) { File.join(fixture_path, 'import') }
-  let(:json_file_name) { File.join(import_directory, "generic_file_zp38wc72r.json") }
+  let(:json_file_name) { File.join(import_directory, 'generic_file_zp38wc72r.json') }
   let(:json2) { File.read(json_file_name) }
 
   # let(:json2) do
@@ -32,51 +32,51 @@ describe Import::WorkBuilder do
     allow(Sufia::Import::PermissionBuilder).to receive(:new).and_return(permission_builder)
   end
 
-  it "creates a Work with metadata and permissions" do
+  it 'creates a Work with metadata and permissions' do
     expect(permission_builder).to receive(:build).with(an_instance_of(Sufia.primary_work_type), gf_metadata[:permissions])
     work = builder.build(gf_metadata)
-    expect(work.id).to eq "th83kz34n"
-    expect(work.label).to eq "15040187724_9e2f2d7c21_z.jpg"
-    expect(work.depositor).to eq "cam156@psu.edu"
-    expect(work.arkivo_checksum).to eq "arkivo checksum"
-    expect(work.relative_path).to eq "relative path"
-    expect(work.import_url).to eq "import url"
-    expect(work.resource_type).to eq ["resource type"]
-    expect(work.title).to eq(["My Awesone File"])
-    expect(work.creator).to eq ["cam156@psu.edu"]
-    expect(work.contributor).to include "contributor1"
-    expect(work.contributor).to include "contribnutor2"
-    expect(work.description).to eq ["description of the file"]
-    expect(work.keyword).to include "tag1"
-    expect(work.keyword).to include "tag2"
-    expect(work.rights).to eq ["http://www.europeana.eu/portal/rights/rr-r.html"]
-    expect(work.publisher).to eq ["publisher joe"]
-    expect(work.date_created).to eq ["a long time ago"]
-    expect(work.date_uploaded).to eq DateTime.parse("2016-06-21T09:08:00.000+00:00")
-    expect(work.date_modified).to eq DateTime.parse("2016-06-21T09:08:00.000+00:00")
-    expect(work.subject).to include "subject 1"
-    expect(work.subject).to include "subject 2"
-    expect(work.language).to eq ["WA Language WA"]
-    expect(work.identifier).to eq ["You ID ME"]
-    expect(work.based_near).to eq ["Kalamazoo"]
-    expect(work.related_url).to eq ["abc123.org"]
-    expect(work.bibliographic_citation).to eq ["cite me"]
-    expect(work.source).to eq ["source of me"]
-    expect(work.visibility).to eq "restricted"
+    expect(work.id).to eq 'th83kz34n'
+    expect(work.label).to eq '15040187724_9e2f2d7c21_z.jpg'
+    expect(work.depositor).to eq 'cam156@psu.edu'
+    expect(work.arkivo_checksum).to eq 'arkivo checksum'
+    expect(work.relative_path).to eq 'relative path'
+    expect(work.import_url).to eq 'import url'
+    expect(work.resource_type).to eq ['resource type']
+    expect(work.title).to eq(['My Awesone File'])
+    expect(work.creator).to eq ['cam156@psu.edu']
+    expect(work.contributor).to include 'contributor1'
+    expect(work.contributor).to include 'contribnutor2'
+    expect(work.description).to eq ['description of the file']
+    expect(work.keyword).to include 'tag1'
+    expect(work.keyword).to include 'tag2'
+    expect(work.rights).to eq ['http://www.europeana.eu/portal/rights/rr-r.html']
+    expect(work.publisher).to eq ['publisher joe']
+    expect(work.date_created).to eq ['a long time ago']
+    expect(work.date_uploaded).to eq DateTime.parse('2016-06-21T09:08:00.000+00:00')
+    expect(work.date_modified).to eq DateTime.parse('2016-06-21T09:08:00.000+00:00')
+    expect(work.subject).to include 'subject 1'
+    expect(work.subject).to include 'subject 2'
+    expect(work.language).to eq ['WA Language WA']
+    expect(work.identifier).to eq ['You ID ME']
+    expect(work.based_near).to eq ['Kalamazoo']
+    expect(work.related_url).to eq ['abc123.org']
+    expect(work.bibliographic_citation).to eq ['cite me']
+    expect(work.source).to eq ['source of me']
+    expect(work.visibility).to eq 'restricted'
   end
 
-  context "when used more than once" do
+  context 'when used more than once' do
     before do
       allow(permission_builder).to receive(:build)
     end
-    it "creates a distinct Works" do
+    it 'creates a distinct Works' do
       work1 = builder.build(gf_metadata)
       work2 = builder.build(gf_metadata2)
       expect(work1.title).to eq ['My Awesone File']
-      expect(work1.id).to eq "th83kz34n"
+      expect(work1.id).to eq 'th83kz34n'
       expect(work2.title).to eq ['another title for us']
-      expect(work2.id).to eq "abc123"
-      expect(work2.creator).to eq ["Adams, Nancy E.", "Gaffney, Maureen A.", "Lynn, Valerie"]
+      expect(work2.id).to eq 'abc123'
+      expect(work2.creator).to eq ['Adams, Nancy E.', 'Gaffney, Maureen A.', 'Lynn, Valerie']
     end
   end
 end

--- a/spec/lib/scholarsphere/role_mapper_spec.rb
+++ b/spec/lib/scholarsphere/role_mapper_spec.rb
@@ -4,11 +4,11 @@ require 'rails_helper'
 describe RoleMapper do
   before do
     @user = create(:user)
-    allow_any_instance_of(User).to receive(:groups).and_return(["umg/up.dlt.gamma-ci", "umg/up.dlt.redmine"])
+    allow_any_instance_of(User).to receive(:groups).and_return(['umg/up.dlt.gamma-ci', 'umg/up.dlt.redmine'])
   end
   after do
     @user.delete
   end
   subject { ::RoleMapper.roles(@user.login) }
-  it { is_expected.to eq(["umg/up.dlt.gamma-ci", "umg/up.dlt.redmine"]) }
+  it { is_expected.to eq(['umg/up.dlt.gamma-ci', 'umg/up.dlt.redmine']) }
 end

--- a/spec/lib/sufia/redis_event_store_spec.rb
+++ b/spec/lib/sufia/redis_event_store_spec.rb
@@ -5,5 +5,5 @@ describe Sufia::RedisEventStore do
   subject { described_class.instance }
 
   it { is_expected.to be_kind_of(Redis::Namespace) }
-  its(:namespace) { is_expected.to eq("scholarsphere") }
+  its(:namespace) { is_expected.to eq('scholarsphere') }
 end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -8,12 +8,12 @@ describe Ability do
   let(:work)     { build(:work, id: '1234') }
   let(:solr_doc) { SolrDocument.new(work.to_solr) }
 
-  context "with a typical user" do
+  context 'with a typical user' do
     subject { described_class.new(user) }
     it { is_expected.not_to be_able_to(:read, solr_doc) }
   end
 
-  context "with an admin" do
+  context 'with an admin' do
     subject { described_class.new(admin) }
     it { is_expected.to be_able_to(:read, solr_doc) }
   end

--- a/spec/models/batch_edit_item_spec.rb
+++ b/spec/models/batch_edit_item_spec.rb
@@ -7,16 +7,16 @@ describe BatchEditItem do
 
   subject { described_class.new(batch: [work1.id, work2.id]) }
 
-  describe "#batch" do
+  describe '#batch' do
     its(:batch) { is_expected.to contain_exactly(work1, work2) }
   end
 
-  describe "#visibility" do
-    context "when all items in the batch have the same visibility" do
-      its(:visibility) { is_expected.to eq("restricted") }
+  describe '#visibility' do
+    context 'when all items in the batch have the same visibility' do
+      its(:visibility) { is_expected.to eq('restricted') }
     end
 
-    context "when items in the batch have different visibilities" do
+    context 'when items in the batch have different visibilities' do
       let(:work2) { create(:public_work) }
       its(:visibility) { is_expected.to be_nil }
     end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -3,30 +3,30 @@ require 'rails_helper'
 
 describe Collection do
   subject { collection }
-  context "with no attached files" do
+  context 'with no attached files' do
     let(:collection) { build(:collection) }
     its(:bytes) { is_expected.to eq(0) }
   end
 
-  context "with attached files" do
+  context 'with attached files' do
     let!(:collection) { create(:public_collection, members: [work1, work2]) }
 
-    let(:work1)       { build(:public_work, id: "1") }
-    let(:work2)       { build(:public_work, id: "2") }
+    let(:work1)       { build(:public_work, id: '1') }
+    let(:work2)       { build(:public_work, id: '2') }
     let(:resp) do
-      [{ Solrizer.solr_name(:file_size, CurationConcerns::CollectionIndexer::STORED_LONG) => "20" }]
+      [{ Solrizer.solr_name(:file_size, CurationConcerns::CollectionIndexer::STORED_LONG) => '20' }]
     end
 
     before { allow(ActiveFedora::SolrService).to receive(:query).and_return(resp) }
     its(:bytes) { is_expected.to eq(40) }
   end
 
-  describe "::indexer" do
+  describe '::indexer' do
     let(:collection) { described_class }
     its(:indexer) { is_expected.to eq(CollectionIndexer) }
   end
 
-  context "with a new collection" do
+  context 'with a new collection' do
     let(:collection) { build(:collection) }
 
     it { is_expected.not_to be_private_access }

--- a/spec/models/content_block_spec.rb
+++ b/spec/models/content_block_spec.rb
@@ -6,12 +6,12 @@ describe ContentBlock do
 
   subject { described_class.license_text }
 
-  describe "::license_text" do
-    its(:value) { is_expected.to eq("License here, license there, license everywhere") }
+  describe '::license_text' do
+    its(:value) { is_expected.to eq('License here, license there, license everywhere') }
   end
 
-  describe "::license_text=" do
-    before { described_class.license_text = "new value" }
-    its(:value) { is_expected.to eq("new value") }
+  describe '::license_text=' do
+    before { described_class.license_text = 'new value' }
+    its(:value) { is_expected.to eq('new value') }
   end
 end

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -2,47 +2,47 @@
 require 'rails_helper'
 
 describe FileSet, type: :model do
-  let(:file) { build(:file_set, :with_png, label: "sample_png") }
+  let(:file) { build(:file_set, :with_png, label: 'sample_png') }
   before do
     allow(file).to receive(:mime_type).and_return('image/png')
   end
 
   subject { file }
 
-  describe "::indexer" do
+  describe '::indexer' do
     subject { described_class.indexer }
     it { is_expected.to be(FileSetIndexer) }
   end
 
-  describe "#.to_solr" do
+  describe '#.to_solr' do
     subject { file.to_solr }
-    it { is_expected.to include(Solrizer.solr_name("file_format") => "png") }
-    it { is_expected.to include(Solrizer.solr_name("label") => "sample_png") }
+    it { is_expected.to include(Solrizer.solr_name('file_format') => 'png') }
+    it { is_expected.to include(Solrizer.solr_name('label') => 'sample_png') }
   end
 
-  describe "#file_format" do
-    its(:file_format) { is_expected.to eq("png") }
+  describe '#file_format' do
+    its(:file_format) { is_expected.to eq('png') }
   end
 
-  describe "#visibility" do
-    context "by default" do
-      its(:visibility) { is_expected.to eq("restricted") }
+  describe '#visibility' do
+    context 'by default' do
+      its(:visibility) { is_expected.to eq('restricted') }
       its(:public?) { is_expected.to be false }
       its(:registered?) { is_expected.to be false }
     end
   end
 
-  describe "#time_uploaded" do
-    context "with a blank date_uploaded" do
+  describe '#time_uploaded' do
+    context 'with a blank date_uploaded' do
       its(:time_uploaded) { is_expected.to be_blank }
     end
-    context "with date_uploaded" do
+    context 'with date_uploaded' do
       let(:file) { build(:file_set, date_uploaded: Date.today) }
-      its(:time_uploaded) { is_expected.to eq(Date.today.strftime("%Y-%m-%d %H:%M:%S")) }
+      its(:time_uploaded) { is_expected.to eq(Date.today.strftime('%Y-%m-%d %H:%M:%S')) }
     end
   end
 
-  describe "#url" do
-    its(:url) { is_expected.to end_with("/concern/file_sets/fixturepng") }
+  describe '#url' do
+    its(:url) { is_expected.to end_with('/concern/file_sets/fixturepng') }
   end
 end

--- a/spec/models/generic_work_spec.rb
+++ b/spec/models/generic_work_spec.rb
@@ -6,44 +6,44 @@ describe GenericWork do
 
   subject { work }
 
-  it "creates a noid on save" do
+  it 'creates a noid on save' do
     expect(subject.id.length).to eq 10
   end
 
-  describe "#time_uploaded" do
-    context "with a blank date_uploaded" do
+  describe '#time_uploaded' do
+    context 'with a blank date_uploaded' do
       its(:time_uploaded) { is_expected.to be_blank }
     end
-    context "with date_uploaded" do
+    context 'with date_uploaded' do
       before { allow(work).to receive(:date_uploaded).and_return(Date.today) }
-      its(:time_uploaded) { is_expected.to eq(Date.today.strftime("%Y-%m-%d %H:%M:%S")) }
+      its(:time_uploaded) { is_expected.to eq(Date.today.strftime('%Y-%m-%d %H:%M:%S')) }
     end
   end
 
-  describe "#url" do
+  describe '#url' do
     its(:url) { is_expected.to end_with("/concern/generic_works/#{work.id}") }
   end
 
-  describe "::indexer" do
+  describe '::indexer' do
     subject { described_class }
     its(:indexer) { is_expected.to eq(WorkIndexer) }
   end
 
-  describe "#bytes" do
+  describe '#bytes' do
     let(:file_size_field)  { work.send(:file_size_field)  }
-    let(:file1)            { build(:file_set, id: "fs1")  }
-    let(:file2)            { build(:file_set, id: "fs2")  }
+    let(:file1)            { build(:file_set, id: 'fs1')  }
+    let(:file2)            { build(:file_set, id: 'fs2')  }
     before do
       ActiveFedora::Cleaner.cleanout_solr
-      ActiveFedora::SolrService.add(file1.to_solr.merge!(file_size_field.to_sym => "1024"))
-      ActiveFedora::SolrService.add(file2.to_solr.merge!(file_size_field.to_sym => "1024"))
+      ActiveFedora::SolrService.add(file1.to_solr.merge!(file_size_field.to_sym => '1024'))
+      ActiveFedora::SolrService.add(file2.to_solr.merge!(file_size_field.to_sym => '1024'))
       ActiveFedora::SolrService.commit
-      allow(work).to receive(:member_ids).and_return(["fs1", "fs2"])
+      allow(work).to receive(:member_ids).and_return(['fs1', 'fs2'])
     end
     its(:bytes) { is_expected.to eq(2048) }
   end
 
-  describe "#upload_set" do
+  describe '#upload_set' do
     its(:upload_set) { is_expected.to be_blank }
   end
 end

--- a/spec/models/ldap_user_spec.rb
+++ b/spec/models/ldap_user_spec.rb
@@ -6,43 +6,43 @@ describe LdapUser do
   let(:empty_user)  { User.new }
 
   # You'll need to change these if I ever go meet Elvis
-  let(:psu_user)        { "agw13" }
-  let(:psu_user_groups) { "umg/up.dlt.scholarsphere-admin" }
+  let(:psu_user)        { 'agw13' }
+  let(:psu_user_groups) { 'umg/up.dlt.scholarsphere-admin' }
 
-  describe "::get_user" do
+  describe '::get_user' do
     before { allow(Hydra::LDAP).to receive(:get_user).and_return(user) }
-    subject { described_class.get_user("filter") }
-    context "when LDAP is responding" do
+    subject { described_class.get_user('filter') }
+    context 'when LDAP is responding' do
       it { is_expected.to eq(user) }
     end
-    context "when LDAP is unwilling" do
+    context 'when LDAP is unwilling' do
       before { allow(described_class).to receive(:unwilling?).and_return(true) }
       it { is_expected.to be_empty }
     end
-    context "when LDAP is unwilling less than the number of tries" do
+    context 'when LDAP is unwilling less than the number of tries' do
       before { allow(described_class).to receive(:unwilling?).at_most(6).times }
       it { is_expected.to eq(user) }
     end
   end
 
-  describe "::check_ldap_exist!" do
-    context "when the login is not present" do
+  describe '::check_ldap_exist!' do
+    context 'when the login is not present' do
       subject { described_class.check_ldap_exist!(nil) }
       it { is_expected.to be false }
     end
-    context "when the user is empty" do
+    context 'when the user is empty' do
       subject { described_class.check_ldap_exist!(empty_user) }
       it { is_expected.to be false }
     end
-    context "when the user is present" do
+    context 'when the user is present' do
       before { allow(Hydra::LDAP).to receive(:does_user_exist?).and_return(true) }
       subject { described_class.check_ldap_exist!(user) }
       it { is_expected.to be true }
 
-      context "when LDAP is unwilling" do
-        let(:message) { "LDAP is unwilling to perform this operation, try upping the number of tries" }
+      context 'when LDAP is unwilling' do
+        let(:message) { 'LDAP is unwilling to perform this operation, try upping the number of tries' }
         before { allow(described_class).to receive(:unwilling?).and_return(true) }
-        it "retries the required number of times" do
+        it 'retries the required number of times' do
           expect(described_class).to receive(:unwilling?).at_most(7).times
           expect(described_class).to receive(:sleep).at_most(7).times
           expect(Rails.logger).to receive(:warn).exactly(:once).with(message)
@@ -50,19 +50,19 @@ describe LdapUser do
         end
       end
 
-      context "when LDAP is willing" do
+      context 'when LDAP is willing' do
         before { allow(described_class).to receive(:unwilling?).and_return(false) }
-        it "does not retry" do
+        it 'does not retry' do
           expect(described_class).not_to receive(:sleep)
           expect(Rails.logger).not_to receive(:warn)
           expect(described_class.check_ldap_exist!(user)).to be true
         end
       end
 
-      context "when Hydra::LDAP raises an error" do
-        let(:message) { "Error getting LDAP response" }
+      context 'when Hydra::LDAP raises an error' do
+        let(:message) { 'Error getting LDAP response' }
         before { allow(Hydra::LDAP).to receive(:does_user_exist?).and_raise(Net::LDAP::Error) }
-        it "does not retry, but logs the error and returns false" do
+        it 'does not retry, but logs the error and returns false' do
           expect(described_class).not_to receive(:sleep)
           expect(Rails.logger).to receive(:warn).with(/message/)
           expect(described_class.check_ldap_exist!(user)).to be false
@@ -71,50 +71,50 @@ describe LdapUser do
     end
   end
 
-  describe "::get_groups" do
-    context "when the login is not present" do
+  describe '::get_groups' do
+    context 'when the login is not present' do
       subject { described_class.get_groups(nil) }
       it { is_expected.to be_empty }
     end
-    context "when the user is present" do
+    context 'when the user is present' do
       before { allow(described_class).to receive(:group_response_from_ldap).and_return(ldap_results) }
       subject { described_class.get_groups(user) }
-      context "with groups" do
+      context 'with groups' do
         let(:ldap_results) do
           [
             { psmemberof:
               [
-                "cn=umg/up.its.wikispaces.users.admin,dc=psu,dc=edu",
-                "cn=umg/up.its.ipv6_planning_team,dc=psu,dc=edu",
-                "cn=xyz/agw13.all.stars,dc=psu,dc=edu"
+                'cn=umg/up.its.wikispaces.users.admin,dc=psu,dc=edu',
+                'cn=umg/up.its.ipv6_planning_team,dc=psu,dc=edu',
+                'cn=xyz/agw13.all.stars,dc=psu,dc=edu'
               ]
             }
           ]
         end
-        it { is_expected.to eq(["umg/up.its.wikispaces.users.admin", "umg/up.its.ipv6_planning_team"]) }
+        it { is_expected.to eq(['umg/up.its.wikispaces.users.admin', 'umg/up.its.ipv6_planning_team']) }
       end
-      context "without groups" do
+      context 'without groups' do
         let(:ldap_results) { [{ psmemberof: [] }] }
         it { is_expected.to be_empty }
       end
-      context "when the ldap response is empty" do
+      context 'when the ldap response is empty' do
         let(:ldap_results) { [] }
         it { is_expected.to be_empty }
       end
     end
-    context "with a real PSU user", :need_ldap, unless: ENV['TRAVIS'] do
+    context 'with a real PSU user', :need_ldap, unless: ENV['TRAVIS'] do
       subject { described_class.get_groups(psu_user) }
       it { is_expected.to include(psu_user_groups) }
     end
   end
 
-  describe "::filter_for" do
-    context "with students, faculty, staff, and employees" do
-      let(:result) { "(| (eduPersonPrimaryAffiliation=STUDENT) (eduPersonPrimaryAffiliation=FACULTY) (eduPersonPrimaryAffiliation=STAFF) (eduPersonPrimaryAffiliation=EMPLOYEE))))" }
+  describe '::filter_for' do
+    context 'with students, faculty, staff, and employees' do
+      let(:result) { '(| (eduPersonPrimaryAffiliation=STUDENT) (eduPersonPrimaryAffiliation=FACULTY) (eduPersonPrimaryAffiliation=STAFF) (eduPersonPrimaryAffiliation=EMPLOYEE))))' }
       subject { described_class.filter_for(:student, :faculty, :staff, :employee) }
       it { is_expected.to eq(result) }
     end
-    context "with nobody" do
+    context 'with nobody' do
       subject { described_class.filter_for }
       it { is_expected.to be_empty }
     end

--- a/spec/models/permissions_change_set_spec.rb
+++ b/spec/models/permissions_change_set_spec.rb
@@ -2,67 +2,67 @@
 require 'rails_helper'
 
 describe PermissionsChangeSet do
-  describe "#added and #removed" do
+  describe '#added and #removed' do
     let(:no_perm)   { [] }
-    let(:one_perm)  { [{ name: "abd123", type: "person", access: "edit" }] }
+    let(:one_perm)  { [{ name: 'abd123', type: 'person', access: 'edit' }] }
     let(:multi_perm) do
       [
-        { name: "zzz123", type: "person", access: "edit" },
-        { name: "def123", type: "person", access: "edit" }
+        { name: 'zzz123', type: 'person', access: 'edit' },
+        { name: 'def123', type: 'person', access: 'edit' }
       ]
     end
 
     subject { described_class.new(before.permissions.map(&:to_hash), after.permissions.map(&:to_hash)) }
 
-    context "with no permissions after" do
+    context 'with no permissions after' do
       let(:after) { build(:file) }
-      context "and no permissions before" do
+      context 'and no permissions before' do
         let(:before) { build(:file) }
         its(:added)   { is_expected.to be_empty }
         its(:removed) { is_expected.to be_empty }
       end
-      context "and one permission before" do
+      context 'and one permission before' do
         let(:before) { build(:file, edit_users: ['abd123']) }
         its(:added)   { is_expected.to be_empty }
         its(:removed) { is_expected.to eq(one_perm) }
       end
-      context "and multiple permissions before" do
+      context 'and multiple permissions before' do
         let(:before) { build(:file, edit_users: ['zzz123', 'def123']) }
         its(:added)   { is_expected.to be_empty }
         its(:removed) { is_expected.to eq(multi_perm) }
       end
     end
-    context "with one permission after" do
+    context 'with one permission after' do
       let(:after) { build(:file, edit_users: ['abd123']) }
-      context "and one permission before" do
+      context 'and one permission before' do
         let(:before) { build(:file, edit_users: ['abd123']) }
         its(:added)   { is_expected.to be_empty }
         its(:removed) { is_expected.to be_empty }
       end
-      context "and no permissions before" do
+      context 'and no permissions before' do
         let(:before) { build(:file) }
         its(:added)   { is_expected.to eq(one_perm) }
         its(:removed) { is_expected.to be_empty }
       end
-      context "and multiple permissions before" do
+      context 'and multiple permissions before' do
         let(:before) { build(:file, edit_users: ['zzz123', 'def123']) }
         its(:added)   { is_expected.to eq(one_perm) }
         its(:removed) { is_expected.to eq(multi_perm) }
       end
     end
-    context "with multiple permissions after" do
+    context 'with multiple permissions after' do
       let(:after) { build(:file, edit_users: ['zzz123', 'def123']) }
-      context "and multiple permissions before" do
+      context 'and multiple permissions before' do
         let(:before) { build(:file, edit_users: ['zzz123', 'def123']) }
         its(:added)   { is_expected.to be_empty }
         its(:removed) { is_expected.to be_empty }
       end
-      context "and no permissions before" do
+      context 'and no permissions before' do
         let(:before) { build(:file) }
         its(:added)   { is_expected.to eq(multi_perm) }
         its(:removed) { is_expected.to be_empty }
       end
-      context "and one permission before" do
+      context 'and one permission before' do
         let(:before) { build(:file, edit_users: ['abd123']) }
         its(:added)   { is_expected.to eq(multi_perm) }
         its(:removed) { is_expected.to eq(one_perm) }
@@ -70,44 +70,44 @@ describe PermissionsChangeSet do
     end
   end
 
-  describe "#privatized?" do
+  describe '#privatized?' do
     subject { described_class.new(before.permissions.map(&:to_hash), after.permissions.map(&:to_hash)) }
 
-    context "when going from public to private" do
+    context 'when going from public to private' do
       let(:before) { build(:public_file) }
       let(:after)  { build(:private_file) }
       it { is_expected.to be_privatized }
     end
 
-    context "when going from private to public" do
+    context 'when going from private to public' do
       let(:before) { build(:private_file) }
       let(:after)  { build(:public_file) }
       it { is_expected.not_to be_privatized }
     end
 
-    context "when visibility remains unchanged" do
+    context 'when visibility remains unchanged' do
       let(:before) { build(:file) }
       let(:after)  { build(:file) }
       it { is_expected.not_to be_privatized }
     end
   end
 
-  describe "#publicized?" do
+  describe '#publicized?' do
     subject { described_class.new(before.permissions.map(&:to_hash), after.permissions.map(&:to_hash)) }
 
-    context "when going from public to private" do
+    context 'when going from public to private' do
       let(:before) { build(:public_file) }
       let(:after)  { build(:private_file) }
       it { is_expected.not_to be_publicized }
     end
 
-    context "when going from private to public" do
+    context 'when going from private to public' do
       let(:before) { build(:private_file) }
       let(:after)  { build(:public_file) }
       it { is_expected.to be_publicized }
     end
 
-    context "when visibility remains unchanged" do
+    context 'when visibility remains unchanged' do
       let(:before) { build(:file) }
       let(:after)  { build(:file) }
       it { is_expected.not_to be_publicized }

--- a/spec/models/public_filtered_list_spec.rb
+++ b/spec/models/public_filtered_list_spec.rb
@@ -3,12 +3,12 @@ require 'rails_helper'
 
 describe PublicFilteredList, type: :model do
   let(:file_list) do
-    [create(:private_file, title: ["private"]), create(:public_file, title: ["public"])]
+    [create(:private_file, title: ['private']), create(:public_file, title: ['public'])]
   end
 
   subject { described_class.new(file_list).filter }
 
-  it "keeps public files" do
+  it 'keeps public files' do
     expect(subject.count).to eq(1)
     expect(subject.map(&:title)).to include(['public'])
     expect(subject.map(&:title)).not_to include(['private'])

--- a/spec/models/resource_filtered_list_spec.rb
+++ b/spec/models/resource_filtered_list_spec.rb
@@ -4,19 +4,19 @@ require 'rails_helper'
 describe ResourceFilteredList, type: :model do
   let(:file_list) do
     [
-      create(:file, title: ["Dataset"], resource_type: ["Dataset"]),
-      create(:file, title: ["Poster"], resource_type: ["Poster"]),
-      create(:file, title: ["Thesis"], resource_type: ["Thesis"]),
-      create(:file, title: ["Dissertation"], resource_type: ["Dissertation"]),
-      create(:file, title: ["Report"], resource_type: ["Report"]),
+      create(:file, title: ['Dataset'], resource_type: ['Dataset']),
+      create(:file, title: ['Poster'], resource_type: ['Poster']),
+      create(:file, title: ['Thesis'], resource_type: ['Thesis']),
+      create(:file, title: ['Dissertation'], resource_type: ['Dissertation']),
+      create(:file, title: ['Report'], resource_type: ['Report']),
       create(:file, title: ['none'])
     ]
   end
 
-  context "when using default resource types" do
+  context 'when using default resource types' do
     subject { described_class.new(file_list).filter }
 
-    it "keeps default resource types" do
+    it 'keeps default resource types' do
       expect(subject.count).to eq(4)
       expect(subject.map(&:title)).to include(['Dataset'])
       expect(subject.map(&:title)).to include(['Poster'])
@@ -27,10 +27,10 @@ describe ResourceFilteredList, type: :model do
     end
   end
 
-  context "when using other resource types" do
+  context 'when using other resource types' do
     subject { described_class.new(file_list, ['Dataset', 'Report']).filter }
 
-    it "keeps default resource types" do
+    it 'keeps default resource types' do
       expect(subject.count).to eq(2)
       expect(subject.map(&:title)).to include(['Dataset'])
       expect(subject.map(&:title)).to include(['Report'])

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -2,31 +2,31 @@
 require 'rails_helper'
 
 describe SolrDocument do
-  let(:work) { build(:work, id: "foo") }
+  let(:work) { build(:work, id: 'foo') }
   subject { described_class.new(work.to_solr) }
 
-  describe "#export_as_endnote" do
+  describe '#export_as_endnote' do
     let(:export) do
       "%0 Work\n" \
       "%T Sample Title\n" \
       "%R http://scholarsphere.psu.edu/files/#{work.id}\n" \
       "%~ ScholarSphere\n" \
-      "%W Penn State"
+      '%W Penn State'
     end
     its(:export_as_endnote) { is_expected.to eq(export) }
   end
 
-  describe "#file_size" do
-    subject { described_class.new(file_size_lts: ["1234"]) }
-    its(:file_size) { is_expected.to eq("1234") }
+  describe '#file_size' do
+    subject { described_class.new(file_size_lts: ['1234']) }
+    its(:file_size) { is_expected.to eq('1234') }
   end
 
-  describe "#bytes" do
-    subject { described_class.new(bytes_lts: ["1234"]) }
-    its(:bytes) { is_expected.to eq("1234") }
+  describe '#bytes' do
+    subject { described_class.new(bytes_lts: ['1234']) }
+    its(:bytes) { is_expected.to eq('1234') }
   end
 
-  describe "#to_hash" do
+  describe '#to_hash' do
     its(:to_hash) { is_expected.to eq(subject.to_h) }
   end
 end

--- a/spec/models/user_mailer_spec.rb
+++ b/spec/models/user_mailer_spec.rb
@@ -6,20 +6,20 @@ describe UserMailer do
   before :all do
     GenericWork.destroy_all
   end
-  describe "#acknowledgment_email" do
-    let(:form)    { { sufia_contact_form: { email: "email@somewhere.com", subject: "Selected topic" } } }
+  describe '#acknowledgment_email' do
+    let(:form)    { { sufia_contact_form: { email: 'email@somewhere.com', subject: 'Selected topic' } } }
     let(:params)  { ActionController::Parameters.new(form) }
     let(:message) { described_class.acknowledgment_email(params) }
 
-    it "sends an email to the user when the contact form is submitted" do
-      expect(message.to).to contain_exactly("email@somewhere.com")
+    it 'sends an email to the user when the contact form is submitted' do
+      expect(message.to).to contain_exactly('email@somewhere.com')
       expect(message.from).to contain_exactly(Rails.application.config.action_mailer.default_options.fetch(:from))
-      expect(message.subject).to eq("ScholarSphere Contact Form - Selected topic")
+      expect(message.subject).to eq('ScholarSphere Contact Form - Selected topic')
       expect(message.body.raw_source).to match(/Thank you for contacting us with your question/)
     end
   end
 
-  describe "#stats_email" do
+  describe '#stats_email' do
     let(:message)      { described_class.stats_email(1.day.ago, DateTime.now) }
     let(:mock_service) { double }
     let(:csv)          { "a,b,c\nd,e,f\n" }
@@ -30,11 +30,11 @@ describe UserMailer do
       allow(mock_service).to receive(:csv).and_return(csv)
     end
 
-    it "emails the report" do
+    it 'emails the report' do
       expect(message['from'].to_s).to eq(Rails.application.config.action_mailer.default_options.fetch(:from))
-      expect(message['to'].to_s).to include("Test email")
+      expect(message['to'].to_s).to include('Test email')
       expect(message.parts.count).to eq(2) # attachment & body
-      expect(message.parts[0].body).to include("Report for")
+      expect(message.parts[0].body).to include('Report for')
       expect(message.parts[0].attachment?).to be_falsey
       expect(message.parts[1].attachment?).to be_truthy
       expect(message.parts[1].body).to include(csv)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,90 +1,90 @@
 # frozen_string_literal: true
 require 'rails_helper'
-require "cancan/matchers"
+require 'cancan/matchers'
 
 describe User, type: :model do
   let(:user) { create(:ldap_jill) }
 
-  it "has a login" do
-    expect(user.login).to eq("jilluser")
+  it 'has a login' do
+    expect(user.login).to eq('jilluser')
   end
-  it "redefines to_param to make redis keys more recognizable" do
+  it 'redefines to_param to make redis keys more recognizable' do
     expect(user.to_param).to eq(user.login)
   end
-  describe "#ldap_exist?" do
+  describe '#ldap_exist?' do
     subject { user.ldap_exist? }
-    context "when the user exists" do
+    context 'when the user exists' do
       before { allow(LdapUser).to receive(:check_ldap_exist!).and_return(true) }
       it { is_expected.to be true }
     end
-    context "when the user does not exist" do
+    context 'when the user does not exist' do
       before { allow(LdapUser).to receive(:check_ldap_exist!).and_return(false) }
       it { is_expected.to be false }
     end
-    context "when LDAP misbehaves" do
+    context 'when LDAP misbehaves' do
       before do
         filter = Net::LDAP::Filter.eq('uid', user.login)
         allow(Hydra::LDAP).to receive(:does_user_exist?).twice.with(filter).and_return(true)
       end
 
       it "returns true after LDAP returns 'unwilling' first, then sleeps and returns true on the second call" do
-        expect(Hydra::LDAP.connection).to receive(:get_operation_result).once.and_return(OpenStruct.new(code: 53, message: "Unwilling"))
-        expect(Hydra::LDAP.connection).to receive(:get_operation_result).once.and_return(OpenStruct.new(code: 0, message: "sucess"))
+        expect(Hydra::LDAP.connection).to receive(:get_operation_result).once.and_return(OpenStruct.new(code: 53, message: 'Unwilling'))
+        expect(Hydra::LDAP.connection).to receive(:get_operation_result).once.and_return(OpenStruct.new(code: 0, message: 'sucess'))
         expect(LdapUser).to receive(:sleep).with(Rails.application.config.ldap_unwilling_sleep)
         expect(user.ldap_exist?).to eq(true)
       end
     end
   end
 
-  describe "#directory_attributes" do
-    let(:entry) { build(:ldap_entry, uid: "mjg36", cn: "MICHAEL JOSEPH GIARLO") }
+  describe '#directory_attributes' do
+    let(:entry) { build(:ldap_entry, uid: 'mjg36', cn: 'MICHAEL JOSEPH GIARLO') }
     before { expect(Hydra::LDAP).to receive(:get_user).and_return([entry]) }
-    it "returns user attributes from LDAP" do
+    it 'returns user attributes from LDAP' do
       expect(described_class.directory_attributes('mjg36', ['cn']).first['cn']).to eq(['MICHAEL JOSEPH GIARLO'])
     end
   end
 
-  describe "#query_ldap_by_name_or_id" do
-    let(:name_part) { "cam" }
+  describe '#query_ldap_by_name_or_id' do
+    let(:name_part) { 'cam' }
     let(:filter) { Net::LDAP::Filter.construct("(& (| (uid=#{name_part}* ) (givenname=#{name_part}*) (sn=#{name_part}*)) (| (eduPersonPrimaryAffiliation=STUDENT) (eduPersonPrimaryAffiliation=FACULTY) (eduPersonPrimaryAffiliation=STAFF) (eduPersonPrimaryAffiliation=EMPLOYEE))))") }
     let(:results) do
       [
-        build(:ldap_entry, uid: "cac6094", displayname: "CAMILO CAPURRO"),
-        build(:ldap_entry, uid: "csl5210", displayname: "CAMERON SIERRA LANGSJOEN"),
-        build(:ldap_entry, uid: "cnt5046", displayname: "CAMILLE NAKIA TINDAL")
+        build(:ldap_entry, uid: 'cac6094', displayname: 'CAMILO CAPURRO'),
+        build(:ldap_entry, uid: 'csl5210', displayname: 'CAMERON SIERRA LANGSJOEN'),
+        build(:ldap_entry, uid: 'cnt5046', displayname: 'CAMILLE NAKIA TINDAL')
       ]
     end
-    let(:attrs) { ["uid", "displayname"] }
+    let(:attrs) { ['uid', 'displayname'] }
 
     before do
       expect(Hydra::LDAP).to receive(:get_user).with(filter, attrs).and_return(results)
-      allow(Hydra::LDAP.connection).to receive(:get_operation_result).and_return(OpenStruct.new(code: 0, message: "Success"))
+      allow(Hydra::LDAP.connection).to receive(:get_operation_result).and_return(OpenStruct.new(code: 0, message: 'Success'))
     end
-    it "returns a list or people" do
-      expect(described_class.query_ldap_by_name_or_id("cam")).to eq([{ id: "cac6094", text: "CAMILO CAPURRO (cac6094)" },
-                                                                     { id: "csl5210", text: "CAMERON SIERRA LANGSJOEN (csl5210)" },
-                                                                     { id: "cnt5046", text: "CAMILLE NAKIA TINDAL (cnt5046)" }
+    it 'returns a list or people' do
+      expect(described_class.query_ldap_by_name_or_id('cam')).to eq([{ id: 'cac6094', text: 'CAMILO CAPURRO (cac6094)' },
+                                                                     { id: 'csl5210', text: 'CAMERON SIERRA LANGSJOEN (csl5210)' },
+                                                                     { id: 'cnt5046', text: 'CAMILLE NAKIA TINDAL (cnt5046)' }
                                                                     ])
     end
   end
 
-  describe "#from_url_component" do
+  describe '#from_url_component' do
     let(:entry) do
-      build(:ldap_entry, uid: 'mjg36', cn: "MICHAEL JOSEPH GIARLO", displayname: "John Smith", psofficelocation: "Beaver Stadium$Seat 100")
+      build(:ldap_entry, uid: 'mjg36', cn: 'MICHAEL JOSEPH GIARLO', displayname: 'John Smith', psofficelocation: 'Beaver Stadium$Seat 100')
     end
-    subject { described_class.from_url_component("cam") }
+    subject { described_class.from_url_component('cam') }
 
-    context "when user exists" do
+    context 'when user exists' do
       before do
         allow(LdapUser).to receive(:check_ldap_exist!).and_return(true)
         allow(LdapUser).to receive(:group_response_from_ldap).and_return([])
         allow(Hydra::LDAP).to receive(:get_user).and_return([entry])
       end
 
-      it "creates a user" do
+      it 'creates a user' do
         expect(described_class.count).to eq 0
         is_expected.to be_a_kind_of(described_class)
-        expect(subject.display_name).to eq "John Smith"
+        expect(subject.display_name).to eq 'John Smith'
         expect(subject.office).to eq "Beaver Stadium\nSeat 100"
         expect(subject.website).to be_nil
         expect(subject.title).to be_nil
@@ -92,10 +92,10 @@ describe User, type: :model do
       end
     end
 
-    context "user does not exists" do
+    context 'user does not exists' do
       before { allow(Hydra::LDAP).to receive(:does_user_exist?).and_return(false) }
 
-      it "does not create a user" do
+      it 'does not create a user' do
         expect(described_class.count).to eq 0
         is_expected.not_to be_a_kind_of(described_class)
         expect(described_class.count).to eq 0
@@ -103,28 +103,28 @@ describe User, type: :model do
     end
   end
 
-  describe "administrator?" do
+  describe 'administrator?' do
     subject { user.administrator? }
 
-    context "normal user" do
+    context 'normal user' do
       let(:user) { create :user }
       it { is_expected.to be_falsey }
     end
-    context "administrative user" do
+    context 'administrative user' do
       let(:user) { create :administrator }
       it { is_expected.to be_truthy }
     end
   end
 
-  describe "file abilities" do
+  describe 'file abilities' do
     let(:private_user) { create(:user) }
     let(:private_file) { create(:private_file, depositor: private_user.login) }
     let(:my_file)      { create(:registered_file, depositor: user.login) }
     let(:shared_file)  { create(:registered_file, depositor: private_user.login, edit_users: [user.login]) }
 
-    describe "abilities" do
+    describe 'abilities' do
       subject { Ability.new(user) }
-      context "normal user" do
+      context 'normal user' do
         let(:user) { create :user }
 
         it { should be_able_to(:edit, my_file) }
@@ -132,7 +132,7 @@ describe User, type: :model do
         it { should_not be_able_to(:edit, private_file) }
       end
 
-      context "administrative user" do
+      context 'administrative user' do
         let(:user) { create :administrator }
 
         it { should be_able_to(:edit, my_file) }
@@ -141,25 +141,25 @@ describe User, type: :model do
       end
     end
 
-    describe "administrating?" do
+    describe 'administrating?' do
       subject { user.administrating?(file) }
 
-      context "normal user" do
+      context 'normal user' do
         let(:user) { create :user }
         context "user's file" do
           let(:file) { my_file }
           it { is_expected.to be_falsey }
         end
-        context "private file" do
+        context 'private file' do
           let(:file) { private_file }
           it { is_expected.to be_falsey }
         end
-        context "shared file" do
+        context 'shared file' do
           let(:file) { shared_file }
           it { is_expected.to be_falsey }
         end
       end
-      context "administrative user" do
+      context 'administrative user' do
         let(:user) { create :administrator }
         context "user's file" do
           let(:file) { my_file }
@@ -167,11 +167,11 @@ describe User, type: :model do
             is_expected.to be_falsey
           }
         end
-        context "private file" do
+        context 'private file' do
           let(:file) { private_file }
           it { is_expected.to be_truthy }
         end
-        context "shared file" do
+        context 'shared file' do
           let(:file) { shared_file }
           it {
             is_expected.to be_falsey

--- a/spec/presenters/collection_presenter_spec.rb
+++ b/spec/presenters/collection_presenter_spec.rb
@@ -2,16 +2,16 @@
 require 'rails_helper'
 
 describe CollectionPresenter do
-  describe "#terms" do
+  describe '#terms' do
     subject { described_class.terms }
     it { is_expected.to include(:date_modified, :date_uploaded) }
   end
 
-  describe "#size" do
+  describe '#size' do
     let(:collection) { build(:public_collection) }
     let(:doc)        { SolrDocument.new(collection.to_solr) }
-    before { allow(collection).to receive(:bytes).and_return("40") }
+    before { allow(collection).to receive(:bytes).and_return('40') }
     subject { CurationConcerns::CollectionPresenter.new(doc, nil) }
-    its(:size) { is_expected.to eq("40 Bytes") }
+    its(:size) { is_expected.to eq('40 Bytes') }
   end
 end

--- a/spec/presenters/error_presenter_spec.rb
+++ b/spec/presenters/error_presenter_spec.rb
@@ -2,51 +2,51 @@
 require 'rails_helper'
 
 describe ErrorPresenter do
-  context "with an class exception" do
+  context 'with an class exception' do
     subject { described_class.new(ActiveFedora::ObjectNotFoundError) }
     its(:status)  { is_expected.to eq(404) }
-    its(:title)   { is_expected.to eq("Not Found") }
-    its(:message) { is_expected.to eq("This item is not available") }
+    its(:title)   { is_expected.to eq('Not Found') }
+    its(:message) { is_expected.to eq('This item is not available') }
 
-    it "logs the error" do
+    it 'logs the error' do
       expect(Rails.logger).to receive(:error)
       subject.log_exception
     end
   end
 
-  context "with an instance exception" do
+  context 'with an instance exception' do
     subject { described_class.new(ActionController::RoutingError.new(nil)) }
     its(:status)  { is_expected.to eq(404) }
-    its(:title)   { is_expected.to eq("Not Found") }
-    its(:message) { is_expected.to eq("This item is not available") }
+    its(:title)   { is_expected.to eq('Not Found') }
+    its(:message) { is_expected.to eq('This item is not available') }
 
-    it "logs the error" do
+    it 'logs the error' do
       expect(Rails.logger).to receive(:error)
       subject.log_exception
     end
   end
 
-  context "with no exception" do
+  context 'with no exception' do
     subject { described_class.new }
     its(:status)  { is_expected.to eq(404) }
-    its(:title)   { is_expected.to eq("Not Found") }
-    its(:message) { is_expected.to eq("This item is not available") }
+    its(:title)   { is_expected.to eq('Not Found') }
+    its(:message) { is_expected.to eq('This item is not available') }
 
-    it "logs the error use Scholarsphere::Error" do
-      expect(Rails.logger).to receive(:error).with("Rendering 404 page due to exception: Scholarsphere::Error - ")
+    it 'logs the error use Scholarsphere::Error' do
+      expect(Rails.logger).to receive(:error).with('Rendering 404 page due to exception: Scholarsphere::Error - ')
       subject.log_exception
     end
   end
 
-  context "when the i18n key is missing" do
+  context 'when the i18n key is missing' do
     subject { described_class.new(Fixnum) }
 
     its(:status)  { is_expected.to eq(500) }
-    its(:title)   { is_expected.to eq("Error") }
-    its(:message) { is_expected.to eq("There was an error with your request") }
+    its(:title)   { is_expected.to eq('Error') }
+    its(:message) { is_expected.to eq('There was an error with your request') }
 
     it "logs that the key isn't there" do
-      expect(Rails.logger).to receive(:warn).with("Error key fixnum is not present in the i18n file. You may want to add it.")
+      expect(Rails.logger).to receive(:warn).with('Error key fixnum is not present in the i18n file. You may want to add it.')
       described_class.new(Fixnum)
     end
   end

--- a/spec/presenters/file_set_presenter_spec.rb
+++ b/spec/presenters/file_set_presenter_spec.rb
@@ -4,17 +4,17 @@ require 'rails_helper'
 describe FileSetPresenter do
   let(:file)          { build(:file_set) }
   let(:solr_document) { SolrDocument.new(file.to_solr) }
-  let(:ability)       { double "Ability" }
+  let(:ability)       { double 'Ability' }
   let(:presenter)     { described_class.new(solr_document, ability) }
 
   subject { presenter }
 
-  describe "#related_files" do
+  describe '#related_files' do
     its(:related_files) { is_expected.to be_empty }
   end
 
-  describe "#file_size" do
-    before { allow(file).to receive(:file_size).and_return(["4906"]) }
-    its(:file_size) { is_expected.to eq("4.79 KB") }
+  describe '#file_size' do
+    before { allow(file).to receive(:file_size).and_return(['4906']) }
+    its(:file_size) { is_expected.to eq('4.79 KB') }
   end
 end

--- a/spec/presenters/null_representative_presenter_spec.rb
+++ b/spec/presenters/null_representative_presenter_spec.rb
@@ -7,13 +7,13 @@ describe NullRepresentativePresenter do
 
   subject { presenter }
 
-  describe "#has?" do
-    it "has a thumbnail url" do
-      expect(subject.has?("thumbnail_path_ss")).to be true
+  describe '#has?' do
+    it 'has a thumbnail url' do
+      expect(subject.has?('thumbnail_path_ss')).to be true
     end
   end
 
-  describe "#display_download_link?" do
+  describe '#display_download_link?' do
     its(:display_download_link?) { is_expected.to be false }
   end
 end

--- a/spec/presenters/stats_presenter_spec.rb
+++ b/spec/presenters/stats_presenter_spec.rb
@@ -12,44 +12,44 @@ describe StatsPresenter, type: :model do
     allow(Sufia::Statistics::Works::Count).to receive(:new).with(start_datetime, end_datetime).and_return(work_stats)
   end
 
-  describe "#single_day?" do
+  describe '#single_day?' do
     subject { presenter.single_day? }
 
-    context "start and end datetime on the same day" do
+    context 'start and end datetime on the same day' do
       let(:start_datetime) { DateTime.now }
       it { is_expected.to be_truthy }
     end
 
-    context "start and end datetime on different days" do
+    context 'start and end datetime on different days' do
       let(:start_datetime) { 1.day.ago }
       it { is_expected.to be_falsey }
     end
   end
 
-  describe "#date_str" do
+  describe '#date_str' do
     subject { presenter.date_str }
 
-    context "start and end datetime on the same day" do
+    context 'start and end datetime on the same day' do
       let(:start_datetime) { DateTime.now }
       it { is_expected.to eq(start_datetime.to_date.to_s) }
     end
 
-    context "start and end datetime on different days" do
+    context 'start and end datetime on different days' do
       let(:start_datetime) { 1.day.ago }
       it { is_expected.to include(start_datetime.to_date.to_s) }
       it { is_expected.to include(end_datetime.to_date.to_s) }
     end
   end
 
-  describe "#start_date" do
-    let(:start_datetime) { DateTime.parse("2004-01-01T01:01:01") }
+  describe '#start_date' do
+    let(:start_datetime) { DateTime.parse('2004-01-01T01:01:01') }
     subject { presenter.start_date.to_s }
-    it { is_expected.to eq "2004-01-01" }
+    it { is_expected.to eq '2004-01-01' }
   end
 
-  describe "accessors" do
-    let(:start_datetime) { DateTime.parse("2004-01-01T01:01:01") }
-    it "responds to expected attributes" do
+  describe 'accessors' do
+    let(:start_datetime) { DateTime.parse('2004-01-01T01:01:01') }
+    it 'responds to expected attributes' do
       expect(presenter).to respond_to(:total_users)
       expect(presenter).to respond_to(:total_uploads)
       expect(presenter).to respond_to(:total_public_uploads)
@@ -59,11 +59,11 @@ describe StatsPresenter, type: :model do
     end
   end
 
-  describe "upload stats" do
-    let(:start_datetime) { DateTime.parse("2004-01-01T01:01:01") }
+  describe 'upload stats' do
+    let(:start_datetime) { DateTime.parse('2004-01-01T01:01:01') }
     let(:stats) { { total: 100, public: 70, registered: 20, private: 10 } }
     before { allow(work_stats).to receive(:by_permission).and_return(stats) }
-    it "calls Sufia::Statistics::Works::Count for data" do
+    it 'calls Sufia::Statistics::Works::Count for data' do
       expect(presenter.total_uploads).to eq(100)
       expect(presenter.total_public_uploads).to eq(70)
       expect(presenter.total_registered_uploads).to eq(20)
@@ -71,10 +71,10 @@ describe StatsPresenter, type: :model do
     end
   end
 
-  describe "#total_users" do
+  describe '#total_users' do
     let(:start_datetime) { DateTime.now }
     before { 3.times { create(:user) } }
-    it "returns the total number of user records" do
+    it 'returns the total number of user records' do
       expect(presenter.total_users).to eq(3)
     end
   end

--- a/spec/presenters/sufia/work_usage_spec.rb
+++ b/spec/presenters/sufia/work_usage_spec.rb
@@ -5,19 +5,19 @@ describe Sufia::WorkUsage do
   let(:work) { create(:work) }
   subject { described_class.new(work.id) }
 
-  describe "#date_for_analytics" do
-    context "without date_uploaded" do
+  describe '#date_for_analytics' do
+    context 'without date_uploaded' do
       its(:date_for_analytics) { is_expected.to eq(work.create_date) }
     end
 
-    context "when date_uploaded is before Sufia.config.analytic_start_date" do
+    context 'when date_uploaded is before Sufia.config.analytic_start_date' do
       let(:work) { create(:work, date_uploaded: DateTime.new(2011, 7, 1)) }
       its(:date_for_analytics) { is_expected.to eq(Sufia.config.analytic_start_date) }
     end
 
-    context "when date_uploaded is after Sufia.config.analytic_start_date" do
+    context 'when date_uploaded is after Sufia.config.analytic_start_date' do
       let(:work) { create(:work, date_uploaded: DateTime.new(2014, 7, 1)) }
-      its(:date_for_analytics) { is_expected.to eq("July 1, 2014") }
+      its(:date_for_analytics) { is_expected.to eq('July 1, 2014') }
     end
   end
 end

--- a/spec/presenters/work_show_presenter_spec.rb
+++ b/spec/presenters/work_show_presenter_spec.rb
@@ -2,80 +2,80 @@
 require 'rails_helper'
 
 describe WorkShowPresenter do
-  let(:work)      { build(:work, id: "1234") }
+  let(:work)      { build(:work, id: '1234') }
   let(:solr_doc)  { SolrDocument.new(work.to_solr) }
   let(:ability)   { Ability.new(nil) }
   let(:presenter) { described_class.new(solr_doc, ability) }
 
   subject { presenter }
 
-  describe "#size" do
-    before { allow(work).to receive(:bytes).and_return("2048") }
-    its(:size) { is_expected.to eq("2 KB") }
+  describe '#size' do
+    before { allow(work).to receive(:bytes).and_return('2048') }
+    its(:size) { is_expected.to eq('2 KB') }
   end
 
-  describe "#total_items" do
-    context "with no files in the work" do
+  describe '#total_items' do
+    context 'with no files in the work' do
       its(:total_items) { is_expected.to eq(0) }
     end
 
-    context "with two files in the work" do
-      let(:solr_doc)    { SolrDocument.new(work.to_solr).to_h.merge!('member_ids_ssim' => ["thing1", "thing2"]) }
+    context 'with two files in the work' do
+      let(:solr_doc)    { SolrDocument.new(work.to_solr).to_h.merge!('member_ids_ssim' => ['thing1', 'thing2']) }
       its(:total_items) { is_expected.to eq(2) }
     end
   end
 
-  describe "#member_presenters" do
+  describe '#member_presenters' do
     let(:work) { create(:public_work, ordered_members: [file_set1, file_set2]) }
 
     subject { presenter.member_presenters }
 
-    context "when the current user has read access to all file sets" do
+    context 'when the current user has read access to all file sets' do
       let(:file_set1) { create(:file_set, :public) }
       let(:file_set2) { create(:file_set, :public) }
       its(:count) { is_expected.to eq(2) }
     end
 
-    context "when the current user does not have read access to all file sets" do
+    context 'when the current user does not have read access to all file sets' do
       let(:file_set1) { create(:file_set, :public) }
       let(:file_set2) { create(:file_set) }
       its(:count) { is_expected.to eq(1) }
     end
   end
 
-  describe "#uploading?" do
+  describe '#uploading?' do
     subject { presenter }
 
-    context "when file sets are in process" do
-      before { QueuedFile.create(work_id: "1234") }
+    context 'when file sets are in process' do
+      before { QueuedFile.create(work_id: '1234') }
       it { is_expected.to be_uploading }
     end
 
-    context "when no file sets are in process" do
+    context 'when no file sets are in process' do
       it { is_expected.not_to be_uploading }
     end
   end
 
-  describe "#facet_mapping" do
-    let(:work) { build(:work, creator: ["JOE SMITH"]) }
+  describe '#facet_mapping' do
+    let(:work) { build(:work, creator: ['JOE SMITH']) }
     subject { presenter.facet_mapping(:creator) }
-    it { is_expected.to eq("JOE SMITH" => "Joe Smith") }
+    it { is_expected.to eq('JOE SMITH' => 'Joe Smith') }
   end
 
-  describe "#events" do
-    context "with no events" do
+  describe '#events' do
+    context 'with no events' do
       let(:work)   { build(:work) }
       its(:events) { is_expected.to be_empty }
     end
 
-    context "with events" do
+    context 'with events' do
       let(:events) { double }
       before do
-        allow(Sufia::RedisEventStore).to receive(:for).with("GenericWork:1234:event").and_return(events)
-        allow(events).to receive(:fetch).with(100).and_return(["event1", "event2"])
+        allow(Sufia::RedisEventStore).to receive(:for).with('GenericWork:1234:event').and_return(events)
+        allow(events).to receive(:fetch).with(100).and_return(['event1', 'event2'])
       end
 
-      its(:events) { is_expected.to contain_exactly("event1", "event2") }
+      its(:events) { is_expected.to contain_exactly('event1', 'event2') }
     end
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,19 +1,19 @@
 # frozen_string_literal: true
 # This file is copied to spec/ when you run 'rails generate rspec:install'
-ENV["RAILS_ENV"] ||= 'test'
+ENV['RAILS_ENV'] ||= 'test'
 require 'rake'
-require File.expand_path("../../config/environment", __FILE__)
+require File.expand_path('../../config/environment', __FILE__)
 require 'rspec/rails'
 require 'equivalent-xml/rspec_matchers'
 require 'byebug' unless ENV['TRAVIS']
 
 def travis?
-  ENV.fetch("TRAVIS", false)
+  ENV.fetch('TRAVIS', false)
 end
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
-Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
+Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 # Checks for pending migrations before tests are run.
 # If you are not using ActiveRecord, you can remove this line.

--- a/spec/rake/scholarsphere/config_spec.rb
+++ b/spec/rake/scholarsphere/config_spec.rb
@@ -2,13 +2,13 @@
 require 'rails_helper'
 require 'rake'
 
-describe "scholarsphere:config" do
+describe 'scholarsphere:config' do
   before do
     load_rake_environment ["#{Rails.root}/lib/tasks/scholarsphere/config.rake"]
   end
 
-  describe ":check" do
-    it "checks the validity of our production yaml files" do
+  describe ':check' do
+    it 'checks the validity of our production yaml files' do
       run_task('scholarsphere:config:check')
     end
   end

--- a/spec/rake/scholarsphere/files_spec.rb
+++ b/spec/rake/scholarsphere/files_spec.rb
@@ -2,12 +2,12 @@
 require 'rails_helper'
 require 'rake'
 
-describe "scholarsphere:files" do
+describe 'scholarsphere:files' do
   before do
     load_rake_environment ["#{Rails.root}/lib/tasks/scholarsphere/files.rake"]
   end
 
-  describe ":create_derivatives" do
+  describe ':create_derivatives' do
     let(:mock_service) { double }
 
     before do
@@ -15,23 +15,23 @@ describe "scholarsphere:files" do
       allow(mock_service).to receive(:errors).and_return(0)
     end
 
-    context "when no list is supplied" do
-      it "uses all FileSets" do
+    context 'when no list is supplied' do
+      it 'uses all FileSets' do
         expect(FileSetManagementService).to receive(:new).with([]).and_return(mock_service)
         run_task('scholarsphere:files:create_derivatives')
       end
     end
 
-    context "with a list of FileSet ids" do
-      let(:argument) { "1 2 3" }
-      it "uses all FileSets" do
-        expect(FileSetManagementService).to receive(:new).with(["1", "2", "3"]).and_return(mock_service)
+    context 'with a list of FileSet ids' do
+      let(:argument) { '1 2 3' }
+      it 'uses all FileSets' do
+        expect(FileSetManagementService).to receive(:new).with(['1', '2', '3']).and_return(mock_service)
         run_task('scholarsphere:files:create_derivatives', argument)
       end
     end
   end
 
-  describe ":characterize" do
+  describe ':characterize' do
     let(:mock_service) { double }
 
     before do
@@ -39,17 +39,17 @@ describe "scholarsphere:files" do
       allow(mock_service).to receive(:errors).and_return(0)
     end
 
-    context "when no list is supplied" do
-      it "uses all FileSets" do
+    context 'when no list is supplied' do
+      it 'uses all FileSets' do
         expect(FileSetManagementService).to receive(:new).with([]).and_return(mock_service)
         run_task('scholarsphere:files:characterize')
       end
     end
 
-    context "with a list of FileSet ids" do
-      let(:argument) { "1 2 3" }
-      it "uses all FileSets" do
-        expect(FileSetManagementService).to receive(:new).with(["1", "2", "3"]).and_return(mock_service)
+    context 'with a list of FileSet ids' do
+      let(:argument) { '1 2 3' }
+      it 'uses all FileSets' do
+        expect(FileSetManagementService).to receive(:new).with(['1', '2', '3']).and_return(mock_service)
         run_task('scholarsphere:files:characterize', argument)
       end
     end

--- a/spec/rake/scholarsphere/harvest_spec.rb
+++ b/spec/rake/scholarsphere/harvest_spec.rb
@@ -2,17 +2,17 @@
 require 'rails_helper'
 require 'rake'
 
-describe "scholarsphere:harvest" do
+describe 'scholarsphere:harvest' do
   before { load_rake_environment ["#{Rails.root}/lib/tasks/scholarsphere/harvest.rake"] }
 
-  context "when harvesting lexvo languages" do
+  context 'when harvesting lexvo languages' do
     it 'loads the terms from the rdf file' do
       expect(LanguageAuthorityImportJob).to receive(:perform_later).with('rdfxml_file')
       run_task('scholarsphere:harvest:lexvo_languages', 'rdfxml_file')
     end
   end
 
-  context "when harvesting LC subjects" do
+  context 'when harvesting LC subjects' do
     it 'loads the terms from the rdf file' do
       expect(SubjectAuthorityImportJob).to receive(:perform_later).with('rdfxml_file')
       run_task('scholarsphere:harvest:lc_subjects', 'rdfxml_file')

--- a/spec/rake/scholarsphere/solr_spec.rb
+++ b/spec/rake/scholarsphere/solr_spec.rb
@@ -2,35 +2,35 @@
 require 'rails_helper'
 require 'rake'
 
-describe "scholarsphere:solr" do
+describe 'scholarsphere:solr' do
   before do
     load_rake_environment ["#{Rails.root}/lib/tasks/scholarsphere/solr.rake"]
   end
 
-  context "with incorrect input" do
-    describe "index" do
-      it "raises an error" do
+  context 'with incorrect input' do
+    describe 'index' do
+      it 'raises an error' do
         expect { run_task 'scholarsphere:solr:index' }.to raise_error(RuntimeError)
       end
     end
   end
 
-  context "with a sample file", clean: true do
+  context 'with a sample file', clean: true do
     let!(:file) { create(:file) }
-    describe "index" do
-      subject { capture_stdout { Rake::Task["scholarsphere:solr:index"].invoke(file.id) } }
+    describe 'index' do
+      subject { capture_stdout { Rake::Task['scholarsphere:solr:index'].invoke(file.id) } }
       it { is_expected.to be_empty }
     end
 
-    describe "compare" do
-      subject { capture_stdout { Rake::Task["scholarsphere:solr:compare"].invoke } }
-      it { is_expected.to start_with("Things appear to be OK") }
-      context "when solr and fedora are out of sync" do
+    describe 'compare' do
+      subject { capture_stdout { Rake::Task['scholarsphere:solr:compare'].invoke } }
+      it { is_expected.to start_with('Things appear to be OK') }
+      context 'when solr and fedora are out of sync' do
         let!(:count) { ActiveFedora::Base.count }
         before { ActiveFedora::Cleaner.cleanout_solr }
-        it "raises an error" do
+        it 'raises an error' do
           # TODO: the active fedora count includes a Hydra::AccessControls::Permission which is a child of Hydra::AccessControls, so it is not at the top level count
-          expect { run_task "scholarsphere:solr:compare" }.to raise_error(RuntimeError, "Fedora's #{count - 1} objects exceeds Solr's 0")
+          expect { run_task 'scholarsphere:solr:compare' }.to raise_error(RuntimeError, "Fedora's #{count - 1} objects exceeds Solr's 0")
         end
       end
     end

--- a/spec/rake/scholarsphere/users_spec.rb
+++ b/spec/rake/scholarsphere/users_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 require 'rake'
 
-describe "scholarsphere:users:list" do
+describe 'scholarsphere:users:list' do
   let!(:user_list) do
     (1..3).map do |n|
       User.create(login: "user#{n}", email: "user#{n}@example.org")
@@ -14,10 +14,10 @@ describe "scholarsphere:users:list" do
     load_rake_environment ["#{Rails.root}/lib/tasks/scholarsphere/users.rake"]
   end
 
-  describe "list users" do
-    it "includes all users" do
-      run_task "scholarsphere:users:list"
-      filename = Rails.root.join("user_emails.txt")
+  describe 'list users' do
+    it 'includes all users' do
+      run_task 'scholarsphere:users:list'
+      filename = Rails.root.join('user_emails.txt')
       expect(Dir.glob(filename).entries.size).to eq(1)
       f = File.open(filename)
       output = f.read
@@ -27,15 +27,15 @@ describe "scholarsphere:users:list" do
     end
   end
 
-  describe "restoring users" do
-    it "adds users to the database" do
-      run_task "scholarsphere:users:restore"
+  describe 'restoring users' do
+    it 'adds users to the database' do
+      run_task 'scholarsphere:users:restore'
     end
   end
 
-  describe "quota report" do
-    it "adds users to the database" do
-      run_task "scholarsphere:users:quota_report"
+  describe 'quota report' do
+    it 'adds users to the database' do
+      run_task 'scholarsphere:users:quota_report'
     end
   end
 end

--- a/spec/rake/share_notify_spec.rb
+++ b/spec/rake/share_notify_spec.rb
@@ -2,12 +2,12 @@
 require 'rails_helper'
 require 'rake'
 
-describe "share" do
+describe 'share' do
   before { load_rake_environment ["#{Rails.root}/lib/tasks/share_notify.rake"] }
 
-  describe "files", clean: true do
+  describe 'files', clean: true do
     let(:work) { create(:public_work) }
-    let(:job)  { double("job") }
+    let(:job)  { double('job') }
     before { allow_any_instance_of(ResourceFilteredList).to receive(:filter).and_return([work]) }
     it 'pushes all available files to SHARE Notify' do
       expect(ShareNotifyJob).to receive(:perform_later).with(work)

--- a/spec/rake/sitemap_spec.rb
+++ b/spec/rake/sitemap_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 require 'rake'
 
-describe "sitemap:generate" do
+describe 'sitemap:generate' do
   def sitemap_path
     Gem.loaded_specs['sitemap'].full_gem_path
   end
@@ -18,9 +18,9 @@ describe "sitemap:generate" do
 
   describe 'sitemap generation', clean: true do
     it 'includes public generic files and users' do
-      pending("See #277")
+      pending('See #277')
       run_task 'sitemap:generate'
-      filename = Rails.root.join(File.expand_path("public"), "sitemap.xml")
+      filename = Rails.root.join(File.expand_path('public'), 'sitemap.xml')
       expect(Dir.glob(filename).entries.size).to eq(1)
       f = File.open(filename)
       output = f.read

--- a/spec/renderers/curation_concerns/attribute_renderer_spec.rb
+++ b/spec/renderers/curation_concerns/attribute_renderer_spec.rb
@@ -2,18 +2,18 @@
 require 'rails_helper'
 
 describe CurationConcerns::Renderers::AttributeRenderer do
-  context "when schema.org locale information is missing" do
-    subject { described_class.new(:size, "3").render }
+  context 'when schema.org locale information is missing' do
+    subject { described_class.new(:size, '3').render }
 
-    it "does not display microdata" do
+    it 'does not display microdata' do
       is_expected.to eq('<dt class="attribute-term">Size</dt><dd class="attribute size">3</dd>')
     end
   end
 
-  context "when schema.org locale information is present" do
-    subject { described_class.new(:creator, "Joe Schmoe").render }
+  context 'when schema.org locale information is present' do
+    subject { described_class.new(:creator, 'Joe Schmoe').render }
 
-    it "displays microdata" do
+    it 'displays microdata' do
       is_expected.to include('itemtype="http://schema.org/Person"')
       is_expected.to include('itemprop="creator"')
       is_expected.to include('<span itemprop="name">Joe Schmoe</span>')

--- a/spec/renderers/translated_facet_attribute_renderer_spec.rb
+++ b/spec/renderers/translated_facet_attribute_renderer_spec.rb
@@ -3,13 +3,13 @@ require 'rails_helper'
 
 describe TranslatedFacetAttributeRenderer do
   let(:field)   { :name }
-  let(:mapping) { { "BOB" => "Bob", "JESSICA" => "Jessica" } }
+  let(:mapping) { { 'BOB' => 'Bob', 'JESSICA' => 'Jessica' } }
 
-  describe "#attribute_to_html" do
+  describe '#attribute_to_html' do
     subject { Nokogiri::HTML(renderer.render) }
     let(:expected) { Nokogiri::HTML(dl_content) }
 
-    context "with explicit facet values" do
+    context 'with explicit facet values' do
       let(:renderer) { described_class.new(field, ['BOB', 'JESSICA'], mapping: mapping) }
 
       let(:dl_content) {%(
@@ -22,7 +22,7 @@ describe TranslatedFacetAttributeRenderer do
       it { expect(subject).to be_equivalent_to(expected) }
     end
 
-    context "without facet values" do
+    context 'without facet values' do
       let(:renderer) { described_class.new(field, ['BOB', 'JESSICA']) }
 
       let(:dl_content) {%(

--- a/spec/requests/download_spec.rb
+++ b/spec/requests/download_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-describe "Download requests", type: :request do
+describe 'Download requests', type: :request do
   let(:collection) { create(:collection) }
   subject { response }
 
   # Tests public/404.html.erb which is required by Hydra::Controller::DownloadBehavior#render_404
-  context "with a missing image" do
+  context 'with a missing image' do
     before { get "/downloads/#{collection.id}" }
     it { is_expected.to be_not_found }
   end

--- a/spec/requests/redirects_spec.rb
+++ b/spec/requests/redirects_spec.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-describe "Redirects", type: :request do
+describe 'Redirects', type: :request do
   subject { response }
 
-  context "from /landing_page/new" do
+  context 'from /landing_page/new' do
     before { get '/landing_page/new' }
     it { is_expected.to redirect_to('/contact') }
   end
 
-  context "from /managedata" do
+  context 'from /managedata' do
     before { get '/managedata' }
     it { is_expected.to redirect_to('/contact') }
   end

--- a/spec/routing/route_spec.rb
+++ b/spec/routing/route_spec.rb
@@ -15,11 +15,11 @@ describe 'Routes', type: :routing do
   end
 
   describe 'Sessions' do
-    it "routes to logout" do
+    it 'routes to logout' do
       expect(get: '/logout').to route_to(controller: 'sessions', action: 'destroy')
     end
 
-    it "routes to login" do
+    it 'routes to login' do
       expect(get: '/login').to route_to(controller: 'sessions', action: 'new')
     end
   end
@@ -28,7 +28,7 @@ describe 'Routes', type: :routing do
     before do
       allow(Sufia::StatsAdmin).to receive(:matches?).and_return(true)
     end
-    it "routes to export" do
+    it 'routes to export' do
       expect(get: 'admin/stats/export').to route_to(controller: 'admin/stats', action: 'export')
     end
   end

--- a/spec/services/attach_files_to_work_failure_service_spec.rb
+++ b/spec/services/attach_files_to_work_failure_service_spec.rb
@@ -3,13 +3,13 @@ require 'rails_helper'
 
 describe AttachFilesToWorkFailureService do
   let(:depositor) { create(:user) }
-  let(:file)      { File.open(File.join(fixture_path, "world.png")) }
+  let(:file)      { File.open(File.join(fixture_path, 'world.png')) }
   let(:inbox)     { depositor.mailbox.inbox }
 
-  describe "#call" do
+  describe '#call' do
     subject { described_class.new(depositor, file) }
 
-    it "sends a failure message" do
+    it 'sends a failure message' do
       subject.call
       expect(inbox.count).to eq(1)
       inbox.each { |msg| expect(msg.last_message.subject).to eq('File failed to attach') }

--- a/spec/services/attach_files_to_work_success_service_spec.rb
+++ b/spec/services/attach_files_to_work_success_service_spec.rb
@@ -3,13 +3,13 @@ require 'rails_helper'
 
 describe AttachFilesToWorkSuccessService do
   let(:depositor) { create(:user) }
-  let(:file)      { File.open(File.join(fixture_path, "world.png")) }
+  let(:file)      { File.open(File.join(fixture_path, 'world.png')) }
   let(:inbox)     { depositor.mailbox.inbox }
 
-  describe "#call" do
+  describe '#call' do
     subject { described_class.new(depositor, file) }
 
-    it "sends passing mail" do
+    it 'sends passing mail' do
       subject.call
       expect(inbox.count).to eq(1)
       inbox.each { |msg| expect(msg.last_message.subject).to eq('File successfully attached') }

--- a/spec/services/field_configurator_spec.rb
+++ b/spec/services/field_configurator_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 describe FieldConfigurator do
-  describe "::index_fields" do
+  describe '::index_fields' do
     subject { described_class.index_fields.keys }
     it {is_expected.to contain_exactly(:resource_type,
                                        :creator,
@@ -15,7 +15,7 @@ describe FieldConfigurator do
                                        :date_uploaded) }
   end
 
-  describe "::show_fields" do
+  describe '::show_fields' do
     subject { described_class.show_fields.keys }
     it {is_expected.to contain_exactly(:description,
                                        :resource_type,
@@ -35,7 +35,7 @@ describe FieldConfigurator do
                                        :subtitle) }
   end
 
-  describe "::facet_fields" do
+  describe '::facet_fields' do
     subject { described_class.facet_fields.keys }
     it {is_expected.to contain_exactly(:resource_type,
                                        :creator,
@@ -48,23 +48,23 @@ describe FieldConfigurator do
                                        :collection,
                                        :has_model) }
 
-    describe "creator facet" do
+    describe 'creator facet' do
       subject { described_class.facet_fields.fetch(:creator) }
       its(:opts) { is_expected.to include(facet_cleaners: [:titleize]) }
     end
 
-    describe "publisher facet" do
+    describe 'publisher facet' do
       subject { described_class.facet_fields.fetch(:publisher) }
       its(:opts) { is_expected.to include(facet_cleaners: [:titleize]) }
     end
 
-    describe "keyword facet" do
+    describe 'keyword facet' do
       subject { described_class.facet_fields.fetch(:keyword) }
       its(:opts) { is_expected.to include(facet_cleaners: [:downcase]) }
     end
   end
 
-  describe "::search_fields" do
+  describe '::search_fields' do
     subject { described_class.search_fields.keys }
     it {is_expected.to contain_exactly(:title,
                                        :description,

--- a/spec/services/file_set_management_service.rb
+++ b/spec/services/file_set_management_service.rb
@@ -2,43 +2,43 @@
 require 'rails_helper'
 
 describe FileSetManagementService do
-  describe "#create_derivatives" do
-    let(:list) { ["1", "2", "3"] }
+  describe '#create_derivatives' do
+    let(:list) { ['1', '2', '3'] }
 
-    context "when an id list is provided" do
+    context 'when an id list is provided' do
       let(:service) { described_class.new(list) }
 
-      it "regenerates thumbnails for each file set in the list" do
+      it 'regenerates thumbnails for each file set in the list' do
         expect(service).to receive(:queue_derivatives_job).with(instance_of(String)).exactly(3).times
         service.create_derivatives
       end
     end
 
-    context "when no list is provided" do
+    context 'when no list is provided' do
       let(:service) { described_class.new }
 
-      it "regenerates thumbnails for all file sets" do
+      it 'regenerates thumbnails for all file sets' do
         service.create_derivatives
       end
     end
   end
 
-  describe "#characterize" do
-    let(:list) { ["1", "2", "3"] }
+  describe '#characterize' do
+    let(:list) { ['1', '2', '3'] }
 
-    context "when an id list is provided" do
+    context 'when an id list is provided' do
       let(:service) { described_class.new(list) }
 
-      it "characterizes each file set in the list" do
+      it 'characterizes each file set in the list' do
         expect(service).to receive(:queue_characterization_job).with(instance_of(String)).exactly(3).times
         service.characterize
       end
     end
 
-    context "when no list is provided" do
+    context 'when no list is provided' do
       let(:service) { described_class.new }
 
-      it "characterizes all file sets" do
+      it 'characterizes all file sets' do
         service.characterize
       end
     end

--- a/spec/services/generic_work_list_to_csv_spec.rb
+++ b/spec/services/generic_work_list_to_csv_spec.rb
@@ -6,42 +6,42 @@ describe GenericWorkListToCSVService do
   let(:service) { described_class.new(file_list) }
   let(:header) { "Work Url,Work Id,Work Title,Work Resource Type,Work Rights,File Set Url,File Set Time Uploaded,File Set Id,File Set Title,File Set Depositor,File Set Creator,File Set Visibility,File Set File Format\n" }
 
-  describe "#csv" do
+  describe '#csv' do
     subject { service.csv }
 
-    context "with no files" do
+    context 'with no files' do
       let(:file_list) { [] }
       it { is_expected.to eq(header) }
     end
 
-    context "with one file" do
-      let(:file_list) { [create(:work, :with_one_file, file_title: ["CSV Report 1"], resource_type: ["Image"], rights: ["mine"])] }
+    context 'with one file' do
+      let(:file_list) { [create(:work, :with_one_file, file_title: ['CSV Report 1'], resource_type: ['Image'], rights: ['mine'])] }
       let(:file_set)  { file_list[0].file_sets[0] }
       let(:work)      { file_set.parent }
-      it "can be parsed" do
+      it 'can be parsed' do
         parsed = CSV.parse(subject)
         expect(parsed.count).to eq 2
-        expect(parsed[0]).to eq(["Work Url", "Work Id", "Work Title", "Work Resource Type", "Work Rights", "File Set Url", "File Set Time Uploaded", "File Set Id", "File Set Title", "File Set Depositor", "File Set Creator", "File Set Visibility", "File Set File Format"])
-        expect(parsed[1]).to eq(["http://test.com/concern/generic_works/#{work.id}", work.id, "Sample Title", "Image", "mine", "http://test.com/concern/file_sets/#{file_set.id}", "", file_set.id, "CSV Report 1", file_set.depositor, "", "restricted", ""])
+        expect(parsed[0]).to eq(['Work Url', 'Work Id', 'Work Title', 'Work Resource Type', 'Work Rights', 'File Set Url', 'File Set Time Uploaded', 'File Set Id', 'File Set Title', 'File Set Depositor', 'File Set Creator', 'File Set Visibility', 'File Set File Format'])
+        expect(parsed[1]).to eq(["http://test.com/concern/generic_works/#{work.id}", work.id, 'Sample Title', 'Image', 'mine', "http://test.com/concern/file_sets/#{file_set.id}", '', file_set.id, 'CSV Report 1', file_set.depositor, '', 'restricted', ''])
       end
     end
 
-    context "with multiple files" do
+    context 'with multiple files' do
       let(:file_list) do
         [
-          create(:work, :with_one_file, file_title: ["CSV Multifile-Report 1"]),
-          create(:work, :with_one_file, file_title: ["CSV Multifile-Report 2"]),
-          create(:work, :with_one_file, file_title: ["CSV Multifile-Report 3"])
+          create(:work, :with_one_file, file_title: ['CSV Multifile-Report 1']),
+          create(:work, :with_one_file, file_title: ['CSV Multifile-Report 2']),
+          create(:work, :with_one_file, file_title: ['CSV Multifile-Report 3'])
         ]
       end
-      it { is_expected.to include("CSV Multifile-Report 1", "CSV Multifile-Report 2", "CSV Multifile-Report 3") }
-      it "can be parsed" do
+      it { is_expected.to include('CSV Multifile-Report 1', 'CSV Multifile-Report 2', 'CSV Multifile-Report 3') }
+      it 'can be parsed' do
         parsed = CSV.parse(subject)
         expect(parsed.count).to eq 4
-        expect(parsed[0]).to eq(["Work Url", "Work Id", "Work Title", "Work Resource Type", "Work Rights", "File Set Url", "File Set Time Uploaded", "File Set Id", "File Set Title", "File Set Depositor", "File Set Creator", "File Set Visibility", "File Set File Format"])
-        expect(parsed[1]).to include("CSV Multifile-Report 1")
-        expect(parsed[2]).to include("CSV Multifile-Report 2")
-        expect(parsed[3]).to include("CSV Multifile-Report 3")
+        expect(parsed[0]).to eq(['Work Url', 'Work Id', 'Work Title', 'Work Resource Type', 'Work Rights', 'File Set Url', 'File Set Time Uploaded', 'File Set Id', 'File Set Title', 'File Set Depositor', 'File Set Creator', 'File Set Visibility', 'File Set File Format'])
+        expect(parsed[1]).to include('CSV Multifile-Report 1')
+        expect(parsed[2]).to include('CSV Multifile-Report 2')
+        expect(parsed[3]).to include('CSV Multifile-Report 3')
       end
     end
   end

--- a/spec/services/generic_work_to_share_json_service_spec.rb
+++ b/spec/services/generic_work_to_share_json_service_spec.rb
@@ -4,21 +4,21 @@ require 'rails_helper'
 describe GenericWorkToShareJSONService do
   let(:name_service) { double }
   before do
-    allow_any_instance_of(GenericWork).to receive(:current_host).and_return("https://scholarsphere.psu.edu")
+    allow_any_instance_of(GenericWork).to receive(:current_host).and_return('https://scholarsphere.psu.edu')
     allow(NameDisambiguationService).to receive(:new).with(creator).and_return(name_service)
   end
-  context "when checking the fixture file" do
-    let(:file) { build(:file, id: "x346f017s", title: ["Set9 ShamR 1.tif"], creator: ["Santy, Lorraine C"], date_modified: DateTime.parse("2015-07-30T20:15:08.528+00:00")) }
+  context 'when checking the fixture file' do
+    let(:file) { build(:file, id: 'x346f017s', title: ['Set9 ShamR 1.tif'], creator: ['Santy, Lorraine C'], date_modified: DateTime.parse('2015-07-30T20:15:08.528+00:00')) }
     let(:json) { JSON.parse(File.open(fixture_path + '/ss-share.json', 'rb').read) }
     let(:creator) { 'Santy, Lorraine C' }
-    it "generates valid json" do
-      pending("See issue #277")
-      expect(name_service).to receive(:disambiguate).and_return([{ email: "lcs13@psu.edu" }])
+    it 'generates valid json' do
+      pending('See issue #277')
+      expect(name_service).to receive(:disambiguate).and_return([{ email: 'lcs13@psu.edu' }])
       expect(JSON.parse(described_class.new(file).json)).to eq(json)
     end
   end
 
-  context "when checking any file" do
+  context 'when checking any file' do
     let(:json_template) do
       "{
         \"jsonData\": {
@@ -37,38 +37,38 @@ describe GenericWorkToShareJSONService do
     end
     let(:json)    { JSON.parse(json_template) }
     let(:file)    { build(:file, id: id, title: [title], creator: [creator], date_modified: DateTime.parse(date_uploaded)) }
-    let(:title)   { "abc123" }
+    let(:title)   { 'abc123' }
     let(:id) { 'zzzzz' }
-    let(:date_uploaded) { "2015-07-30T20:15:08Z" }
+    let(:date_uploaded) { '2015-07-30T20:15:08Z' }
     subject { JSON.parse(described_class.new(file).json) }
 
-    context "when the creator exists in ldap" do
+    context 'when the creator exists in ldap' do
       let(:creator) { ' Cole, Carolyn Ann' }
       let(:creator_email) { 'cam156@psu.edu' }
-      it "formats the json" do
-        pending("See issue #277")
+      it 'formats the json' do
+        pending('See issue #277')
         expect(name_service).to receive(:disambiguate).and_return([{ email: creator_email }])
         is_expected.to eq(json)
       end
     end
 
-    context "when the creator does not exist in ldap" do
+    context 'when the creator does not exist in ldap' do
       let(:creator) { ' Frog, Kermit The' }
       let(:creator_email) {}
-      it "formats the json" do
-        pending("See issue #277")
+      it 'formats the json' do
+        pending('See issue #277')
         expect(name_service).to receive(:disambiguate).and_return([])
         is_expected.to eq(json)
       end
     end
 
-    context "when deleting the file" do
+    context 'when deleting the file' do
       let(:creator) { 'Guy, Bad' }
       let(:creator_email) { 'badguy@trouble.com' }
       before { allow(name_service).to receive(:disambiguate).and_return([{ email: creator_email }]) }
       subject { JSON.parse(described_class.new(file, delete: true).json) }
-      it "adds a delete property" do
-        expect(subject["jsonData"]["otherProperties"]).to eq([{ "name" => "status", "properties" => { "status" => ["deleted"] } }])
+      it 'adds a delete property' do
+        expect(subject['jsonData']['otherProperties']).to eq([{ 'name' => 'status', 'properties' => { 'status' => ['deleted'] } }])
       end
     end
   end

--- a/spec/services/lock_manager_spec.rb
+++ b/spec/services/lock_manager_spec.rb
@@ -6,8 +6,8 @@ describe CurationConcerns::LockManager do
   subject { described_class.new(CurationConcerns.config.lock_time_to_live,
                                 CurationConcerns.config.lock_retry_count,
                                 CurationConcerns.config.lock_retry_delay) }
-  describe "lock", unless: travis? do
-    it "calls the block" do
+  describe 'lock', unless: travis? do
+    it 'calls the block' do
       expect { |probe| subject.lock('foobar', &probe) }.to yield_with_no_args
     end
   end

--- a/spec/services/name_disabiguation_service_spec.rb
+++ b/spec/services/name_disabiguation_service_spec.rb
@@ -4,102 +4,102 @@ require 'rails_helper'
 describe NameDisambiguationService, unless: travis? do
   subject { described_class.new(name).disambiguate }
 
-  context "when we have a normal name" do
-    let(:name) { "Thompson, Britta M" }
-    it "finds the user" do
-      expect(subject).to eq([{ id: "bmt13", given_name: "BRITTA MAY", surname: "THOMPSON", email: "bmt13@psu.edu", affiliation: ["FACULTY"], displayname: "BRITTA MAY THOMPSON" }])
+  context 'when we have a normal name' do
+    let(:name) { 'Thompson, Britta M' }
+    it 'finds the user' do
+      expect(subject).to eq([{ id: 'bmt13', given_name: 'BRITTA MAY', surname: 'THOMPSON', email: 'bmt13@psu.edu', affiliation: ['FACULTY'], displayname: 'BRITTA MAY THOMPSON' }])
     end
   end
 
-  context "when we have an id" do
-    let(:name) { "cam156" }
-    it "finds the ids" do
-      expect(subject).to eq([{ id: "cam156", given_name: "CAROLYN ANN", surname: "COLE", email: "cam156@psu.edu", affiliation: ["STAFF"], displayname: "CAROLYN ANN COLE" }])
+  context 'when we have an id' do
+    let(:name) { 'cam156' }
+    it 'finds the ids' do
+      expect(subject).to eq([{ id: 'cam156', given_name: 'CAROLYN ANN', surname: 'COLE', email: 'cam156@psu.edu', affiliation: ['STAFF'], displayname: 'CAROLYN ANN COLE' }])
     end
   end
 
-  context "when we have multiple combined with an and" do
-    let(:name) { "Carolyn Cole and Adam Wead" }
-    it "finds both users" do
-      is_expected.to eq([{ id: "cam156", given_name: "CAROLYN ANN", surname: "COLE", email: "cam156@psu.edu", affiliation: ["STAFF"], displayname: "CAROLYN ANN COLE" },
-                         { id: "agw13", given_name: "ADAM GARNER", surname: "WEAD", email: "agw13@psu.edu", affiliation: ["STAFF"], displayname: "ADAM GARNER WEAD" }])
+  context 'when we have multiple combined with an and' do
+    let(:name) { 'Carolyn Cole and Adam Wead' }
+    it 'finds both users' do
+      is_expected.to eq([{ id: 'cam156', given_name: 'CAROLYN ANN', surname: 'COLE', email: 'cam156@psu.edu', affiliation: ['STAFF'], displayname: 'CAROLYN ANN COLE' },
+                         { id: 'agw13', given_name: 'ADAM GARNER', surname: 'WEAD', email: 'agw13@psu.edu', affiliation: ['STAFF'], displayname: 'ADAM GARNER WEAD' }])
     end
   end
 
-  context "when we have initials for first name" do
-    let(:name) { "K.B. Baker" }
-    it "finds the user" do
-      is_expected.to eq([{ id: "kbb2", given_name: "KURT BRADLEY", surname: "BAKER", email: "kbb2@psu.edu", affiliation: ["RETIREE"], displayname: "KURT BRADLEY BAKER" }])
+  context 'when we have initials for first name' do
+    let(:name) { 'K.B. Baker' }
+    it 'finds the user' do
+      is_expected.to eq([{ id: 'kbb2', given_name: 'KURT BRADLEY', surname: 'BAKER', email: 'kbb2@psu.edu', affiliation: ['RETIREE'], displayname: 'KURT BRADLEY BAKER' }])
     end
   end
 
-  context "when we have multiple results" do
-    let(:name) { "Jane Doe" }
-    it "finds the user" do
+  context 'when we have multiple results' do
+    let(:name) { 'Jane Doe' }
+    it 'finds the user' do
       is_expected.to eq([])
     end
   end
 
-  context "when the user has many titles" do
-    let(:name) { "Nicole Seger, MSN, RN, CPN" }
-    it "finds the user" do
-      is_expected.to eq([{ id: "nas150", given_name: "NICOLE A", surname: "SEGER", email: "nas150@psu.edu", affiliation: ["STAFF"], displayname: "NICOLE A SEGER" }])
+  context 'when the user has many titles' do
+    let(:name) { 'Nicole Seger, MSN, RN, CPN' }
+    it 'finds the user' do
+      is_expected.to eq([{ id: 'nas150', given_name: 'NICOLE A', surname: 'SEGER', email: 'nas150@psu.edu', affiliation: ['STAFF'], displayname: 'NICOLE A SEGER' }])
     end
   end
 
-  context "when the user has a title first" do
-    let(:name) { "MSN Deb Cardenas" }
-    it "finds the user" do
-      is_expected.to eq([{ id: "dac40", given_name: "DEBORAH A.", surname: "CARDENAS", email: "dac40@psu.edu", affiliation: ["STAFF"], displayname: "DEBORAH A. CARDENAS" }])
+  context 'when the user has a title first' do
+    let(:name) { 'MSN Deb Cardenas' }
+    it 'finds the user' do
+      is_expected.to eq([{ id: 'dac40', given_name: 'DEBORAH A.', surname: 'CARDENAS', email: 'dac40@psu.edu', affiliation: ['STAFF'], displayname: 'DEBORAH A. CARDENAS' }])
     end
   end
 
-  context "when the user has strange characters" do
-    let(:name) { "Patricia Hswe *" }
-    it "cleans the name" do
-      is_expected.to eq([{ id: "pmh22", given_name: "PATRICIA M", surname: "HSWE", email: "pmh22@psu.edu", affiliation: ["MEMBER"], displayname: "PATRICIA M HSWE" }])
+  context 'when the user has strange characters' do
+    let(:name) { 'Patricia Hswe *' }
+    it 'cleans the name' do
+      is_expected.to eq([{ id: 'pmh22', given_name: 'PATRICIA M', surname: 'HSWE', email: 'pmh22@psu.edu', affiliation: ['MEMBER'], displayname: 'PATRICIA M HSWE' }])
     end
   end
 
-  context "when the user has an apostrophy" do
+  context 'when the user has an apostrophy' do
     let(:name) { "Anthony R. D'Augelli" }
-    it "finds the user" do
-      is_expected.to eq([{ id: "ard", given_name: "ANTHONY RAYMOND", surname: "D'AUGELLI", email: "ard@psu.edu", affiliation: ["FACULTY"], displayname: "ANTHONY RAYMOND D'AUGELLI" }])
+    it 'finds the user' do
+      is_expected.to eq([{ id: 'ard', given_name: 'ANTHONY RAYMOND', surname: "D'AUGELLI", email: 'ard@psu.edu', affiliation: ['FACULTY'], displayname: "ANTHONY RAYMOND D'AUGELLI" }])
     end
   end
 
-  context "when the user has many names" do
-    let(:name) { "ALIDA HEATHER DOHN ROSS" }
-    it "finds the user" do
-      is_expected.to eq([{ id: "hdr10", given_name: "ALIDA HEATHER", surname: "DOHN ROSS", email: "hdr10@psu.edu", affiliation: ["STAFF"], displayname: "ALIDA HEATHER DOHN ROSS" }])
+  context 'when the user has many names' do
+    let(:name) { 'ALIDA HEATHER DOHN ROSS' }
+    it 'finds the user' do
+      is_expected.to eq([{ id: 'hdr10', given_name: 'ALIDA HEATHER', surname: 'DOHN ROSS', email: 'hdr10@psu.edu', affiliation: ['STAFF'], displayname: 'ALIDA HEATHER DOHN ROSS' }])
     end
   end
 
-  context "when the user has additional information" do
-    let(:name) { "Cole, Carolyn (Kubicki Group)" }
-    it "cleans the name" do
-      is_expected.to eq([{ id: "cam156", given_name: "CAROLYN ANN", surname: "COLE", email: "cam156@psu.edu", affiliation: ["STAFF"], displayname: "CAROLYN ANN COLE" }])
+  context 'when the user has additional information' do
+    let(:name) { 'Cole, Carolyn (Kubicki Group)' }
+    it 'cleans the name' do
+      is_expected.to eq([{ id: 'cam156', given_name: 'CAROLYN ANN', surname: 'COLE', email: 'cam156@psu.edu', affiliation: ['STAFF'], displayname: 'CAROLYN ANN COLE' }])
     end
   end
 
-  context "when the user has an email in thier name" do
-    context "when the email is not their id" do
-      let(:name) { "Barbara I. Dewey a bdewey@psu.edu" }
-      it "does not find the user" do
-        is_expected.to eq([{ id: "bid1", given_name: "BARBARA IRENE", surname: "DEWEY", email: "bid1@psu.edu", affiliation: ["STAFF"], displayname: "BARBARA IRENE DEWEY" }])
+  context 'when the user has an email in thier name' do
+    context 'when the email is not their id' do
+      let(:name) { 'Barbara I. Dewey a bdewey@psu.edu' }
+      it 'does not find the user' do
+        is_expected.to eq([{ id: 'bid1', given_name: 'BARBARA IRENE', surname: 'DEWEY', email: 'bid1@psu.edu', affiliation: ['STAFF'], displayname: 'BARBARA IRENE DEWEY' }])
       end
     end
 
-    context "when the email is their id" do
-      let(:name) { "sjs230@psu.edu" }
-      it "finds the user" do
+    context 'when the email is their id' do
+      let(:name) { 'sjs230@psu.edu' }
+      it 'finds the user' do
         expect(subject.count).to eq(1)
       end
     end
 
-    context "when the email is their id" do
-      let(:name) { "sjs230@psu.edu, cam156@psu.edu" }
-      it "finds the user" do
+    context 'when the email is their id' do
+      let(:name) { 'sjs230@psu.edu, cam156@psu.edu' }
+      it 'finds the user' do
         expect(subject.count).to eq(2)
       end
     end

--- a/spec/services/permissions_change_service_spec.rb
+++ b/spec/services/permissions_change_service_spec.rb
@@ -4,11 +4,11 @@ require 'rails_helper'
 describe PermissionsChangeService do
   let(:user)            { double('stubbed user') }
   let(:batch_user)      { double('stubbed batch user') }
-  let(:message)         { "You can now edit file title" }
-  let(:message_subject) { "Permission change notification" }
-  let(:generic_work)    { double('stubbed file', id: "1234", title: "title") }
+  let(:message)         { 'You can now edit file title' }
+  let(:message_subject) { 'Permission change notification' }
+  let(:generic_work)    { double('stubbed file', id: '1234', title: 'title') }
   let(:state)           { double('subbed permission change set') }
-  let(:permissions)     { [{ name: "abd123", type: "person", access: "edit" }] }
+  let(:permissions)     { [{ name: 'abd123', type: 'person', access: 'edit' }] }
   let(:service) { described_class.new(state, generic_work) }
 
   before do
@@ -17,57 +17,57 @@ describe PermissionsChangeService do
     allow(service).to receive(:unshareable?).and_return(true)
   end
 
-  context "permissions no change" do
+  context 'permissions no change' do
     before { allow(state).to receive(:unchanged?).and_return(true) }
-    it "notifies no one" do
+    it 'notifies no one' do
       expect(batch_user).not_to receive(:send_message)
       expect(service.call).to be_nil
     end
   end
-  context "permissions added" do
+  context 'permissions added' do
     before do
       allow(state).to receive(:unchanged?).and_return(false)
       allow(state).to receive(:added).and_return(permissions)
     end
-    it "notifies one user added" do
+    it 'notifies one user added' do
       expect(batch_user).to receive(:send_message).with(user, message, message_subject)
       expect(service.call).to be_nil
     end
   end
-  context "permissions removed" do
+  context 'permissions removed' do
     before do
       allow(state).to receive(:unchanged?).and_return(false)
       allow(state).to receive(:added).and_return([])
     end
-    it "notifies no one" do
+    it 'notifies no one' do
       expect(batch_user).not_to receive(:send_message)
       expect(service.call).to be_nil
     end
   end
 
-  context "with SHARE Notify" do
+  context 'with SHARE Notify' do
     before do
       allow(service).to receive(:unshareable?).and_return(false)
       allow(state).to receive(:unchanged?).and_return(false)
       allow(state).to receive(:added).and_return([])
     end
-    context "if the file has been privatized" do
+    context 'if the file has been privatized' do
       before do
         allow(state).to receive(:privatized?).and_return(true)
         allow(state).to receive(:publicized?).and_return(false)
       end
-      it "deletes the file from SHARE" do
+      it 'deletes the file from SHARE' do
         expect(ShareNotifyDeleteJob).to receive(:perform_later)
         expect(ShareNotifyJob).not_to receive(:perform_later)
         expect(service.call).to be_nil
       end
     end
-    context "if the file has been publicized" do
+    context 'if the file has been publicized' do
       before do
         allow(state).to receive(:privatized?).and_return(false)
         allow(state).to receive(:publicized?).and_return(true)
       end
-      it "sends the file to SHARE" do
+      it 'sends the file to SHARE' do
         expect(ShareNotifyDeleteJob).not_to receive(:perform_later)
         expect(ShareNotifyJob).to receive(:perform_later)
         expect(service.call).to be_nil

--- a/spec/services/read_only_spec.rb
+++ b/spec/services/read_only_spec.rb
@@ -3,23 +3,23 @@
 require 'rails_helper'
 
 describe ReadOnly do
-  describe "#read_only?" do
+  describe '#read_only?' do
     subject { described_class.read_only? }
-    context "configuration not set" do
+    context 'configuration not set' do
       before do
         allow(ScholarSphere::Application.config).to receive(:respond_to?).with(:read_only).and_return(false)
       end
       it { is_expected.to be_falsey }
     end
 
-    context "read only flag false" do
+    context 'read only flag false' do
       before do
         allow(ScholarSphere::Application.config).to receive(:read_only).and_return(false)
       end
       it { is_expected.to be_falsey }
     end
 
-    context "read only flag true" do
+    context 'read only flag true' do
       before do
         allow(ScholarSphere::Application.config).to receive(:read_only).and_return(true)
       end
@@ -41,18 +41,18 @@ describe ReadOnly do
     end
   end
 
-  describe "#announcement_text" do
+  describe '#announcement_text' do
     subject { described_class.announcement_text }
     before do
       allow(ContentBlock).to receive(:find_by).and_return(content_block)
     end
 
-    context "no homepage announcement" do
+    context 'no homepage announcement' do
       let(:content_block) { instance_double ContentBlock, value: '' }
-      it { is_expected.to eq("The system is currently in read only mode for maintenance. Please try again later to upload or modify your ScholarSphere content.") }
+      it { is_expected.to eq('The system is currently in read only mode for maintenance. Please try again later to upload or modify your ScholarSphere content.') }
     end
 
-    context "homepage announcement" do
+    context 'homepage announcement' do
       let(:content_block) { instance_double ContentBlock, value: 'Announcment' }
       it { is_expected.to eq('Announcment') }
     end

--- a/spec/services/solr_document_groomer_spec.rb
+++ b/spec/services/solr_document_groomer_spec.rb
@@ -2,20 +2,20 @@
 require 'rails_helper'
 
 describe SolrDocumentGroomer do
-  let(:work)     { create(:work, creator: ["I AM LEGEND", "Will I. Am,"], keyword: ["CAPITAL", "Title."]) }
+  let(:work)     { create(:work, creator: ['I AM LEGEND', 'Will I. Am,'], keyword: ['CAPITAL', 'Title.']) }
   let(:document) { SolrDocument.new(work.to_solr) }
 
-  describe "#groom" do
+  describe '#groom' do
     before { described_class.call(document) }
 
-    context "with normalized fields" do
-      subject { document.fetch("creator_sim") }
-      it { is_expected.to contain_exactly("I Am Legend", "Will I Am") }
+    context 'with normalized fields' do
+      subject { document.fetch('creator_sim') }
+      it { is_expected.to contain_exactly('I Am Legend', 'Will I Am') }
     end
 
-    context "with downcased fields" do
-      subject { document.fetch("keyword_sim") }
-      it { is_expected.to contain_exactly("capital", "title") }
+    context 'with downcased fields' do
+      subject { document.fetch('keyword_sim') }
+      it { is_expected.to contain_exactly('capital', 'title') }
     end
   end
 end

--- a/spec/services/sufia/change_content_depositor_service_spec.rb
+++ b/spec/services/sufia/change_content_depositor_service_spec.rb
@@ -12,41 +12,41 @@ describe Sufia::ChangeContentDepositorService do
     described_class.call(work, receiver, reset)
   end
 
-  context "by default, when permissions are not reset" do
+  context 'by default, when permissions are not reset' do
     let(:reset) { false }
 
-    it "changes the depositor and records an original depositor" do
+    it 'changes the depositor and records an original depositor' do
       work.reload
       expect(work.depositor).to eq receiver.user_key
       expect(work.proxy_depositor).to eq depositor.user_key
       expect(work.edit_users).to include(receiver.user_key, depositor.user_key)
-      expect(work.visibility).to eq("open")
+      expect(work.visibility).to eq('open')
     end
 
-    it "changes the depositor of the child file sets" do
+    it 'changes the depositor of the child file sets' do
       file.reload
       expect(file.depositor).to eq receiver.user_key
       expect(file.edit_users).to include(receiver.user_key, depositor.user_key)
-      expect(file.visibility).to eq("open")
+      expect(file.visibility).to eq('open')
     end
   end
 
-  context "when permissions are reset" do
+  context 'when permissions are reset' do
     let(:reset) { true }
 
-    it "excludes the depositor from the edit users" do
+    it 'excludes the depositor from the edit users' do
       work.reload
       expect(work.depositor).to eq receiver.user_key
       expect(work.proxy_depositor).to eq depositor.user_key
       expect(work.edit_users).to contain_exactly(receiver.user_key)
-      expect(work.visibility).to eq("restricted")
+      expect(work.visibility).to eq('restricted')
     end
 
-    it "changes the depositor of the child file sets" do
+    it 'changes the depositor of the child file sets' do
       file.reload
       expect(file.depositor).to eq receiver.user_key
       expect(file.edit_users).to contain_exactly(receiver.user_key)
-      expect(file.visibility).to eq("restricted")
+      expect(file.visibility).to eq('restricted')
     end
   end
 end

--- a/spec/services/zotero_subscription_spec.rb
+++ b/spec/services/zotero_subscription_spec.rb
@@ -8,8 +8,8 @@ describe ZoteroSubscription do
     create(:user, login: 'def333', zotero_userid: 'def', arkivo_token: 'def333', arkivo_subscription: 'subscribed')
   end
   let(:job) { double }
-  describe "#call" do
-    it "Creates a subscription job for users with no subscription" do
+  describe '#call' do
+    it 'Creates a subscription job for users with no subscription' do
       expect(Sufia::Arkivo::CreateSubscriptionJob).to receive(:new).with('abc111').and_return(job)
       expect(Sufia::Arkivo::CreateSubscriptionJob).not_to receive(:new).with('def333')
       expect(Sufia::Arkivo::CreateSubscriptionJob).not_to receive(:new).with('zzz')

--- a/spec/support/helpers/generic_works.rb
+++ b/spec/support/helpers/generic_works.rb
@@ -7,7 +7,7 @@ module GenericWorksHelper
   end
 
   def find_work_by_title(title)
-    GenericWork.where(Solrizer.solr_name("title", :stored_searchable, type: :string) => title).first
+    GenericWork.where(Solrizer.solr_name('title', :stored_searchable, type: :string) => title).first
   end
 end
 

--- a/spec/support/helpers/locations.rb
+++ b/spec/support/helpers/locations.rb
@@ -8,7 +8,7 @@ module Locations
 
   def go_to_dashboard_works
     visit '/dashboard/works'
-    expect(page).to have_selector('li.active', text: "My Works")
+    expect(page).to have_selector('li.active', text: 'My Works')
   end
 
   def go_to_dashboard_collections

--- a/spec/support/helpers/proxies.rb
+++ b/spec/support/helpers/proxies.rb
@@ -5,10 +5,10 @@ module ProxiesHelper
       expect(User).to receive(:query_ldap_by_name_or_id).and_return([{ id: user.user_key, text: "#{user.display_name} (#{user.user_key})" }])
 
       first('a.select2-choice').click
-      find(".select2-input").set(user.user_key)
+      find('.select2-input').set(user.user_key)
       expect(page).to have_css('div.select2-result-label')
       first('div.select2-result-label').click
-      within("#authorizedProxies") do
+      within('#authorizedProxies') do
         expect(page).to have_content(user.display_name)
       end
     end

--- a/spec/support/helpers/solr.rb
+++ b/spec/support/helpers/solr.rb
@@ -5,7 +5,7 @@ module SolrHelper
   end
 
   def contributor_facet
-    Solrizer.solr_name("contributor", :facetable)
+    Solrizer.solr_name('contributor', :facetable)
   end
 
   def index_work(object)

--- a/spec/support/shared/forms.rb
+++ b/spec/support/shared/forms.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
-shared_examples "a standard work form" do
-  describe "#visibility" do
+shared_examples 'a standard work form' do
+  describe '#visibility' do
     subject { form }
-    context "with a new work" do
-      its(:visibility) { is_expected.to eq("open") }
+    context 'with a new work' do
+      its(:visibility) { is_expected.to eq('open') }
     end
   end
 end

--- a/spec/support/user_no_ldap.rb
+++ b/spec/support/user_no_ldap.rb
@@ -5,6 +5,6 @@ require 'active_fedora/cleaner'
 RSpec.configure do |config|
   config.before(:each) do
     allow(Hydra::LDAP).to receive(:groups_for_user).and_return([])
-    allow(Hydra::LDAP.connection).to receive(:get_operation_result).and_return(OpenStruct.new(code: 0, message: "Success"))
+    allow(Hydra::LDAP.connection).to receive(:get_operation_result).and_return(OpenStruct.new(code: 0, message: 'Success'))
   end unless :need_ldap
 end

--- a/spec/views/admin/_export_link.html.erb_spec.rb
+++ b/spec/views/admin/_export_link.html.erb_spec.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-describe "admin/stats/_export_link.html.erb" do
-  let(:href) { "/admin/stats/export" }
+describe 'admin/stats/_export_link.html.erb' do
+  let(:href) { '/admin/stats/export' }
 
   before do
     render
   end
 
-  it "creates and export link" do
-    expect(rendered).to have_link("Export File Metadata", href: href)
+  it 'creates and export link' do
+    expect(rendered).to have_link('Export File Metadata', href: href)
   end
 end

--- a/spec/views/collections/_form_permission.html.erb_spec.rb
+++ b/spec/views/collections/_form_permission.html.erb_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-describe "collections/_form_permission.html.erb" do
+describe 'collections/_form_permission.html.erb' do
   let(:collection) { build(:collection) }
   let(:form) { CollectionForm.new(collection, Ability.new(nil), double) }
 
@@ -14,7 +14,7 @@ describe "collections/_form_permission.html.erb" do
 
   before { assign(:collection, collection) }
 
-  it "omits the private visibility option" do
-    expect(page).to have_no_checked_field("Private")
+  it 'omits the private visibility option' do
+    expect(page).to have_no_checked_field('Private')
   end
 end

--- a/spec/views/collections/_sort_and_per_page.html.erb_spec.rb
+++ b/spec/views/collections/_sort_and_per_page.html.erb_spec.rb
@@ -1,27 +1,27 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-describe "collections/_sort_and_per_page.html.erb" do
-  let(:collection) { build(:collection, id: "coll1") }
+describe 'collections/_sort_and_per_page.html.erb' do
+  let(:collection) { build(:collection, id: 'coll1') }
   let(:page)       { Capybara::Node::Simple.new(rendered) }
 
   before do
     assign(:response, solr_response)
-    allow(controller).to receive(:params).and_return(action: "edit")
-    render "collections/sort_and_per_page", collection: collection
+    allow(controller).to receive(:params).and_return(action: 'edit')
+    render 'collections/sort_and_per_page', collection: collection
   end
 
-  context "when the collection has only one work" do
+  context 'when the collection has only one work' do
     let(:solr_response) { Blacklight::Solr::Response.new({ response: { numFound: 1 } }, nil) }
-    it "renders the button for removing the item from the collection" do
-      expect(page.find(".collection-remove-selected").value).to eq("Remove From Collection")
+    it 'renders the button for removing the item from the collection' do
+      expect(page.find('.collection-remove-selected').value).to eq('Remove From Collection')
     end
   end
 
-  context "when the collection has no works" do
+  context 'when the collection has no works' do
     let(:solr_response) { Blacklight::Solr::Response.new({ response: { numFound: 0 } }, nil) }
-    it "does not render the button for removing the item from the collection" do
-      expect(page).not_to have_selector(".collection-remove-selected")
+    it 'does not render the button for removing the item from the collection' do
+      expect(page).not_to have_selector('.collection-remove-selected')
     end
   end
 end

--- a/spec/views/curations_concerns/base/_form.html.erb_spec.rb
+++ b/spec/views/curations_concerns/base/_form.html.erb_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-describe "curation_concerns/base/_form.html.erb" do
+describe 'curation_concerns/base/_form.html.erb' do
   include Devise::Test::ControllerHelpers
 
   let(:form) { CurationConcerns::GenericWorkForm.new(GenericWork.new, Ability.new(nil)) }
@@ -9,24 +9,24 @@ describe "curation_concerns/base/_form.html.erb" do
   before do
     assign(:form, form)
     allow(controller).to receive(:params).and_return(params)
-    stub_template "_form_files.html.erb" => ""
-    stub_template "_form_metadata.html.erb" => ""
-    stub_template "_form_relationships.html.erb" => ""
-    stub_template "_form_share.html.erb" => ""
-    stub_template "_form_progress.html.erb" => ""
-    render "curation_concerns/base/form.html.erb"
+    stub_template '_form_files.html.erb' => ''
+    stub_template '_form_metadata.html.erb' => ''
+    stub_template '_form_relationships.html.erb' => ''
+    stub_template '_form_share.html.erb' => ''
+    stub_template '_form_progress.html.erb' => ''
+    render 'curation_concerns/base/form.html.erb'
   end
 
-  describe "rendering the link that switches to the batch create page" do
+  describe 'rendering the link that switches to the batch create page' do
     subject { rendered }
 
-    context "without no collection id parameters" do
+    context 'without no collection id parameters' do
       let(:params) { {} }
       it { is_expected.to include('href="/batch_uploads/new"') }
     end
 
-    context "with collection ids" do
-      let(:params) { { collection_ids: ["collection-id"] } }
+    context 'with collection ids' do
+      let(:params) { { collection_ids: ['collection-id'] } }
       it { is_expected.to include('href="/batch_uploads/new?collection_ids%5B%5D=collection-id"') }
     end
   end

--- a/spec/views/curations_concerns/base/_form_files.html.erb_spec.rb
+++ b/spec/views/curations_concerns/base/_form_files.html.erb_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-describe "curation_concerns/base/_form_files.html.erb" do
+describe 'curation_concerns/base/_form_files.html.erb' do
   let(:user)      { create(:user) }
   let(:work)      { create(:work, depositor: user.login) }
   let(:ability)   { Ability.new(user) }
@@ -15,24 +15,24 @@ describe "curation_concerns/base/_form_files.html.erb" do
     end
   end
 
-  it "displays informative and accessible elements" do
-    expect(page).to have_selector("h2", text: "Add Local Files")
-    expect(page).to have_selector("h2", text: "Add Files from the Cloud")
-    expect(page).to have_selector("h2", text: "Files Available for Upload")
-    expect(page).to have_selector("caption", text: "Listing of files ready to be uploaded")
-    expect(all_label).to eq("Upload all local files from the listing of files")
-    expect(page).to have_selector("button.all", visible: false)
+  it 'displays informative and accessible elements' do
+    expect(page).to have_selector('h2', text: 'Add Local Files')
+    expect(page).to have_selector('h2', text: 'Add Files from the Cloud')
+    expect(page).to have_selector('h2', text: 'Files Available for Upload')
+    expect(page).to have_selector('caption', text: 'Listing of files ready to be uploaded')
+    expect(all_label).to eq('Upload all local files from the listing of files')
+    expect(page).to have_selector('button.all', visible: false)
   end
 
-  describe "BrowseEverything button selector" do
-    subject { page.find("#browse-btn")["data-target"] }
-    context "#edit" do
+  describe 'BrowseEverything button selector' do
+    subject { page.find('#browse-btn')['data-target'] }
+    context '#edit' do
       it { is_expected.to eq("#edit_generic_work_#{work.id}") }
     end
 
-    context "#new" do
+    context '#new' do
       let(:work) { build(:work, depositor: user.login) }
-      it { is_expected.to eq("#new_generic_work") }
+      it { is_expected.to eq('#new_generic_work') }
     end
   end
 end

--- a/spec/views/curations_concerns/base/_form_permission.html.erb_spec.rb
+++ b/spec/views/curations_concerns/base/_form_permission.html.erb_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-describe "curation_concerns/base/_form_permission.html.erb" do
+describe 'curation_concerns/base/_form_permission.html.erb' do
   let(:work) { build(:work) }
   let(:form) { CurationConcerns::GenericWorkForm.new(work, Ability.new(nil)) }
 
@@ -12,7 +12,7 @@ describe "curation_concerns/base/_form_permission.html.erb" do
     Capybara::Node::Simple.new(rendered)
   }
 
-  it "omits the private visibility option" do
-    expect(page).to have_no_checked_field("Private")
+  it 'omits the private visibility option' do
+    expect(page).to have_no_checked_field('Private')
   end
 end

--- a/spec/views/curations_concerns/base/_form_progress.html.erb_spec.rb
+++ b/spec/views/curations_concerns/base/_form_progress.html.erb_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-describe "curation_concerns/base/_form_progress.html.erb" do
+describe 'curation_concerns/base/_form_progress.html.erb' do
   let(:work)  { build(:work) }
   let(:proxy) { create(:first_proxy) }
   let(:form)  { CurationConcerns::GenericWorkForm.new(work, Ability.new(user)) }
@@ -15,29 +15,29 @@ describe "curation_concerns/base/_form_progress.html.erb" do
     Capybara::Node::Simple.new(rendered)
   end
 
-  describe "#edit" do
-    before { allow(controller).to receive(:action_name).and_return("edit") }
-    context "when the user is a proxy" do
+  describe '#edit' do
+    before { allow(controller).to receive(:action_name).and_return('edit') }
+    context 'when the user is a proxy' do
       let(:user) { create(:user, :with_proxy, proxy_for: proxy) }
-      it { is_expected.not_to have_selector("#generic_work_on_behalf_of") }
+      it { is_expected.not_to have_selector('#generic_work_on_behalf_of') }
     end
 
-    context "when the user is not a proxy" do
+    context 'when the user is not a proxy' do
       let(:user) { create(:user) }
-      it { is_expected.not_to have_selector("#generic_work_on_behalf_of") }
+      it { is_expected.not_to have_selector('#generic_work_on_behalf_of') }
     end
   end
 
-  describe "#create" do
-    before { allow(controller).to receive(:action_name).and_return("new") }
-    context "when the user is a proxy" do
+  describe '#create' do
+    before { allow(controller).to receive(:action_name).and_return('new') }
+    context 'when the user is a proxy' do
       let(:user) { create(:user, :with_proxy, proxy_for: proxy) }
-      it { is_expected.to have_selector("#generic_work_on_behalf_of") }
+      it { is_expected.to have_selector('#generic_work_on_behalf_of') }
     end
 
-    context "when the user is not a proxy" do
+    context 'when the user is not a proxy' do
       let(:user) { create(:user) }
-      it { is_expected.not_to have_selector("#generic_work_on_behalf_of") }
+      it { is_expected.not_to have_selector('#generic_work_on_behalf_of') }
     end
   end
 end

--- a/spec/views/curations_concerns/base/_form_relationships.html.erb_spec.rb
+++ b/spec/views/curations_concerns/base/_form_relationships.html.erb_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe "curation_concerns/base/_form_relationships.html.erb" do
+describe 'curation_concerns/base/_form_relationships.html.erb' do
   let(:work) { build(:work) }
   let(:collection) { build :collection, id: 'collection_id' }
   let(:collection2) { build :collection, id: 'collection_id2' }
@@ -18,27 +18,27 @@ describe "curation_concerns/base/_form_relationships.html.erb" do
     allow(view).to receive(:available_collections).and_return([collection, collection2])
   end
 
-  it "lists the available collections" do
+  it 'lists the available collections' do
     expect(page).to have_content(collection.title)
     expect(page).to have_content(collection2.title)
-    expect(page.find_by_id("generic_work_collection_ids").value).to eq([])
+    expect(page.find_by_id('generic_work_collection_ids').value).to eq([])
   end
 
-  context "when the work is a member of the collection" do
+  context 'when the work is a member of the collection' do
     before do
       allow(form).to receive(:collection_ids).and_return([collection.id])
     end
-    it "lists the collection as selected" do
-      expect(page.find_by_id("generic_work_collection_ids").value).to eq(["collection_id"])
+    it 'lists the collection as selected' do
+      expect(page.find_by_id('generic_work_collection_ids').value).to eq(['collection_id'])
     end
   end
 
-  context "when collection is passed as a parameter" do
+  context 'when collection is passed as a parameter' do
     before do
       allow(view).to receive(:params).and_return(collection_ids: [collection.id])
     end
-    it "lists the collection as selected" do
-      expect(page.find_by_id("generic_work_collection_ids").value).to eq(["collection_id"])
+    it 'lists the collection as selected' do
+      expect(page.find_by_id('generic_work_collection_ids').value).to eq(['collection_id'])
     end
   end
 end

--- a/spec/views/curations_concerns/base/_form_visibility_component.html.erb_spec.rb
+++ b/spec/views/curations_concerns/base/_form_visibility_component.html.erb_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe "curation_concerns/base/_form_visibility_component.html.erb" do
+describe 'curation_concerns/base/_form_visibility_component.html.erb' do
   let(:work) { build(:work) }
   let(:form) { CurationConcerns::GenericWorkForm.new(work, Ability.new(nil)) }
 
@@ -13,11 +13,11 @@ describe "curation_concerns/base/_form_visibility_component.html.erb" do
     Capybara::Node::Simple.new(rendered)
   end
 
-  it "omits the private visibility option" do
-    expect(page).to have_no_checked_field("Private")
+  it 'omits the private visibility option' do
+    expect(page).to have_no_checked_field('Private')
   end
 
-  it "has an embargo date" do
-    expect(page.find("#generic_work_embargo_release_date").value).to eq((Date.tomorrow + 2.years).to_s)
+  it 'has an embargo date' do
+    expect(page.find('#generic_work_embargo_release_date').value).to eq((Date.tomorrow + 2.years).to_s)
   end
 end

--- a/spec/views/curations_concerns/base/_items.html.erb_spec.rb
+++ b/spec/views/curations_concerns/base/_items.html.erb_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-describe "curation_concerns/base/_items.html.erb", verify_partial_doubles: false do
+describe 'curation_concerns/base/_items.html.erb', verify_partial_doubles: false do
   let(:user)        { create(:user) }
-  let(:solr_doc)    { SolrDocument.new(build(:work, id: "1234").to_solr) }
+  let(:solr_doc)    { SolrDocument.new(build(:work, id: '1234').to_solr) }
   let(:ability)     { Ability.new(user) }
   let(:presenter)   { WorkShowPresenter.new(solr_doc, ability) }
-  let(:queued_file) { QueuedFile.create(work_id: presenter.id, file_id: "1") }
+  let(:queued_file) { QueuedFile.create(work_id: presenter.id, file_id: '1') }
 
   subject { Capybara::Node::Simple.new(rendered) }
 
@@ -15,49 +15,49 @@ describe "curation_concerns/base/_items.html.erb", verify_partial_doubles: false
     allow(controller).to receive(:current_ability).and_return(ability)
   end
 
-  context "when the user has edit rights" do
+  context 'when the user has edit rights' do
     before { allow(ability).to receive(:can?).with(:edit, presenter.id).and_return(true) }
 
-    context "without files" do
-      context "without uploads" do
-        before { render "curation_concerns/base/items.html.erb", presenter: presenter }
-        it { is_expected.to have_content("This Work has no files associated with it.") }
+    context 'without files' do
+      context 'without uploads' do
+        before { render 'curation_concerns/base/items.html.erb', presenter: presenter }
+        it { is_expected.to have_content('This Work has no files associated with it.') }
       end
 
-      context "with uploads" do
+      context 'with uploads' do
         before do
           allow(presenter).to receive(:uploading?).and_return(true)
           allow(presenter).to receive(:queued_files).and_return([queued_file])
-          render "curation_concerns/base/items.html.erb", presenter: presenter
+          render 'curation_concerns/base/items.html.erb', presenter: presenter
         end
-        it { is_expected.to have_content("Uploading in progress") }
+        it { is_expected.to have_content('Uploading in progress') }
       end
     end
   end
 
-  context "when the user does not have edit rights" do
+  context 'when the user does not have edit rights' do
     before { allow(ability).to receive(:can?).with(:edit, presenter.id).and_return(false) }
 
-    context "without files" do
-      context "without uploads" do
-        before { render "curation_concerns/base/items.html.erb", presenter: presenter }
-        it { is_expected.not_to have_content("This Work has no files associated with it.") }
+    context 'without files' do
+      context 'without uploads' do
+        before { render 'curation_concerns/base/items.html.erb', presenter: presenter }
+        it { is_expected.not_to have_content('This Work has no files associated with it.') }
       end
 
-      context "with uploads" do
+      context 'with uploads' do
         before do
           allow(presenter).to receive(:uploading?).and_return(true)
-          render "curation_concerns/base/items.html.erb", presenter: presenter
+          render 'curation_concerns/base/items.html.erb', presenter: presenter
         end
-        it { is_expected.not_to have_content("Uploads are in progress.") }
+        it { is_expected.not_to have_content('Uploads are in progress.') }
       end
 
-      context "with queued files" do
+      context 'with queued files' do
         before do
           allow(presenter).to receive(:queued_files).and_return([queued_file])
-          render "curation_concerns/base/items.html.erb", presenter: presenter
+          render 'curation_concerns/base/items.html.erb', presenter: presenter
         end
-        it { is_expected.not_to have_content("Queued file") }
+        it { is_expected.not_to have_content('Queued file') }
       end
     end
   end

--- a/spec/views/curations_concerns/base/_member.html.erb_spec.rb
+++ b/spec/views/curations_concerns/base/_member.html.erb_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-describe "curation_concerns/base/_member.html.erb", verify_partial_doubles: false do
+describe 'curation_concerns/base/_member.html.erb', verify_partial_doubles: false do
   let(:user)     { create(:user) }
-  let(:solr_doc) { SolrDocument.new(build(:file_set, id: "1234").to_solr) }
+  let(:solr_doc) { SolrDocument.new(build(:file_set, id: '1234').to_solr) }
   let(:ability)  { Ability.new(user) }
   let(:member)   { FileSetPresenter.new(solr_doc, ability) }
 
@@ -12,25 +12,25 @@ describe "curation_concerns/base/_member.html.erb", verify_partial_doubles: fals
   before do
     allow(view).to receive(:current_user).and_return(user)
     allow(controller).to receive(:current_ability).and_return(ability)
-    allow(view).to receive(:render_thumbnail_tag).with(member).and_return("thumbnail tag")
-    allow(view).to receive(:contextual_path).and_return("contextual_path")
+    allow(view).to receive(:render_thumbnail_tag).with(member).and_return('thumbnail tag')
+    allow(view).to receive(:contextual_path).and_return('contextual_path')
     allow(ability).to receive(:can?).with(:read, member.id).and_return(true)
   end
 
-  context "when the user can only read" do
+  context 'when the user can only read' do
     before do
       allow(ability).to receive(:can?).with(:edit, member.id).and_return(false)
-      render("curation_concerns/base/member.html.erb", member: member)
+      render('curation_concerns/base/member.html.erb', member: member)
     end
-    it { is_expected.to have_selector('a.btn', text: "Download") }
+    it { is_expected.to have_selector('a.btn', text: 'Download') }
   end
 
-  context "when the user can edit" do
+  context 'when the user can edit' do
     before do
       allow(ability).to receive(:can?).with(:edit, member.id).and_return(true)
       allow(ability).to receive(:can?).with(:destroy, member.id).and_return(true)
-      render("curation_concerns/base/member.html.erb", member: member)
+      render('curation_concerns/base/member.html.erb', member: member)
     end
-    it { is_expected.to have_selector("button#dropdownMenu_1234") }
+    it { is_expected.to have_selector('button#dropdownMenu_1234') }
   end
 end

--- a/spec/views/curations_concerns/base/_show_actions.html.erb_spec.rb
+++ b/spec/views/curations_concerns/base/_show_actions.html.erb_spec.rb
@@ -1,20 +1,20 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-describe "curation_concerns/base/_show_actions.html.erb" do
+describe 'curation_concerns/base/_show_actions.html.erb' do
   let(:user)      { create(:user) }
   let(:ability)   { Ability.new(user) }
-  let(:work)      { build(:work, id: "1", depositor: user.email) }
+  let(:work)      { build(:work, id: '1', depositor: user.email) }
   let(:doc)       { SolrDocument.new(work.to_solr) }
   let(:presenter) { WorkShowPresenter.new(doc, ability, nil) }
 
-  context "when files are being uploaded" do
+  context 'when files are being uploaded' do
     before do
       allow(presenter).to receive(:uploading?).and_return(true)
-      render "curation_concerns/base/show_actions", presenter: presenter
+      render 'curation_concerns/base/show_actions', presenter: presenter
     end
 
-    it "displays disabled buttons" do
+    it 'displays disabled buttons' do
       expect(rendered).to include('<button type="button" class="btn btn-default" disabled="disabled">Edit</button>')
       expect(rendered).to include('<button type="button" class="btn btn-danger" disabled="disabled">Delete</button>')
     end

--- a/spec/views/curations_concerns/file_sets/_single_use_links.html.erb_spec.rb
+++ b/spec/views/curations_concerns/file_sets/_single_use_links.html.erb_spec.rb
@@ -1,32 +1,32 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-describe "curation_concerns/file_sets/_single_use_links.html.erb" do
+describe 'curation_concerns/file_sets/_single_use_links.html.erb' do
   let(:user)      { create(:user) }
-  let(:solr_doc)  { SolrDocument.new(build(:file_set, id: "1234").to_solr) }
+  let(:solr_doc)  { SolrDocument.new(build(:file_set, id: '1234').to_solr) }
   let(:ability)   { Ability.new(user) }
   let(:presenter) { FileSetPresenter.new(solr_doc, ability) }
 
-  context "when no links are present" do
-    before { render "curation_concerns/file_sets/single_use_links", presenter: presenter }
-    it "renders accessible text" do
-      expect(rendered).to have_content("No links present. To create a new link, click Create Single-Use Link")
+  context 'when no links are present' do
+    before { render 'curation_concerns/file_sets/single_use_links', presenter: presenter }
+    it 'renders accessible text' do
+      expect(rendered).to have_content('No links present. To create a new link, click Create Single-Use Link')
     end
   end
 
-  context "when links are present" do
+  context 'when links are present' do
     let(:sul_presenter) { CurationConcerns::SingleUseLinkPresenter.new(create(:single_use_link)) }
     let(:page) { Capybara::Node::Simple.new(rendered) }
     let(:copy_button) { page.find('button.copy-single-use-link')['aria-label'] }
     let(:delete_link) { page.find('a.delete-single-use-link')['aria-label'] }
 
     before do
-      controller.params = { id: "fs-id" }
+      controller.params = { id: 'fs-id' }
       allow(presenter).to receive(:single_use_links).and_return([sul_presenter])
-      render "curation_concerns/file_sets/single_use_links", presenter: presenter
+      render 'curation_concerns/file_sets/single_use_links', presenter: presenter
     end
 
-    it "renders accessible actions" do
+    it 'renders accessible actions' do
       expect(page).to have_content("Link id #{sul_presenter.short_key} expires in 23 hours")
       expect(copy_button).to eq("Copy link id #{sul_presenter.short_key} to clipboard")
       expect(delete_link).to eq("Delete link id #{sul_presenter.short_key}")

--- a/spec/views/dashboard/heading_greetings.html.erb_spec.rb
+++ b/spec/views/dashboard/heading_greetings.html.erb_spec.rb
@@ -8,26 +8,26 @@ describe 'dashboard/_index_partials/_heading_greetings.html.erb', type: :view do
     allow(controller).to receive(:current_ability).and_return(ability)
   end
 
-  context "when a user is an administrator" do
+  context 'when a user is an administrator' do
     before do
       allow(ability).to receive(:can?).with(:admin_stats, User).and_return(true)
     end
-    it "creates a link to admin stats" do
+    it 'creates a link to admin stats' do
       render
       page = Capybara::Node::Simple.new(rendered)
-      expect(page).to have_content("Hello")
+      expect(page).to have_content('Hello')
       expect(page).to have_selector('a.admin_stats_link', text: 'System Statistics')
     end
   end
 
-  context "when a user is not an administrator" do
+  context 'when a user is not an administrator' do
     before do
       allow(ability).to receive(:can?).with(:admin_stats, User).and_return(false)
     end
-    it "creates a link to admin stats" do
+    it 'creates a link to admin stats' do
       render
       page = Capybara::Node::Simple.new(rendered)
-      expect(page).to have_content("Hello")
+      expect(page).to have_content('Hello')
       expect(page).not_to have_selector('a.admin_stats_link', text: 'System Statistics')
     end
   end

--- a/spec/views/error.html.erb_spec.rb
+++ b/spec/views/error.html.erb_spec.rb
@@ -7,19 +7,19 @@ describe 'error.html.erb' do
     render
   end
 
-  context "with no exception" do
+  context 'with no exception' do
     let(:presenter) { ErrorPresenter.new }
 
-    it "displays the page" do
-      expect(rendered).to include("This item is not available")
+    it 'displays the page' do
+      expect(rendered).to include('This item is not available')
     end
   end
 
-  context "with an exception" do
+  context 'with an exception' do
     let(:presenter) { ErrorPresenter.new(ActiveFedora::ObjectNotFoundError) }
 
-    it "displays the page" do
-      expect(rendered).to include("This item is not available")
+    it 'displays the page' do
+      expect(rendered).to include('This item is not available')
     end
   end
 end

--- a/spec/views/my/_sort_and_per_page.html.erb_spec.rb
+++ b/spec/views/my/_sort_and_per_page.html.erb_spec.rb
@@ -10,23 +10,23 @@ RSpec.describe 'my/_sort_and_per_page.html.erb', type: :view do
     allow(view).to receive(:sort_fields).and_return(sort_fields)
   end
 
-  context "on my works page" do
+  context 'on my works page' do
     before do
       allow(view).to receive(:on_my_works?).and_return(true)
       render
     end
-    it "has buttons" do
+    it 'has buttons' do
       expect(rendered).to have_selector('button', text: 'Add to Collection')
       expect(rendered).to have_selector('input[value="Edit Selected"]')
     end
   end
 
-  context "not on my works page (i.e. Works shared with me)" do
+  context 'not on my works page (i.e. Works shared with me)' do
     before do
       allow(view).to receive(:on_my_works?).and_return(false)
       render
     end
-    it "has buttons" do
+    it 'has buttons' do
       expect(rendered).not_to have_selector('button', text: 'Add to Collection')
       expect(rendered).to have_selector('input[value="Edit Selected"]')
     end

--- a/spec/views/shared/_gscholar.html.erb_spec.rb
+++ b/spec/views/shared/_gscholar.html.erb_spec.rb
@@ -1,29 +1,29 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-describe "shared/_gscholar.html.erb" do
-  let(:doc)       { SolrDocument.new(build(:work, id: "citation-test").to_solr) }
+describe 'shared/_gscholar.html.erb' do
+  let(:doc)       { SolrDocument.new(build(:work, id: 'citation-test').to_solr) }
   let(:presenter) { WorkShowPresenter.new(doc, Ability.new(nil)) }
 
   subject { rendered }
 
-  context "without a representative file set" do
+  context 'without a representative file set' do
     before do
       allow(presenter).to receive(:member_presenters).and_return([])
-      render "shared/gscholar", presenter: presenter
+      render 'shared/gscholar', presenter: presenter
     end
 
     it { is_expected.to include('<meta name="citation_title" content="Sample Title"/>') }
   end
 
-  context "with a file set" do
-    let(:fs_doc)       { SolrDocument.new(build(:file_set, id: "citation-download").to_solr) }
+  context 'with a file set' do
+    let(:fs_doc)       { SolrDocument.new(build(:file_set, id: 'citation-download').to_solr) }
     let(:fs_presenter) { FileSetPresenter.new(fs_doc, Ability.new(nil)) }
 
     before do
       allow(presenter).to receive(:member_presenters).and_return([fs_presenter])
       allow(presenter).to receive(:representative_presenter).and_return(fs_presenter)
-      render "shared/gscholar", presenter: presenter
+      render 'shared/gscholar', presenter: presenter
     end
 
     it { is_expected.to include('<meta name="citation_pdf_url" content="http://test.host/downloads/citation-download"/>') }

--- a/spec/views/shared/_twitter.html.erb_spec.rb
+++ b/spec/views/shared/_twitter.html.erb_spec.rb
@@ -1,29 +1,29 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-describe "shared/_twitter.html.erb" do
-  let(:doc)       { SolrDocument.new(build(:work, id: "citation-test").to_solr) }
+describe 'shared/_twitter.html.erb' do
+  let(:doc)       { SolrDocument.new(build(:work, id: 'citation-test').to_solr) }
   let(:presenter) { WorkShowPresenter.new(doc, Ability.new(nil)) }
 
   subject { rendered }
 
-  context "without a representative file set" do
+  context 'without a representative file set' do
     before do
       allow(presenter).to receive(:member_presenters).and_return([])
-      render "shared/twitter", presenter: presenter
+      render 'shared/twitter', presenter: presenter
     end
 
     it { is_expected.to include('<meta property="og:title" content="Sample Title"/>') }
   end
 
-  context "with a file set" do
-    let(:fs_doc)       { SolrDocument.new(build(:file_set, id: "citation-download").to_solr) }
+  context 'with a file set' do
+    let(:fs_doc)       { SolrDocument.new(build(:file_set, id: 'citation-download').to_solr) }
     let(:fs_presenter) { FileSetPresenter.new(fs_doc, Ability.new(nil)) }
 
     before do
       allow(presenter).to receive(:member_presenters).and_return([fs_presenter])
       allow(presenter).to receive(:representative_presenter).and_return(fs_presenter)
-      render "shared/twitter", presenter: presenter
+      render 'shared/twitter', presenter: presenter
     end
 
     it { is_expected.to include('<meta property="og:image" content="http://test.host/downloads/citation-download?file=thumbnail"/>') }

--- a/spec/views/static/about.html.erb_spec.rb
+++ b/spec/views/static/about.html.erb_spec.rb
@@ -6,7 +6,7 @@ describe 'pages/show.html.erb', type: :view do
 
   before do
     allow(view).to receive(:can?).and_return(false)
-    assign(:page, ContentBlock.new(name: "about", value: "What is ScholarSphere?"))
+    assign(:page, ContentBlock.new(name: 'about', value: 'What is ScholarSphere?'))
     render
   end
 

--- a/spec/views/static/help.html.erb_spec.rb
+++ b/spec/views/static/help.html.erb_spec.rb
@@ -7,7 +7,7 @@ describe 'static/help.html.erb', type: :view do
     assign(:page, ContentBlock.new)
   end
 
-  context "when the user can not edit" do
+  context 'when the user can not edit' do
     before do
       allow(view).to receive(:can?).and_return(false)
       render
@@ -17,7 +17,7 @@ describe 'static/help.html.erb', type: :view do
     it { is_expected.not_to match(/Edit/) }
   end
 
-  context "when the user can edit" do
+  context 'when the user can edit' do
     before do
       allow(view).to receive(:can?).and_return(true)
       render

--- a/spec/views/static/mendeley.html.erb_spec.rb
+++ b/spec/views/static/mendeley.html.erb_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 describe 'static/mendeley.html.erb', type: :view do
-  it "shows the static page" do
+  it 'shows the static page' do
     render
     expect(rendered).to match(/Export to Mendeley/)
   end

--- a/spec/views/static/zotero.html.erb_spec.rb
+++ b/spec/views/static/zotero.html.erb_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 describe 'static/zotero.html.erb', type: :view do
-  it "shows the static page" do
+  it 'shows the static page' do
     render
     expect(rendered).to match(/Export to Zotero/)
   end

--- a/spec/views/sufia/batch_uploads/_form.html.erb_spec.rb
+++ b/spec/views/sufia/batch_uploads/_form.html.erb_spec.rb
@@ -1,30 +1,30 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-describe "sufia/batch_uploads/_form.html.erb" do
+describe 'sufia/batch_uploads/_form.html.erb' do
   let(:form) { BatchUploadForm.new(BatchUploadItem.new, Ability.new(nil)) }
 
   before do
     assign(:form, form)
     allow(controller).to receive(:params).and_return(params)
-    stub_template "_form_files.html.erb" => ""
-    stub_template "_form_metadata.html.erb" => ""
-    stub_template "_form_relationships.html.erb" => ""
-    stub_template "_form_share.html.erb" => ""
-    stub_template "_form_progress.html.erb" => ""
-    render "sufia/batch_uploads/form.html.erb"
+    stub_template '_form_files.html.erb' => ''
+    stub_template '_form_metadata.html.erb' => ''
+    stub_template '_form_relationships.html.erb' => ''
+    stub_template '_form_share.html.erb' => ''
+    stub_template '_form_progress.html.erb' => ''
+    render 'sufia/batch_uploads/form.html.erb'
   end
 
-  describe "rendering the link that switches to the new single work page" do
+  describe 'rendering the link that switches to the new single work page' do
     subject { rendered }
 
-    context "without no collection id parameters" do
+    context 'without no collection id parameters' do
       let(:params) { {} }
       it { is_expected.to include('href="/concern/generic_works/new"') }
     end
 
-    context "with collection ids" do
-      let(:params) { { collection_ids: ["collection-id"] } }
+    context 'with collection ids' do
+      let(:params) { { collection_ids: ['collection-id'] } }
       it { is_expected.to include('href="/concern/generic_works/new?collection_ids%5B%5D=collection-id"') }
     end
   end

--- a/spec/views/user_mailer/acknowledgment_email.html_spec.rb
+++ b/spec/views/user_mailer/acknowledgment_email.html_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 
 describe 'user_mailer/acknowledgment_email.html.erb', type: :view do
   before { render }
-  it "creates an email with html links" do
+  it 'creates an email with html links' do
     expect(rendered).to include('<a href="https://scholarsphere.psu.edu/help/">help page</a>')
   end
 end

--- a/spec/views/user_mailer/stats_email.html.erb_spec.rb
+++ b/spec/views/user_mailer/stats_email.html.erb_spec.rb
@@ -13,7 +13,7 @@ describe 'user_mailer/stats_email.html.erb', type: :view do
     allow(presenter).to receive(:total_private_uploads).and_return(10)
   end
 
-  context "when single day" do
+  context 'when single day' do
     let(:start_datetime) { DateTime.now }
     let(:end_datetime) { DateTime.now }
 
@@ -21,21 +21,21 @@ describe 'user_mailer/stats_email.html.erb', type: :view do
       allow(presenter).to receive(:single_day?).and_return(true)
     end
 
-    it "draws report" do
+    it 'draws report' do
       render
       page = Capybara::Node::Simple.new(rendered)
-      expect(page).to have_selector("h1")
+      expect(page).to have_selector('h1')
       expect(page).to have_text("Report for #{start_datetime}")
       expect(page).not_to have_text("to #{start_datetime}")
-      expect(page).to have_text("Total Users 10")
-      expect(page).to have_text("Total Uploads 100")
-      expect(page).to have_text("Total Public Uploads 70")
-      expect(page).to have_text("Total Registered Uploads 20")
-      expect(page).to have_text("Total Private Uploads 10")
+      expect(page).to have_text('Total Users 10')
+      expect(page).to have_text('Total Uploads 100')
+      expect(page).to have_text('Total Public Uploads 70')
+      expect(page).to have_text('Total Registered Uploads 20')
+      expect(page).to have_text('Total Private Uploads 10')
     end
   end
 
-  context "when single day" do
+  context 'when single day' do
     let(:start_datetime) { 1.day.ago }
     let(:end_datetime) { DateTime.now }
 
@@ -43,10 +43,10 @@ describe 'user_mailer/stats_email.html.erb', type: :view do
       allow(presenter).to receive(:single_day?).and_return(false)
     end
 
-    it "draws report" do
+    it 'draws report' do
       render
       page = Capybara::Node::Simple.new(rendered)
-      expect(page).to have_selector("h1")
+      expect(page).to have_selector('h1')
       expect(page).to have_text("Report for #{start_datetime} to #{end_datetime}")
     end
   end

--- a/spec/views/users/show.html.erb_spec.rb
+++ b/spec/views/users/show.html.erb_spec.rb
@@ -21,23 +21,23 @@ describe 'users/show.html.erb', type: :view do
   describe "when the user doesn't have a title" do
     let(:user) { build(:user, title: nil, created_at: join_date) }
 
-    it "has the vitals" do
+    it 'has the vitals' do
       expect(rendered).to match(/<span class="glyphicon glyphicon-time"><\/span> Joined on #{join_date.strftime("%b %d, %Y")}/)
       expect(rendered).not_to match(/<dt>Title<\/dt>/)
     end
   end
 
-  describe "when user has a title" do
-    let(:user) { build(:user, created_at: join_date, title: "Mrs") }
-    it "has the vitals" do
+  describe 'when user has a title' do
+    let(:user) { build(:user, created_at: join_date, title: 'Mrs') }
+    it 'has the vitals' do
       expect(rendered).to match(/<span class="glyphicon glyphicon-time"><\/span> Joined on #{join_date.strftime("%b %d, %Y")}/)
       expect(rendered).to match(/<dt>Title<\/dt>/)
       expect(rendered).to match(/<dd>Mrs<\/dd>/)
     end
   end
 
-  describe "when user has a phone number" do
-    let(:user) { build(:user, created_at: join_date, telephone: "+1 800 867 5309") }
+  describe 'when user has a phone number' do
+    let(:user) { build(:user, created_at: join_date, telephone: '+1 800 867 5309') }
     it { is_expected.to include('<a href="tel:+18008675309">+1 800 867 5309</a>') }
   end
 end


### PR DESCRIPTION
As an alternative to #1006.

Double-quotes are allowed in cases of interpolation or other needs as required. Rubocop rules can be suspended on a per-method basis.