### PR TITLE
Correctly encode the URL for translated facets, ref #998

### DIFF
--- a/app/renderers/translated_facet_attribute_renderer.rb
+++ b/app/renderers/translated_facet_attribute_renderer.rb
@@ -14,4 +14,11 @@ class TranslatedFacetAttributeRenderer < CurationConcerns::Renderers::FacetedAtt
       return value unless options.key?(:mapping)
       options[:mapping][value]
     end
+
+    # @return [String] url-encoded path
+    # Overrides CurationConcerns::Renderers::FacetedAttributeRenderer to not use ERB::Util methods
+    # to rewrite the url.
+    def search_path(value)
+      Rails.application.routes.url_helpers.search_catalog_path(:"f[#{search_field}][]" => value)
+    end
 end

--- a/spec/renderers/translated_facet_attribute_renderer_spec.rb
+++ b/spec/renderers/translated_facet_attribute_renderer_spec.rb
@@ -34,5 +34,22 @@ describe TranslatedFacetAttributeRenderer do
       it { expect(renderer).not_to be_microdata(field) }
       it { expect(subject).to be_equivalent_to(expected) }
     end
+
+    context 'with special characters' do
+      let(:field)    { :keyword }
+      let(:mapping)  { { "'55 Chet Atkins" => "'55 chet atkins" } }
+      let(:renderer) { described_class.new(field, ["'55 Chet Atkins"], mapping: mapping) }
+
+      let(:dl_content) {%(
+        <dt class="attribute-term">Keyword</dt>
+        <dd class="attribute keyword">
+          <span itemprop="keywords">
+            <a href="/catalog?f%5Bkeyword_sim%5D%5B%5D=%2755+chet+atkins">'55 Chet Atkins</a>
+          </span>
+        </dd>
+      )}
+
+      it { expect(subject).to be_equivalent_to(expected) }
+    end
   end
 end


### PR DESCRIPTION
Facets that were translated from their original input, such as titleized or downcased, were not correctly rendered as urls for facet links.

This changes TranslatedFacetAttributeRenderer to not use any additional html rewriting methods to generate the url.