### PR TITLE
Rename file sets during upload errors, ref #974 & #969

### DIFF
--- a/app/jobs/import_url_job.rb
+++ b/app/jobs/import_url_job.rb
@@ -1,4 +1,13 @@
 # frozen_string_literal: true
+# Overrides the CurationConcerns job to accept the remote file's original name and handle failures.
+#
+# The file is downloaded using its original name and extension, but sanitized with CarrierWave to
+# remove any non-alphanumeric characters. This is the same process that occurs with locally
+# uploaded files (via CarrierWave) and avoids problems later when interacting with filenames
+# that have unsupported characters.
+#
+# Additionally, if the job encounters any issues when downloading the file, such as an expired
+# url or a timeout, the file set's name is changed to reflect the error.
 
 require 'uri'
 require 'tempfile'
@@ -15,28 +24,25 @@ class ImportUrlJob < ActiveJob::Base
   # @param [FileSet] file_set
   # @param [String] file_name
   # @param [CurationConcerns::Operation] log to send messages
-  # Overrides the CurationConcerns job to accept the remote file's original name. The file
-  # is downloaded using its original name and extension, but sanitized with CarrierWave to
-  # remove any non-alphanumeric characters. This is the same process that occurs with locally
-  # uploaded files (via CarrierWave) and avoids problems later when interacting with filenames
-  # that have unsupported characters.
   def perform(file_set, file_name, log)
     log.performing!
     user = User.find_by_user_key(file_set.depositor)
     File.open(File.join(Dir.tmpdir, CarrierWave::SanitizedFile.new(file_name).filename), 'w+') do |f|
-      status = copy_remote_file(file_set, f)
-      unless status
-        file_set.errors.add('Error', "Downloading Content for #{ActionController::Base.helpers.link_to(file_name, Rails.application.routes.url_helpers.curation_concerns_file_set_path(file_set.id))}")
+      importer = UrlImporter.new(file_set.import_url, f)
+
+      unless importer.success?
+        file_set.title = [I18n.t('scholarsphere.import_url.failed_title', file_name: file_name)]
+        file_set.errors.add(
+          'Error:',
+          I18n.t('scholarsphere.import_url.failed_message', link: file_link(file_name, file_set.id),
+                                                            message: importer.error))
         on_error(log, file_set, user)
         return false
       end
 
-      # reload the FileSet once the data is copied since this is a long running task
       file_set.reload
 
-      # attach downloaded file to FileSet stubbed out
       if CurationConcerns::Actors::FileSetActor.new(file_set, user).create_content(f)
-        # send message to user on download success
         CurationConcerns.config.callback.run(:after_import_url_success, file_set, user)
         log.success!
       else
@@ -52,20 +58,46 @@ class ImportUrlJob < ActiveJob::Base
       log.fail!(file_set.errors.full_messages.join(' '))
     end
 
-    def copy_remote_file(file_set, f)
-      # check the uri to make certain we will get a valid response from the remote host
-      uri = URI(file_set.import_url)
-      head_res = HTTParty.head(uri)
-      return false unless head_res.success?
+    def file_link(file_name, id)
+      ActionController::Base.helpers.link_to(
+        file_name,
+        Rails.application.routes.url_helpers.curation_concerns_file_set_path(id))
+    end
 
-      f.binmode
+    class UrlImporter
+      attr_reader :url, :file, :error
 
-      # download file from url
-      spec = { 'url' => uri }
-      retriever = BrowseEverything::Retriever.new
-      retriever.retrieve(spec) do |chunk|
-        f.write(chunk)
+      # @param [String] url
+      # @param [File] file
+      def initialize(url, file)
+        @url = url
+        @file = file
       end
-      f.rewind
+
+      def success?
+        return false unless active_url?
+        copy_remote_file
+      end
+
+      # @return [Boolean]
+      # Checks to see if the remote url is active and valid
+      def active_url?
+        status = HTTParty.head(url).success?
+        @error = 'Expired URL' unless status
+        status
+      end
+
+      # @return [Boolean]
+      # Downloads the remote file from the url to the file
+      def copy_remote_file
+        file.binmode
+        retriever = BrowseEverything::Retriever.new
+        retriever.retrieve('url' => url) { |chunk| file.write(chunk) }
+        file.rewind
+        true
+      rescue StandardError => e
+        @error = e.message
+        false
+      end
     end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -64,6 +64,10 @@ en:
       local: "Files must be added before they can be uploaded"
     batch_edit:
       permissions_warning: "Warning! Making changes to visibility or sharing permissions will remove any existing permissions on the files in this batch and replace them with the ones specified here."
+    import_url:
+      failed_title: "Upload failed for %{file_name}. Please delete and upload again"
+      failed_message: "Could not retrieve file for %{link}. Reason: %{message}"
+
   statistic:
     report:
       subject: "ScholarSphere - Statistic Report"

--- a/spec/jobs/import_url_job_spec.rb
+++ b/spec/jobs/import_url_job_spec.rb
@@ -3,13 +3,14 @@
 require 'rails_helper'
 
 describe ImportUrlJob do
-  let(:user)           { create(:user) }
-  let(:file_set)       { create(:file_set, user: user, import_url: 'import_url') }
-  let(:log)            { double }
-  let(:mock_retriever) { double }
-  let(:http_status) { true }
+  let(:user)             { create(:user) }
+  let(:file_set)         { create(:file_set, user: user, import_url: 'import_url') }
+  let(:log)              { double }
+  let(:mock_retriever)   { double }
+  let(:http_status)      { true }
   let(:mock_http_result) { instance_double('HTTParty::Response', success?: http_status) }
-  let(:file_name) { 'Development Team Projects and Milestones (not downloaded).xlsx' }
+  let(:file_name)        { 'Development Team Projects and Milestones (not downloaded).xlsx' }
+  let(:inbox)            { user.mailbox.inbox }
 
   before do
     allow(log).to receive(:performing!)
@@ -19,25 +20,42 @@ describe ImportUrlJob do
     allow(HTTParty).to receive(:head).and_return(mock_http_result)
   end
 
-  it 'sanitizes the file name' do
-    expect(CurationConcerns.config.callback).to receive(:run).with(:after_import_url_success, file_set, user)
-    expect(log).to receive(:success!)
-    described_class.perform_now(file_set, file_name, log)
-    expect(file_set.label).to eq('Development_Team_Projects_and_Milestones__not_downloaded_.xlsx')
+  context 'with a successful import' do
+    it 'attaches a sanitized the file name to the file set' do
+      expect(CurationConcerns.config.callback).to receive(:run).with(:after_import_url_success, file_set, user)
+      expect(log).to receive(:success!)
+      described_class.perform_now(file_set, file_name, log)
+      expect(file_set.label).to eq('Development_Team_Projects_and_Milestones__not_downloaded_.xlsx')
+    end
   end
 
-  context 'http head fails' do
+  context 'when the remote file is unavailable' do
     let(:http_status) { false }
-    let(:inbox) { user.mailbox.inbox }
 
-    it 'fails to add the content' do
+    it 'logs the error and renames the file set' do
       expect(log).to receive(:fail!)
       expect(file_set.original_file).to be_nil
       described_class.perform_now(file_set, file_name, log)
+      expect(file_set.title).to eq(['Upload failed for Development Team Projects and Milestones (not downloaded).xlsx. Please delete and upload again'])
       expect(inbox.count).to eq(1)
       last_message = inbox[0].last_message
       expect(last_message.subject).to eq('File Import Error')
-      expect(last_message.body).to eq("Error Downloading Content for <a href=\"/concern/file_sets/#{file_set.id}\">Development Team Projects and Milestones (not downloaded).xlsx</a>")
+      expect(last_message.body).to eq("Error: Could not retrieve file for <a href=\"/concern/file_sets/#{file_set.id}\">Development Team Projects and Milestones (not downloaded).xlsx</a>. Reason: Expired URL")
+    end
+  end
+
+  context 'when retrieval fails' do
+    before { allow(mock_retriever).to receive(:retrieve).and_raise(StandardError, 'Timeout') }
+
+    it 'logs the error and renames the file set' do
+      expect(log).to receive(:fail!)
+      expect(file_set.original_file).to be_nil
+      described_class.perform_now(file_set, file_name, log)
+      expect(file_set.title).to eq(['Upload failed for Development Team Projects and Milestones (not downloaded).xlsx. Please delete and upload again'])
+      expect(inbox.count).to eq(1)
+      last_message = inbox[0].last_message
+      expect(last_message.subject).to eq('File Import Error')
+      expect(last_message.body).to eq("Error: Could not retrieve file for <a href=\"/concern/file_sets/#{file_set.id}\">Development Team Projects and Milestones (not downloaded).xlsx</a>. Reason: Timeout")
     end
   end
 end


### PR DESCRIPTION
ImportUrlJob will fail if the file's url has expired, or if there is some other kind of error during its retrieval, such as a timeout or other disruption.

Instead of letting the job fail and having Resque capture the error, we can have the job capture the error and rename the file set to the kind of error.

The benefit is that it surfaces the error to the user so that they can take action: delete the file set and try again. The drawback is that it's still creating the resource in Fedora. Ideally, perhaps, we ought to capture these errors even before the file set is created and attached to the work. However, that would require deeper changes to the stack.