### PR TITLE
updating to_flot to fill in missing days with zero.

### DIFF
--- a/app/prepends/prepended_presenters/stats_usage_behavior.rb
+++ b/app/prepends/prepended_presenters/stats_usage_behavior.rb
@@ -14,4 +14,44 @@ module PrependedPresenters::StatsUsageBehavior
     rescue ArgumentError, TypeError
       nil
     end
+
+    def to_flots(stats)
+      stats = fill_in_missing_dates_with_zero(stats)
+      super(stats)
+    end
+
+    def fill_in_missing_dates_with_zero(stats)
+      return stats if stats.count < 2
+
+      date_range_for_stats = date_range(stats)
+      return stats if stats.count == date_range_for_stats.count
+
+      complete_stats_for_range(date_range_for_stats, stats)
+    end
+
+    def date_range(stats)
+      start_date = stats.first.date.to_date
+      end_date = stats.last.date
+      start_date..end_date
+    end
+
+    def complete_stats_for_range(date_range, stats)
+      stats_class = stats.first.class
+
+      date_range.map do |date|
+        if stat_for_date?(stats.first, date)
+          stats.shift
+        else
+          empty_stat(stats_class, date)
+        end
+      end
+    end
+
+    def stat_for_date?(stat, date)
+      stat.date.to_date == date
+    end
+
+    def empty_stat(stat_class, date)
+      stat_class.new(date: date, stat_class.cache_column => 0)
+    end
 end

--- a/spec/presenters/sufia/work_usage_spec.rb
+++ b/spec/presenters/sufia/work_usage_spec.rb
@@ -24,4 +24,46 @@ describe Sufia::WorkUsage do
       its(:date_for_analytics) { is_expected.to eq('July 1, 2014') }
     end
   end
+
+  describe '#to_flots' do
+    subject { described_class.new(work.id).send(:to_flots, stats) }
+
+    let(:start_datetime) { 3.days.ago }
+    let(:yesterday_stat) { WorkViewStat.new(work_id: 'abc123', date: 1.day.ago, work_views: 10) }
+    let(:yesterday_flot) { yesterday_stat.to_flot }
+    let(:five_days_ago_stat) { WorkViewStat.new(work_id: 'abc123', date: 5.days.ago, work_views: 15) }
+    let(:five_days_ago_flot) { five_days_ago_stat.to_flot }
+    let(:four_days_ago_stat) { WorkViewStat.new(work_id: 'abc123', date: 4.days.ago.to_date, work_views: 0) }
+    let(:four_days_ago_flot) { four_days_ago_stat.to_flot }
+    let(:three_days_ago_stat) { WorkViewStat.new(work_id: 'abc123', date: 3.days.ago.to_date, work_views: 0) }
+    let(:three_days_ago_flot) { three_days_ago_stat.to_flot }
+    let(:two_days_ago_stat) { WorkViewStat.new(work_id: 'abc123', date: 2.days.ago.to_date, work_views: 0) }
+    let(:two_days_ago_flot) { two_days_ago_stat.to_flot }
+    let(:stats) { [five_days_ago_stat, yesterday_stat] }
+
+    context 'no days are present' do
+      let(:stats) { [] }
+
+      it { is_expected.to eq([]) }
+    end
+
+    context 'all days are present' do
+      let(:stats) { [two_days_ago_stat, yesterday_stat] }
+
+      it { is_expected.to eq([two_days_ago_flot, yesterday_flot]) }
+    end
+
+    context 'one day is missing' do
+      let(:stats) { [three_days_ago_stat, yesterday_stat] }
+
+      it { is_expected.to eq([three_days_ago_flot, two_days_ago_flot, yesterday_flot]) }
+    end
+
+    context 'multiple days are missing' do
+      let(:stats) { [five_days_ago_stat, yesterday_stat] }
+
+      it { is_expected.to eq([five_days_ago_flot, four_days_ago_flot,
+                              three_days_ago_flot, two_days_ago_flot, yesterday_flot])}
+    end
+  end
 end


### PR DESCRIPTION
This is the first step in correcting the download stats and not storing zeros for the view stats 

It will also help out with the user stats query since we will only get values back for when a view or download occurs.