### PR TITLE
Work Show Metadata List

### DIFF
--- a/app/assets/stylesheets/scholarsphere/work_show.scss
+++ b/app/assets/stylesheets/scholarsphere/work_show.scss
@@ -1,11 +1,13 @@
 .attribute-term,
 dd.attribute {
   float: left;
+  line-height: 1.5em;
 }
 
 .attribute-term {
   clear: left;
-  width: 8em;
+  min-width: 8em;
+  width: 35%;
 }
 
 dd.attribute + dd.attribute::before {

--- a/app/views/curation_concerns/base/_attribute_rows.html.erb
+++ b/app/views/curation_concerns/base/_attribute_rows.html.erb
@@ -1,21 +1,20 @@
-<%= presenter.attribute_to_html(:creator, render_as: :translated_facet, mapping: presenter.facet_mapping(:creator_name), search_field: 'creator_name') %>
+<%= presenter.attribute_to_html(:creator, render_as: :translated_facet, mapping: presenter.facet_mapping(:creator_name),
+                                search_field: 'creator_name') %>
+<%= presenter.attribute_to_html(:keyword, render_as: :translated_facet,
+                                mapping: presenter.facet_mapping(:keyword)) %>
+<%= presenter.attribute_to_html(:rights, render_as: :rights) %>
+<%= presenter.attribute_to_html(:resource_type, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:contributor, render_as: :faceted) %>
-<%= presenter.attribute_to_html(:admin_set, render_as: :faceted) %>
-<%= presenter.attribute_to_html(:subject, render_as: :faceted) %>
-
 <%= presenter.attribute_to_html(:publisher, render_as: :translated_facet,
-                                          mapping: presenter.facet_mapping(:publisher)) %>
-
+                                mapping: presenter.facet_mapping(:publisher)) %>
+<%= presenter.attribute_to_html(:date_created, render_as: :linked, search_field: 'date_created_tesim') %>
+<%= presenter.attribute_to_html(:subject, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:language, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:identifier, render_as: :linked, search_field: 'identifier_tesim') %>
-
-<%= presenter.attribute_to_html(:keyword, render_as: :translated_facet,
-                                          mapping: presenter.facet_mapping(:keyword)) %>
-
-<%= presenter.attribute_to_html(:date_created, render_as: :linked, search_field: 'date_created_tesim') %>
 <%= presenter.attribute_to_html(:based_near, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:related_url, render_as: :external_link) %>
-<%= presenter.attribute_to_html(:resource_type, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:source) %>
 <%= presenter.attribute_to_html(:size) %>
 <%= presenter.attribute_to_html(:total_items) %>
+<%= presenter.attribute_to_html(:embargo_release_date, render_as: :date) %>
+<%= presenter.attribute_to_html(:lease_expiration_date, render_as: :date) %>

--- a/app/views/curation_concerns/base/_metadata.html.erb
+++ b/app/views/curation_concerns/base/_metadata.html.erb
@@ -3,8 +3,5 @@
   <h2 class="border-bottom-1px"><%= t('.header') %></h2>
   <dl class="<%= dom_class(presenter) %> attributes" <%= presenter.microdata_type_to_html %>>
     <%= render 'attribute_rows', presenter: presenter %>
-    <%= presenter.attribute_to_html(:embargo_release_date, render_as: :date) %>
-    <%= presenter.attribute_to_html(:lease_expiration_date, render_as: :date) %>
-    <%= presenter.attribute_to_html(:rights, render_as: :rights) %>
   </dl>
 </div>


### PR DESCRIPTION
Reorders the metadata to match the work form, moves other attributes out of the metadata partial and into the attribute rows partial, and makes adjustment to the spacing of the definition terms.