### PR TITLE
Refactor UserStatsImporter

### DIFF
--- a/app/services/google_analytics/user_statistic_report.rb
+++ b/app/services/google_analytics/user_statistic_report.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module GoogleAnalytics
+  class UserStatisticReport < Sufia::UserStatImporter
+    attr_reader :user, :stats
+
+    def initialize(user)
+      @user = user
+      @stats = {}
+    end
+
+    def call
+      tally_stats_for_user_files
+      tally_stats_for_user_works
+      stats
+    end
+
+    private
+
+      def tally_stats_for_user_files
+        file_ids_for_user(user).each do |file_id|
+          file_set = FileSet.find(file_id)
+          tally_object_stat(file_set, FileDownloadStat, :downloads)
+          tally_object_stat(file_set, FileViewStat, :views)
+        end
+      end
+
+      def tally_stats_for_user_works
+        work_ids_for_user(user).each do |work_id|
+          tally_object_stat(GenericWork.find(work_id), WorkViewStat, :work_views)
+        end
+      end
+
+      def tally_object_stat(object, statistic_class, tally_key)
+        results = statistic_class.send(:statistics_for, object).order(date: :asc)
+        tally_results(results, tally_key, stats) if results.present?
+      end
+  end
+end

--- a/app/services/user_stats_importer.rb
+++ b/app/services/user_stats_importer.rb
@@ -1,12 +1,9 @@
 # frozen_string_literal: true
 
-class UserStatsImporter < Sufia::UserStatImporter
-  attr_reader :start_date, :end_date, :view_report, :download_report
+class UserStatsImporter
+  attr_reader :view_report, :download_report
 
-  def initialize(start_date, end_date = 1.day.ago, options = {})
-    super(options)
-    @start_date = start_date
-    @end_date = end_date
+  def initialize(start_date, end_date = 1.day.ago)
     @view_report = GoogleAnalytics::ViewReport.new(start_date, end_date)
     @download_report = GoogleAnalytics::DownloadReport.new(start_date, end_date)
   end
@@ -28,11 +25,9 @@ class UserStatsImporter < Sufia::UserStatImporter
   end
 
   def tally_user_results
-    sorted_users.each do |user|
-      stats = {}
-      stats = tally_stats_for_user_files(user, stats)
-      stats = tally_stats_for_user_works(user, stats)
-      create_or_update_user_stats(stats, user)
+    User.find_each do |user|
+      test_stats = GoogleAnalytics::UserStatisticReport.new(user).call
+      create_or_update_user_stats(test_stats, user)
     end
   end
 
@@ -48,45 +43,6 @@ class UserStatsImporter < Sufia::UserStatImporter
                                        object, stat_class)
         end
       end
-    end
-
-    def tally_stats_for_user_files(user, stats)
-      safe_method_call("Error find file ids for user: #{user} ", :file_ids_for_user, user) do |file_id_list|
-        file_id_list.each do |file_id|
-          safe_method_call("Error tallying Stats for FilesSet: #{file_id} ", :lookup_object, file_id) do |file_set|
-            tally_file_set_download_stat(file_set, stats)
-            tally_file_set_view_stat(file_set, stats)
-          end
-        end
-      end
-      stats
-    end
-
-    def tally_stats_for_user_works(user, stats)
-      work_ids_for_user(user).each do |work_id|
-        safe_method_call("Error tallying Stats for Work: #{work_id} ", :lookup_object, work_id) do |work|
-          stats = tally_work_view_stat(work, stats)
-        end
-      end
-      stats
-    end
-
-    def tally_work_view_stat(work, stats)
-      view_stats = WorkViewStat.statistics_for(work).order(date: :asc)
-      tally_results(view_stats, :work_views, stats) if view_stats.present?
-      stats
-    end
-
-    def tally_file_set_view_stat(file_set, stats)
-      view_stats = FileViewStat.statistics_for(file_set).order(date: :asc)
-      stats = tally_results(view_stats, :views, stats) if view_stats.present?
-      stats
-    end
-
-    def tally_file_set_download_stat(file_set, stats)
-      download_stats = FileDownloadStat.statistics_for(file_set).order(date: :asc)
-      stats = tally_results(download_stats, :downloads, stats) if download_stats.present?
-      stats
     end
 
     def get_download_statistic_object(id)
@@ -133,5 +89,19 @@ class UserStatsImporter < Sufia::UserStatImporter
                        stat_class.build_for(object, date: view_date, stat_class.cache_column => event[stat_class.event_type], user_id: user_db_id)
                      end
       updated_stat.save
+    end
+
+    # This was copied from Sufia::UserStatImporter to avoid having to inherit the entire class
+    def create_or_update_user_stats(stats, user)
+      stats.each do |date_string, data|
+        date = Time.zone.parse(date_string)
+
+        user_stat = UserStat.where(user_id: user.id, date: date).first_or_initialize(user_id: user.id, date: date)
+
+        user_stat.file_views = data.fetch(:views, 0)
+        user_stat.file_downloads = data.fetch(:downloads, 0)
+        user_stat.work_views = data.fetch(:work_views, 0)
+        user_stat.save!
+      end
     end
 end

--- a/spec/services/user_statistic_report_spec.rb
+++ b/spec/services/user_statistic_report_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe GoogleAnalytics::UserStatisticReport do
+  let(:importer) { described_class.new(user1) }
+  let(:user1)    { create(:user) }
+  let(:user2)    { create(:user) }
+  let(:results)  { described_class.new(user1).call }
+
+  describe '#tally_user_results' do
+    subject { results }
+
+    let(:user1_work) { create :work, depositor: user1.login }
+    let(:user1_file_set) { create :file_set, user: user1 }
+
+    context 'no statuses are available' do
+      it { is_expected.to be_empty }
+    end
+
+    context 'people have viewed and downloaded the objects' do
+      let(:day1)            { Date.parse('2017-08-15') }
+      let(:day2)            { Date.parse('2017-08-16') }
+      let(:user2_file_set)  { create(:file_set, user: user2) }
+      let(:user2_work)      { create(:work, depositor: user2.login) }
+      let(:user1_work2)     { create(:work, depositor: user1.login) }
+      let(:user1_file_set2) { create(:file_set, user: user1) }
+
+      before do
+        WorkViewStat.create date: day1, work_id: user1_work.id, user_id: user1.id, work_views: 2
+        WorkViewStat.create date: day2, work_id: user1_work.id, user_id: user1.id, work_views: 2
+        WorkViewStat.create date: day1, work_id: user2_work.id, user_id: user2.id, work_views: 1
+        WorkViewStat.create date: day2, work_id: user2_work.id, user_id: user1.id, work_views: 2
+        WorkViewStat.create date: day1, work_id: user1_work2.id, user_id: user1.id, work_views: 3
+        FileViewStat.create date: day1, file_id: user1_file_set2.id, user_id: user1.id, views: 25
+        FileViewStat.create date: day1, file_id: user1_file_set.id, user_id: user1.id, views: 5
+        FileViewStat.create date: day1, file_id: user2_file_set.id, user_id: user2.id, views: 3
+        FileDownloadStat.create(date: day2, file_id: user1_file_set.id, user_id: user1.id, downloads: 6)
+      end
+      it 'creates view entries in user table' do
+        results = importer.call
+
+        expect(results['2017-08-15 00:00:00 UTC']).to include(views: 30, work_views: 5)
+        expect(results['2017-08-16 00:00:00 UTC']).to include(downloads: 6, work_views: 2)
+      end
+    end
+  end
+end

--- a/spec/services/user_stats_importer_spec.rb
+++ b/spec/services/user_stats_importer_spec.rb
@@ -159,4 +159,13 @@ describe UserStatsImporter do
       end
     end
   end
+
+  describe '#import' do
+    it 'runs the entire import process' do
+      expect(importer).to receive(:gather_view_stats)
+      expect(importer).to receive(:gather_download_stats)
+      expect(importer).to receive(:tally_user_results)
+      importer.import
+    end
+  end
 end


### PR DESCRIPTION
From our Friday refactoring session, we extracted the various tally
methods into a new class and removed the inheritance from
Sufia::UserStatImporter.