### PR TITLE
Allow ordering of alias objects in place of persons, ref #991, #949

### DIFF
--- a/app/assets/javascripts/scholarsphere/creator/creator.js
+++ b/app/assets/javascripts/scholarsphere/creator/creator.js
@@ -4,7 +4,8 @@ ScholarSphere.creator = {
    */
   id: '',
   firstName: '',
-  lastName: '', displayName: '',
+  lastName: '',
+  displayName: '',
   index: '',
   readonly: ''
 }

--- a/app/assets/javascripts/scholarsphere/creator/creator.js
+++ b/app/assets/javascripts/scholarsphere/creator/creator.js
@@ -4,7 +4,7 @@ ScholarSphere.creator = {
    */
   id: '',
   firstName: '',
-  lastName: '',
+  lastName: '', displayName: '',
   index: '',
   readonly: ''
 }

--- a/app/controllers/batch_edits_controller.rb
+++ b/app/controllers/batch_edits_controller.rb
@@ -5,6 +5,7 @@ class BatchEditsController < ApplicationController
   include FileSetHelper
   include Sufia::BatchEditsControllerBehavior
 
+  # @todo See https://github.com/psu-stewardship/scholarsphere/issues/1038
   def edit
     super
     work = BatchEditItem.new(batch: batch)

--- a/app/forms/batch_edit_form.rb
+++ b/app/forms/batch_edit_form.rb
@@ -6,7 +6,7 @@ class BatchEditForm < Sufia::Forms::BatchEditForm
 
   def self.build_permitted_params
     permitted = super
-    permitted << { creators: [:id, :given_name, :sur_name, :_destroy] }
+    permitted << { creators: [:id, :display_name, :given_name, :sur_name, :_destroy] }
     permitted << :visibility
     permitted
   end

--- a/app/forms/concerns/with_creator.rb
+++ b/app/forms/concerns/with_creator.rb
@@ -3,21 +3,35 @@
 module WithCreator
   extend ActiveSupport::Concern
 
+  # @return [Array<CreatorForm>]
+  # If there are no creators, a new CreatorForm is built using the logged-in user
+  # @todo add Solr search here or in CreatorForm to user existing Alias record for the user
   def creators
-    model.creators.build(current_creator_attributes) if model.creators.blank?
-    model.creators.to_a
+    if model.creators.blank?
+      Array.wrap(CreatorForm.new(Alias.new(display_name: current_display_name)))
+    else
+      model.creators.map { |c| CreatorForm.new(c) }
+    end
   end
 
   included do
-    # Auto-fill the creator field with the currently logged-in user's name.
-    def current_creator_attributes
-      @current_creator_attributes ||= { display_name: current_ability.current_user.display_name }
-    end
-
     def self.build_permitted_params
       permitted = super
       permitted << { creators: [:id, :display_name, :given_name, :sur_name, :_destroy] }
       permitted
     end
   end
+
+  private
+
+    # @return [String]
+    # Sometimes current_ability is really a user
+    # @todo See https://github.com/psu-stewardship/scholarsphere/issues/1038
+    def current_display_name
+      if current_ability.is_a?(User)
+        current_ability.display_name
+      else
+        current_ability.current_user.display_name
+      end
+    end
 end

--- a/app/forms/concerns/with_creator.rb
+++ b/app/forms/concerns/with_creator.rb
@@ -11,17 +11,12 @@ module WithCreator
   included do
     # Auto-fill the creator field with the currently logged-in user's name.
     def current_creator_attributes
-      return @current_creator_attributes if @current_creator_attributes
-      parsed_name = Namae::Name.parse(current_ability.current_user.display_name)
-      @current_creator_attributes = {
-        given_name: parsed_name.given,
-        sur_name: parsed_name.family
-      }
+      @current_creator_attributes ||= { display_name: current_ability.current_user.display_name }
     end
 
     def self.build_permitted_params
       permitted = super
-      permitted << { creators: [:id, :given_name, :sur_name, :_destroy] }
+      permitted << { creators: [:id, :display_name, :given_name, :sur_name, :_destroy] }
       permitted
     end
   end

--- a/app/forms/creator_form.rb
+++ b/app/forms/creator_form.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class CreatorForm
+  attr_reader :person_alias
+
+  delegate :id, :display_name, to: :person_alias
+
+  # @param [Alias]
+  def initialize(person_alias)
+    @person_alias = person_alias
+  end
+
+  def read_only_name?
+    person_alias.person.present?
+  end
+
+  def sur_name
+    if read_only_name?
+      person_alias.person.sur_name
+    else
+      parsed_name.family
+    end
+  end
+
+  def given_name
+    if read_only_name?
+      person_alias.person.given_name
+    else
+      parsed_name.given
+    end
+  end
+
+  private
+
+    def parsed_name
+      @parsed_name ||= Namae::Name.parse(display_name)
+    end
+end

--- a/app/indexers/indexes_creator.rb
+++ b/app/indexers/indexes_creator.rb
@@ -12,14 +12,7 @@ module IndexesCreator
   private
 
     def index_creator(solr_doc)
-      creator_names = object.creators.map do |creator|
-        first = creator.given_name
-        first = nil if first.blank?
-        last = creator.sur_name
-        last = nil if last.blank?
-        [first, last].compact.join(' ')
-      end
-
+      creator_names = object.creators.map(&:display_name)
       solr_doc[Solrizer.solr_name('creator_name', :facetable)] = creator_names
       solr_doc[Solrizer.solr_name('creator_name', :stored_searchable)] = creator_names
     end

--- a/app/models/alias.rb
+++ b/app/models/alias.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Alias < ActiveFedora::Base
+  include Hydra::PCDM::ObjectBehavior
+
+  belongs_to :person, class_name: 'Person', predicate: ::RDF::Vocab::FOAF.name
+
+  property :display_name, predicate: ::RDF::Vocab::FOAF.nick, multiple: false do |index|
+    index.as :stored_searchable, :symbol
+  end
+end

--- a/app/models/batch_edit_item.rb
+++ b/app/models/batch_edit_item.rb
@@ -26,4 +26,8 @@ class BatchEditItem < ActiveFedora::Base
     return nil if range.count > 1
     range.first
   end
+
+  def creators
+    batch.map(&:creator).flatten
+  end
 end

--- a/app/models/concerns/has_creators.rb
+++ b/app/models/concerns/has_creators.rb
@@ -4,18 +4,16 @@ module HasCreators
   extend ActiveSupport::Concern
 
   included do
-    has_and_belongs_to_many :creators, class_name: 'Person', predicate: ::RDF::Vocab::DC11.creator
+    ordered_aggregation :creators,
+                    has_member_relation: ::RDF::Vocab::DC11.creator,
+                    class_name: 'Alias',
+                    type_validator: type_validator,
+                    through: :list_source
     alias_method :creator, :creators
 
     def creators=(values)
       values = values.values if values.is_a? Hash
-      person_records = values.map do |v|
-        if v.is_a? Person
-          v
-        else
-          Person.find_or_create(v)
-        end
-      end
+      person_records = values.map { |v| AliasManagementService.call(v) }
       super(person_records)
     end
   end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,28 +1,13 @@
 # frozen_string_literal: true
 
 class Person < ActiveFedora::Base
+  has_many :aliases
+
   property :given_name, predicate: ::RDF::Vocab::FOAF.firstName, multiple: false do |index|
     index.as :stored_searchable, :symbol
   end
 
   property :sur_name, predicate: ::RDF::Vocab::FOAF.lastName, multiple: false do |index|
     index.as :stored_searchable, :symbol
-  end
-
-  # If ID exists, match on ID, else try to match name
-  def self.find_or_create(attributes)
-    attributes = attributes.with_indifferent_access
-    attributes.delete(:id) if attributes[:id].blank?
-    query_attrs = if attributes[:id].blank?
-                    {
-                      given_name_ssim: attributes[:given_name],
-                      sur_name_ssim: attributes[:sur_name]
-                    }
-                  else
-                    { id: attributes[:id] }
-                  end
-    person = Person.where(query_attrs).limit(1).first
-    person ||= Person.create(attributes)
-    person
   end
 end

--- a/app/presenters/work_show_presenter.rb
+++ b/app/presenters/work_show_presenter.rb
@@ -4,7 +4,7 @@ class WorkShowPresenter < Sufia::WorkShowPresenter
   include ActionView::Helpers::NumberHelper
   include Sufia::WithEvents
 
-  delegate :bytes, :subtitle, :display_name, to: :solr_document
+  delegate :bytes, :subtitle, to: :solr_document
 
   self.file_presenter_class = ::FileSetPresenter
 

--- a/app/presenters/work_show_presenter.rb
+++ b/app/presenters/work_show_presenter.rb
@@ -4,7 +4,7 @@ class WorkShowPresenter < Sufia::WorkShowPresenter
   include ActionView::Helpers::NumberHelper
   include Sufia::WithEvents
 
-  delegate :bytes, :subtitle, to: :solr_document
+  delegate :bytes, :subtitle, :display_name, to: :solr_document
 
   self.file_presenter_class = ::FileSetPresenter
 

--- a/app/services/alias_management_service.rb
+++ b/app/services/alias_management_service.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+class AliasManagementService
+  class Error < StandardError
+  end
+
+  # @param [Hash, ActionController::Parameters, Alias] attributes_or_alias
+  # @return [Alias]
+  # Returns an alias for a person, creating any objects as needed.
+  def self.call(parameter)
+    if parameter.is_a?(Alias)
+      new(alias: parameter)._alias_
+    else
+      new(parameter.with_indifferent_access)._alias_
+    end
+  end
+
+  attr_reader :given_name, :display_name, :sur_name, :person_alias
+
+  def initialize(attributes)
+    @display_name = attributes.fetch(:display_name, nil)
+    @sur_name = attributes.fetch(:sur_name, nil)
+    @given_name = attributes.fetch(:given_name, nil)
+    @person_alias = attributes.fetch(:alias, nil) || find_alias(attributes.fetch(:id, nil))
+  end
+
+  def _alias_
+    if person_alias.present?
+      raise Error, I18n.t('scholarsphere.aliases.person_error') if person_alias.person.blank?
+      person_alias
+    else
+      create_alias
+    end
+  end
+
+  private
+
+    def find_alias(id)
+      if id.blank?
+        Alias.where(display_name_ssim: display_name).first
+      else
+        Alias.find(id)
+      end
+    end
+
+    def create_alias
+      raise Error, I18n.t('scholarsphere.aliases.parameter_error') unless all_names_present?
+      Alias.create(display_name: display_name, person: person)
+    end
+
+    def all_names_present?
+      display_name.present? && given_name.present? && sur_name.present?
+    end
+
+    def person
+      person = Person.where(sur_name_ssim: sur_name, given_name_ssim: given_name).first
+      return person if person.present?
+      Person.create(sur_name: sur_name, given_name: given_name)
+    end
+end

--- a/app/services/field_configurator.rb
+++ b/app/services/field_configurator.rb
@@ -21,8 +21,7 @@ class FieldConfigurator
              rights: FieldConfig.new('Rights'),
              identifier: FieldConfig.new('Identifier'),
              description: FieldConfig.new('Description'),
-             subtitle: FieldConfig.new('Subtitle'),
-             display_name: FieldConfig.new('Display Name'))
+             subtitle: FieldConfig.new('Subtitle'))
   end
 
   # Defines what fields are shown in the facets on the search index view

--- a/app/services/field_configurator.rb
+++ b/app/services/field_configurator.rb
@@ -21,7 +21,8 @@ class FieldConfigurator
              rights: FieldConfig.new('Rights'),
              identifier: FieldConfig.new('Identifier'),
              description: FieldConfig.new('Description'),
-             subtitle: FieldConfig.new('Subtitle'))
+             subtitle: FieldConfig.new('Subtitle'),
+             display_name: FieldConfig.new('Display Name'))
   end
 
   # Defines what fields are shown in the facets on the search index view

--- a/app/services/generic_work_to_share_json_service.rb
+++ b/app/services/generic_work_to_share_json_service.rb
@@ -22,7 +22,7 @@ class GenericWorkToShareJSONService
 
     def add_contributors_to_document
       work.creators.each do |creator|
-        creator_name = [creator.sur_name, creator.given_name].compact.join(', ')
+        creator_name = [creator.person.sur_name, creator.person.given_name].compact.join(', ')
         document.add_contributor(name: creator_name, email: email_for_name(creator_name))
       end
     end

--- a/app/views/curation_concerns/base/_attribute_rows.html.erb
+++ b/app/views/curation_concerns/base/_attribute_rows.html.erb
@@ -1,3 +1,4 @@
+<%= presenter.attribute_to_html(:display_name) %>
 <%= presenter.attribute_to_html(:creator, render_as: :translated_facet, mapping: presenter.facet_mapping(:creator_name), search_field: 'creator_name') %>
 <%= presenter.attribute_to_html(:contributor, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:admin_set, render_as: :faceted) %>

--- a/app/views/curation_concerns/base/_attribute_rows.html.erb
+++ b/app/views/curation_concerns/base/_attribute_rows.html.erb
@@ -1,4 +1,3 @@
-<%= presenter.attribute_to_html(:display_name) %>
 <%= presenter.attribute_to_html(:creator, render_as: :translated_facet, mapping: presenter.facet_mapping(:creator_name), search_field: 'creator_name') %>
 <%= presenter.attribute_to_html(:contributor, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:admin_set, render_as: :faceted) %>

--- a/app/views/records/edit_fields/_creator.html.erb
+++ b/app/views/records/edit_fields/_creator.html.erb
@@ -33,6 +33,14 @@
     options: [readonly: true],
     id: sur_name_id,
       class: 'form-control string required creator-last-name creator' %>
+
+    <% display_name_id = "#{id_base}[display_name]" %>
+    <%= label_tag display_name_id, 'Display Name' %>
+    <%= text_field_tag display_name_id,
+                       creator.display_name,
+                       required: false,
+                       id: display_name_id,
+                       class: 'form-control string required creator-display-name creator' %>
   </div>
 <% end %>
 </div>

--- a/app/views/records/edit_fields/_creator.html.erb
+++ b/app/views/records/edit_fields/_creator.html.erb
@@ -1,49 +1,54 @@
 <h3>Creators</h3>
 <div class="creator_container">
- <div class="find_creator_container">
-  <label for="find_creator">Find Creator</label>
-  <input type="text" name="find_creator" id="find_creator" class="form-control string" placeholder="Search for an existing creator" />
-</div>
-<% @form.creators.each_with_index do |creator, index| %>
-  <% id_base = "#{@form.model_class_name}[creators][#{index}]"%>
-
-  <div class="well creator_inputs">
-    <button type="button" class="btn btn-link remove remove-creator"><span class="glyphicon glyphicon-remove"></span><span class="controls-remove-text">Remove</span></button>
-
-  <% unless creator.id.blank? %>
-     <%= hidden_field_tag "#{id_base}[id]", creator.id %>
-     <% is_readonly = true %>
-  <% end %>
-
-  <% given_name_id = "#{id_base}[given_name]" %>
-  <%= label_tag given_name_id, 'Given Name' %>
-  <%= text_field_tag given_name_id,
-    creator.given_name,
-    required: false,
-    readonly: is_readonly,
-    id: given_name_id,
-    class: 'form-control string required creator-first-name creator' %>
-
-  <% sur_name_id = "#{id_base}[sur_name]" %>
-  <%= label_tag sur_name_id, 'Last Name' %>
-  <%= text_field_tag sur_name_id,
-    creator.sur_name,
-    required: false,
-    readonly: is_readonly,
-    options: [readonly: true],
-    id: sur_name_id,
-      class: 'form-control string required creator-last-name creator' %>
-
-    <% display_name_id = "#{id_base}[display_name]" %>
-    <%= label_tag display_name_id, 'Display Name' %>
-    <%= text_field_tag display_name_id,
-                       creator.display_name,
-                       required: false,
-                       id: display_name_id,
-                       class: 'form-control string required creator-display-name creator' %>
+  <div class="find_creator_container">
+    <label for="find_creator">Find Creator</label>
+    <input type="text"
+           name="find_creator"
+           id="find_creator"
+           class="form-control string"
+           placeholder="Search for an existing creator" />
   </div>
-<% end %>
+
+  <% @form.creators.each_with_index do |creator_form, index| %>
+    <% id_base = "#{@form.model_class_name}[creators][#{index}]"%>
+
+    <div class="well creator_inputs">
+      <button type="button" class="btn btn-link remove remove-creator">
+        <span class="glyphicon glyphicon-remove"></span>
+        <span class="controls-remove-text">Remove</span>
+      </button>
+
+      <%= hidden_field_tag "#{id_base}[id]", creator_form.id unless creator_form.read_only_name? %>
+
+      <% given_name_id = "#{id_base}[given_name]" %>
+      <%= label_tag given_name_id, 'Given Name' %>
+      <%= text_field_tag given_name_id, creator_form.given_name,
+            required: false,
+            readonly: creator_form.read_only_name?,
+            id: given_name_id,
+            class: 'form-control string required creator-first-name creator' %>
+
+      <% sur_name_id = "#{id_base}[sur_name]" %>
+      <%= label_tag sur_name_id, 'Last Name' %>
+      <%= text_field_tag sur_name_id, creator_form.sur_name,
+            required: false,
+            readonly: creator_form.read_only_name?,
+            id: sur_name_id,
+            class: 'form-control string required creator-last-name creator' %>
+
+      <% display_name_id = "#{id_base}[display_name]" %>
+      <%= label_tag display_name_id, 'Display Name' %>
+      <%= text_field_tag display_name_id, creator_form.display_name,
+            required: false,
+            id: display_name_id,
+            class: 'form-control string required creator-display-name creator' %>
+    </div>
+  <% end %>
 </div>
-<button type="button" id="add-creator" class="btn btn-link add add-creator"><span class="glyphicon glyphicon-plus"></span><span class="controls-add-text">Add another Creator</span></button>
+
+<button type="button" id="add-creator" class="btn btn-link add add-creator">
+  <span class="glyphicon glyphicon-plus"></span>
+  <span class="controls-add-text">Add another Creator</span>
+</button>
 
 <%= render partial: 'records/edit_fields/creator_template' %>

--- a/app/views/records/edit_fields/_creator_template.html.erb
+++ b/app/views/records/edit_fields/_creator_template.html.erb
@@ -5,8 +5,10 @@
       <span class="glyphicon glyphicon-remove"></span><span class="controls-remove-text">Remove</span>
     </button>
     <label for="<%= @form.model_class_name %>{{index}}_given_name">Given Name</label>
-    <input type="text" {{readonly}} name="<%= @form.model_class_name %>[creators][{{index}}][given_name]" id="<%= @form.model_class_name %>[creators][{{index}}][given_name]" class="form-control string required creator-first-name creator" value="{{firstName}}">
+      <input type="text" {{readonly}} name="<%= @form.model_class_name %>[creators][{{index}}][given_name]" id="<%= @form.model_class_name %>[creators][{{index}}][given_name]" class="form-control string required creator-first-name creator" value="{{firstName}}">
     <label for="<%= @form.model_class_name %>{{index}}_sur_name">Last Name</label>
-    <input type="text" {{readonly}} name="<%= @form.model_class_name %>[creators][{{index}}][sur_name]" id="<%= @form.model_class_name %>[creators][{{index}}][sur_name]" class="form-control string required creator-last-name creator" value="{{lastName}}">
+      <input type="text" {{readonly}} name="<%= @form.model_class_name %>[creators][{{index}}][sur_name]" id="<%= @form.model_class_name %>[creators][{{index}}][sur_name]" class="form-control string required creator-last-name creator" value="{{lastName}}">
+    <label for="{{index}}_display_name">Display Name</label>
+     <input type="text" name="<%= @form.model_class_name %>[creators][{{index}}][display_name]" id="<%= @form.model_class_name %>[creators][{{index}}][display_name]" class="form-control string required creator-display-name creator" value="{{displayName}}">
   </div>
 </script>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -67,6 +67,9 @@ en:
     import_url:
       failed_title: "Upload failed for %{file_name}. Please delete and upload again"
       failed_message: "Could not retrieve file for %{link}. Reason: %{message}"
+    aliases:
+      parameter_error: "Please provide either an alias, id, or display name; or, all of: surname, given name, and display name"
+      person_error: "The provided alias does not have a person associated with it"
 
   statistic:
     report:

--- a/spec/actors/curation_concerns/generic_work_actor_spec.rb
+++ b/spec/actors/curation_concerns/generic_work_actor_spec.rb
@@ -26,17 +26,17 @@ describe CurationConcerns::Actors::GenericWorkActor do
     end
   end
 
-  context 'with an existing Person record' do
-    let!(:existing_person) { create(:person) }
+  context 'with an existing Alias record' do
+    let!(:existing_alias) { create(:alias, :with_person) }
     let(:attributes) do
       {
         title: ['A title'],
-        creators: { '0' => { id: existing_person.id, given_name: 'a' } }
+        creators: { '0' => { id: existing_alias.id } }
       }
     end
 
-    it 'sets creator to existing Person record' do
-      expect(work.creators).to eq [existing_person]
+    it 'sets creator to existing Alias record' do
+      expect(work.creators).to eq [existing_alias]
     end
   end
 
@@ -44,13 +44,12 @@ describe CurationConcerns::Actors::GenericWorkActor do
     let(:attributes) do
       {
         title: ['A title'],
-        creators: { '0' => { id: nil, given_name: 'first', sur_name: 'last' } }
+        creators: { '0' => { id: nil, given_name: 'first', sur_name: 'last', display_name: 'first last' } }
       }
     end
 
     it 'sets the creators' do
-      expect(work.creators.map(&:given_name)).to eq ['first']
-      expect(work.creators.map(&:sur_name)).to eq ['last']
+      expect(work.creators.map(&:display_name)).to eq ['first last']
     end
   end
 

--- a/spec/factories/aliases.rb
+++ b/spec/factories/aliases.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+FactoryGirl.define do
+  factory :alias do
+    sequence(:display_name) { |n| "Display Name #{n}" }
+
+    trait :with_person do
+      after(:build) do |resource|
+        resource.person = Person.new(sur_name: 'Sur Name', given_name: 'Given Name')
+      end
+    end
+
+    factory :creator do
+      with_person
+    end
+  end
+end

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -14,9 +14,9 @@ FactoryGirl.define do
     after(:build) do |collection, attrs|
       collection.apply_depositor_metadata((attrs.depositor || attrs.user.user_key))
 
-      # Note: This builds an alias for the creator that is not linked to a person
       if attrs.creators.blank?
-        collection.creators.build(display_name: 'creatorcreator')
+        collection.creators.build(display_name: 'creatorcreator',
+                                  person: Person.new(given_name: 'Creator C.', sur_name: 'Creator'))
       end
     end
 

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -14,8 +14,9 @@ FactoryGirl.define do
     after(:build) do |collection, attrs|
       collection.apply_depositor_metadata((attrs.depositor || attrs.user.user_key))
 
+      # Note: This builds an alias for the creator that is not linked to a person
       if attrs.creators.blank?
-        collection.creators.build(given_name: 'creatorcreator')
+        collection.creators.build(display_name: 'creatorcreator')
       end
     end
 

--- a/spec/factories/persons.rb
+++ b/spec/factories/persons.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryGirl.define do
-  factory :person, aliases: [:creator] do
+  factory :person do
     sequence(:given_name) { |n| "First Name #{n}" }
     sequence(:sur_name) { |n| "Last Name #{n}" }
   end

--- a/spec/factories/works.rb
+++ b/spec/factories/works.rb
@@ -158,7 +158,8 @@ FactoryGirl.define do
 
       after(:build) do |work, evaluator|
         if evaluator.creators.blank?
-          work.creators.build(display_name: 'creatorcreator')
+          work.creators.build(display_name: 'creatorcreator',
+                              person: Person.new(given_name: 'Creator C.', sur_name: 'Creator'))
         end
       end
     end
@@ -172,7 +173,8 @@ FactoryGirl.define do
 
       after(:build) do |work, evaluator|
         if evaluator.creators.blank?
-          work.creators.build(display_name: 'required creator')
+          work.creators.build(display_name: 'required creator',
+                              person: Person.new(given_name: 'Required T.', sur_name: 'Creator'))
         end
       end
     end

--- a/spec/factories/works.rb
+++ b/spec/factories/works.rb
@@ -29,7 +29,8 @@ FactoryGirl.define do
 
         after(:build) do |work, evaluator|
           if evaluator.creators.blank?
-            work.creators.build(given_name: 'Joe', sur_name: 'Contributor')
+            work.creators.build(display_name: 'Joe Contributor',
+                                person: Person.new(sur_name: 'Contributor', given_name: 'Joe'))
           end
         end
       end
@@ -157,7 +158,7 @@ FactoryGirl.define do
 
       after(:build) do |work, evaluator|
         if evaluator.creators.blank?
-          work.creators.build(given_name: 'creatorcreator')
+          work.creators.build(display_name: 'creatorcreator')
         end
       end
     end
@@ -171,7 +172,7 @@ FactoryGirl.define do
 
       after(:build) do |work, evaluator|
         if evaluator.creators.blank?
-          work.creators.build(given_name: 'required creator')
+          work.creators.build(display_name: 'required creator')
         end
       end
     end

--- a/spec/features/batch_edit_spec.rb
+++ b/spec/features/batch_edit_spec.rb
@@ -4,9 +4,8 @@ require 'feature_spec_helper'
 
 describe 'Batch management of works', type: :feature do
   let(:current_user) { create(:user) }
-  let!(:work1)       { create(:public_work, :with_complete_metadata, depositor: current_user.login, creators: [creator]) }
-  let!(:work2)       { create(:public_work, :with_complete_metadata, depositor: current_user.login, creators: [creator]) }
-  let(:creator) { create(:creator) }
+  let!(:work1)       { create(:public_work, :with_complete_metadata, depositor: current_user.login) }
+  let!(:work2)       { create(:public_work, :with_complete_metadata, depositor: current_user.login) }
 
   before do
     sign_in_with_named_js(:batch_edit, current_user, disable_animations: true)
@@ -40,8 +39,9 @@ describe 'Batch management of works', type: :feature do
       expect(page).to have_css "input#batch_edit_item_keyword[value*='tagtag']"
       expect(page).to have_css "input#batch_edit_item_based_near[value*='based_nearbased_near']"
       expect(page).to have_css "input#batch_edit_item_language[value*='languagelanguage']"
-      expect(find_field(id: 'batch_edit_item[creators][0][given_name]').value).to eq creator.given_name
-      expect(find_field(id: 'batch_edit_item[creators][0][sur_name]').value).to eq creator.sur_name
+      expect(find_field(id: 'batch_edit_item[creators][0][given_name]').value).to eq('Creator C.')
+      expect(find_field(id: 'batch_edit_item[creators][0][sur_name]').value).to eq('Creator')
+      expect(find_field(id: 'batch_edit_item[creators][0][display_name]').value).to eq('creatorcreator')
       expect(page).to have_css "input#batch_edit_item_publisher[value*='publisherpublisher']"
       expect(page).to have_css "input#batch_edit_item_subject[value*='subjectsubject']"
       expect(page).to have_css "input#batch_edit_item_related_url[value*='http://example.org/TheRelatedURLLink/']"

--- a/spec/features/collection/edit_spec.rb
+++ b/spec/features/collection/edit_spec.rb
@@ -84,14 +84,15 @@ describe Collection, type: :feature do
       expect(page).to have_no_checked_field('Private')
       fill_in 'Title', with: updated_title
       fill_in 'Description', with: updated_description
-      fill_in 'collection[creators][0][given_name]', with: 'Dorje'
-      fill_in 'collection[creators][0][sur_name]', with: 'Trollo'
+      expect(find('.creator-first-name')['readonly']).to eq('readonly')
+      expect(find('.creator-last-name')['readonly']).to eq('readonly')
+      fill_in 'collection[creators][0][display_name]', with: 'Mdme. Dorje Trollo'
       click_button 'Update Collection'
       expect(page).not_to have_content original_title.first
       expect(page).not_to have_content original_description.first
       expect(page).to have_content updated_title
       expect(page).to have_content updated_description
-      expect(page).to have_content 'Dorje Trollo'
+      expect(page).to have_content 'Mdme. Dorje Trollo'
     end
   end
 

--- a/spec/features/collection/view_and_search_spec.rb
+++ b/spec/features/collection/view_and_search_spec.rb
@@ -6,8 +6,7 @@ require 'feature_spec_helper'
 include Selectors::Dashboard
 
 describe Collection, type: :feature do
-  let(:creator) { FactoryGirl.create(:person) }
-  let(:creator_name) { [creator.given_name, creator.sur_name].join(' ') }
+  let(:creator) { create(:alias, :with_person) }
 
   let!(:collection)  { create(:public_collection, :with_complete_metadata,
                               creators: [creator],
@@ -34,7 +33,7 @@ describe Collection, type: :feature do
       specify do
         expect(page).to have_content collection.title.first
         expect(page).to have_content collection.description.first
-        expect(page).to have_content creator_name
+        expect(page).to have_content collection.creator.first.display_name
         expect(page).to have_content file1.title.first
         expect(page).to have_content file2.title.first
         expect(page).to have_content 'Total Items 2'
@@ -66,7 +65,7 @@ describe Collection, type: :feature do
         expect(page).not_to have_content file2.title.first
 
         # Should not have Collection Descriptive metadata table
-        expect(page).not_to have_content creator_name
+        expect(page).not_to have_content collection.creator.first.display_name
       end
     end
 

--- a/spec/features/dashboard/dashboard_collections_spec.rb
+++ b/spec/features/dashboard/dashboard_collections_spec.rb
@@ -6,11 +6,9 @@ include Selectors::Dashboard
 
 describe 'Dashboard Collections:', type: :feature do
   let!(:jill_collection) { create(:collection, title: ["Jill's Collection"], depositor: jill.login) }
-  let!(:collection)      { create(:collection, depositor: current_user.login) }
+  let!(:collection)      { create(:collection, creators: [creator], depositor: current_user.login) }
 
-  let(:creator) { collection.creators.first }
-  let(:creator_name) { [creator.given_name, creator.sur_name].join(' ') }
-
+  let(:creator)      { create(:alias, :with_person) }
   let(:current_user) { create(:user) }
   let(:jill)         { create(:jill) }
 
@@ -33,14 +31,14 @@ describe 'Dashboard Collections:', type: :feature do
 
   specify 'toggle displays additional information' do
     first('span.glyphicon-chevron-right').click
-    expect(page).to have_content(creator_name)
+    expect(page).to have_content(creator.display_name)
     expect(page).to have_content(collection.depositor)
     expect(page).to have_content 'Edit Access'
     expect(page).to have_content(current_user)
   end
 
   specify 'additional information is hidden' do
-    expect(page).not_to have_content(creator_name)
+    expect(page).not_to have_content(creator.display_name)
     expect(page).not_to have_content(collection.depositor)
     expect(page).not_to have_content 'Edit Access'
     expect(page).not_to have_content(current_user)
@@ -67,7 +65,7 @@ describe 'Dashboard Collections:', type: :feature do
         click_link('Object Type')
         expect(page).to have_content('Collection (1)')
         click_link('Creator')
-        expect(page).to have_content(creator_name)
+        expect(page).to have_content(creator.display_name)
       end
     end
   end

--- a/spec/features/dashboard/dashboard_works_spec.rb
+++ b/spec/features/dashboard/dashboard_works_spec.rb
@@ -5,25 +5,28 @@ require 'feature_spec_helper'
 include Selectors::Dashboard
 
 describe 'Dashboard Works', type: :feature do
-  let!(:current_user) { create(:user) }
-  let(:creator) { create(:creator, given_name: 'Creator1', sur_name: 'Jones') }
+  let(:current_user) { create(:user) }
+  let(:jill) { create(:jill) }
+  let(:work1_creator_name) { 'Work One Creator' }
+
+  let(:creator) { build(:alias, display_name: work1_creator_name,
+                                person: Person.new(given_name: 'Work One', sur_name: 'Creator')) }
 
   let!(:work1) do
     create(:public_work, :with_complete_metadata,
+           id: 'dashboard-works-work1',
            depositor: current_user.login,
            title: ['little_file.txt'],
-           creators: [create(:creator)],
+           creators: [creator],
            date_uploaded: DateTime.now + 1.hour)
   end
-  let(:work1_creator_name) { [work1.creator.first.given_name, work1.creator.first.sur_name].join(' ') }
 
   let!(:work2) do
-    create(:registered_work, depositor: current_user.login, title: ['Registered work'])
+    create(:registered_work, id: 'dashboard-works-work2', depositor: current_user.login, title: ['Registered work'])
   end
 
-  let(:jill) { create(:jill) }
   let!(:other_collection) do
-    create(:collection, title: ['jill collection'], depositor: jill.login)
+    create(:collection, id: 'dashboard-works-other_collection', title: ['jill collection'], depositor: jill.login)
   end
 
   before do
@@ -299,7 +302,7 @@ describe 'Dashboard Works', type: :feature do
       # Since the work isn't persisted, the relationship doesn't
       # resolve properly for the indexer. Just stub the values
       # so we can avoid saving the work record for this spec.
-      allow(work).to receive(:creators).and_return([creator])
+      allow(work).to receive(:creators).and_return([Alias.new(display_name: 'Creator1 Jones')])
 
       # TODO: how to do we set the work1 format in the objects with build
       hash = work.to_solr

--- a/spec/features/facet_spec.rb
+++ b/spec/features/facet_spec.rb
@@ -3,9 +3,12 @@
 require 'feature_spec_helper'
 
 describe 'Catalog facets' do
-  let(:patricia) { { given_name: 'Patricia M', sur_name: 'Hswe' } }
-  let(:patricia_with_dot) { { given_name: 'Patricia M.', sur_name: 'Hswe' } }
-  let(:patricia_caps) { { given_name: 'PATRICIA M.', sur_name: 'HSWE' } }
+  let(:patricia) { create(:alias, display_name: 'Patricia M Hswe',
+                                  person: Person.new(given_name: 'Patricia M', sur_name: 'Hswe')) }
+  let(:patricia_with_dot) { create(:alias, display_name: 'Patricia M. Hswe',
+                                           person: Person.new(given_name: 'Patricia M.', sur_name: 'Hswe')) }
+  let(:patricia_caps) { create(:alias, display_name: 'PATRICIA M. HSWE',
+                                       person: Person.new(given_name: 'PATRICIA M.', sur_name: 'HSWE')) }
 
   let(:work1) { build(:public_work, id: '1',
                                     contributor: ['Contri B. Utor'],
@@ -21,9 +24,9 @@ describe 'Catalog facets' do
                                     keyword: ['Key Word']) }
 
   before do
-    work1.creators.build(patricia_with_dot)
-    work2.creators.build(patricia_caps)
-    work3.creators.build(patricia)
+    work1.creators = [patricia_with_dot]
+    work2.creators = [patricia_caps]
+    work3.creators = [patricia]
     index_works_and_collections(work1, work2, work3)
     visit '/catalog'
     click_link('Creator')

--- a/spec/features/generic_work/edit_work_spec.rb
+++ b/spec/features/generic_work/edit_work_spec.rb
@@ -7,8 +7,10 @@ describe 'Editing a work', js: true do
   let(:proxy) { create(:first_proxy) }
   let(:user)  { create(:user, :with_proxy, proxy_for: proxy) }
   let(:work)  { create(:public_work, :with_required_metadata, depositor: user.user_key, creators: [sally, yuki]) }
-  let(:sally) { create(:creator, given_name: 'Sally', sur_name: 'Henry') }
-  let(:yuki) { create(:creator, given_name: 'Yuki', sur_name: 'Matsumoto') }
+  let(:sally) { create(:alias, display_name: 'Sally Henry',
+                               person: Person.new(given_name: 'Sally', sur_name: 'Henry')) }
+  let(:yuki)  { create(:alias, display_name: 'Yuki Matsumoto',
+                               person: Person.new(given_name: 'Yuki', sur_name: 'Matsumoto')) }
 
   before { login_as user }
 
@@ -31,16 +33,18 @@ describe 'Editing a work', js: true do
     # '0' and '1' were already used by Sally and Yuki.
     fill_in 'generic_work[creators][2][given_name]', with: 'Verity'
     fill_in 'generic_work[creators][2][sur_name]', with: 'Brown'
+    fill_in 'generic_work[creators][2][display_name]', with: 'Downtown Verity Brown'
     click_button 'Save'
 
     # The updated creator data should appear on the show page
     expect(page).not_to have_link 'Sally Henry'
-    expect(page).to     have_link 'Verity Brown'
+    expect(page).to     have_link 'Downtown Verity Brown'
     expect(page).to     have_link 'Yuki Matsumoto'
 
     # The persisted work should have the updated creator data
     work.reload
-    expect(work.creators.map(&:given_name)).to contain_exactly('Verity', 'Yuki')
+
+    expect(work.creators.map(&:display_name)).to contain_exactly('Downtown Verity Brown', 'Yuki Matsumoto')
   end
 
   # Tests the basic outline of the form. This can be expanded later with more detail including

--- a/spec/features/generic_work/view_and_download_spec.rb
+++ b/spec/features/generic_work/view_and_download_spec.rb
@@ -16,7 +16,6 @@ describe GenericWork, type: :feature do
                depositor: current_user.login,
                description: ['Description http://example.org/TheDescriptionLink/'])
       end
-      let(:work1_creator_name) { [work1.creator.first.given_name, work1.creator.first.sur_name].compact.join(' ') }
 
       specify 'I can see all the correct information' do
         visit(root_path)
@@ -51,7 +50,7 @@ describe GenericWork, type: :feature do
 
         within('dl.generic_work') do
           expect(page).to have_link work1.related_url.first
-          expect(page).to have_link work1_creator_name
+          expect(page).to have_link work1.creator.first.display_name
           expect(page).to have_link work1.contributor.first
           expect(page).to have_link work1.keyword.first
           expect(page).to have_link work1.subject.first

--- a/spec/forms/batch_upload_form_spec.rb
+++ b/spec/forms/batch_upload_form_spec.rb
@@ -18,12 +18,9 @@ describe BatchUploadForm do
   end
 
   describe '#initialize_field' do
-    it 'inits to the name of the current user' do
-      expect(form.creators.count).to eq 1
-      current_creator = form.creators.first
-      expect(current_creator.given_name).to eq 'Test A'
-      expect(current_creator.sur_name).to eq 'User'
-    end
+    subject { form.creators.map(&:display_name) }
+
+    it { is_expected.to contain_exactly('Test A User') }
   end
 
   describe '#model_attributes' do

--- a/spec/forms/creator_form_spec.rb
+++ b/spec/forms/creator_form_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe CreatorForm do
+  subject { form }
+
+  let(:form) { described_class.new(aliaz) }
+
+  context 'when the alias exists with a person' do
+    let(:aliaz) { build(:alias, display_name: 'Joe Bob',
+                                person: Person.new(sur_name: 'Bob', given_name: 'Joe')) }
+
+    it { is_expected.to be_read_only_name }
+    its(:display_name) { is_expected.to eq('Joe Bob') }
+    its(:id) { is_expected.to eq(aliaz.id) }
+    its(:given_name) { is_expected.to eq('Joe') }
+    its(:sur_name) { is_expected.to eq('Bob') }
+  end
+
+  context 'when the alias is new and has no person' do
+    let(:aliaz) { build(:alias, display_name: 'Joe Bob') }
+
+    it { is_expected.not_to be_read_only_name }
+    its(:display_name) { is_expected.to eq('Joe Bob') }
+    its(:id) { is_expected.to eq(aliaz.id) }
+    its(:given_name) { is_expected.to eq('Joe') }
+    its(:sur_name) { is_expected.to eq('Bob') }
+  end
+end

--- a/spec/forms/generic_work_form_spec.rb
+++ b/spec/forms/generic_work_form_spec.rb
@@ -8,18 +8,32 @@ describe CurationConcerns::GenericWorkForm do
   let(:work)    { build(:work) }
   let(:form)    { described_class.new(work, ability) }
 
-  describe 'initialize creator fields' do
-    subject { form.creators.map(&:display_name) }
+  describe '#creators' do
+    subject { form.creators.first }
 
-    context 'with a display name' do
-      it { is_expected.to contain_exactly('Test A User') }
+    context 'without any existing creators' do
+      its(:display_name) { is_expected.to eq('Test A User') }
+      its(:given_name) { is_expected.to eq('Test A') }
+      its(:sur_name) { is_expected.to eq('User') }
     end
 
     context 'without a display name' do
       before { User.destroy_all }
       let(:user) { User.create(login: 'SomeUser') }
 
-      it { is_expected.to contain_exactly(nil) }
+      # Note: I don't think we will ever encounter this scenario (awead)
+      its(:display_name) { is_expected.to be_nil }
+      its(:given_name) { is_expected.to be_nil }
+      its(:sur_name) { is_expected.to be_nil }
+    end
+
+    context 'with existing creators' do
+      let(:creator) { build(:alias, :with_person) }
+      let(:work) { build(:work, creators: [creator]) }
+
+      its(:display_name) { is_expected.to eq(creator.display_name) }
+      its(:given_name) { is_expected.to eq(creator.person.given_name) }
+      its(:sur_name) { is_expected.to eq(creator.person.sur_name) }
     end
   end
 

--- a/spec/forms/generic_work_form_spec.rb
+++ b/spec/forms/generic_work_form_spec.rb
@@ -9,25 +9,17 @@ describe CurationConcerns::GenericWorkForm do
   let(:form)    { described_class.new(work, ability) }
 
   describe 'initialize creator fields' do
+    subject { form.creators.map(&:display_name) }
+
     context 'with a display name' do
-      it 'inits to the name of the current user' do
-        expect(form.creators.count).to eq 1
-        current_creator = form.creators.first
-        expect(current_creator.given_name).to eq 'Test A'
-        expect(current_creator.sur_name).to eq 'User'
-      end
+      it { is_expected.to contain_exactly('Test A User') }
     end
 
     context 'without a display name' do
       before { User.destroy_all }
       let(:user) { User.create(login: 'SomeUser') }
 
-      it 'inits blank fields for the creator' do
-        expect(form.creators.count).to eq 1
-        current_creator = form.creators.first
-        expect(current_creator.given_name).to eq nil
-        expect(current_creator.sur_name).to eq nil
-      end
+      it { is_expected.to contain_exactly(nil) }
     end
   end
 

--- a/spec/indexers/work_indexer_spec.rb
+++ b/spec/indexers/work_indexer_spec.rb
@@ -46,7 +46,7 @@ describe WorkIndexer do
     end
 
     describe 'a groomed document' do
-      before { work.creators.build(given_name: 'BIG.', sur_name: 'Name') }
+      before { work.creators.build(display_name: 'BIG. Name') }
 
       it { is_expected.to include('creator_name_sim' => ['Big Name']) }
       it { is_expected.to include('creator_name_tesim' => ['BIG. Name']) }
@@ -55,7 +55,7 @@ describe WorkIndexer do
     end
 
     describe 'creator missing fields' do
-      before { work.creators.build(given_name: 'John', sur_name: '') }
+      before { work.creators.build(display_name: 'John') }
       it { is_expected.to include('creator_name_sim' => ['John']) }
       it { is_expected.to include('creator_name_tesim' => ['John']) }
     end

--- a/spec/models/alias_spec.rb
+++ b/spec/models/alias_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Alias do
+  describe '#display_name' do
+    subject { build(:alias, display_name: 'Some Name') }
+
+    its(:display_name) { is_expected.to eq('Some Name') }
+  end
+
+  describe '#person' do
+    let(:person) { create(:person) }
+    let(:aliaz)  { create(:alias, display_name: 'The Real Joe Schmoe', person: person) }
+
+    it 'links to the person' do
+      expect(aliaz.person.id).to eq(person.id)
+      expect(person.aliases).to contain_exactly(aliaz)
+    end
+  end
+end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -6,27 +6,23 @@ describe Collection do
   subject { collection }
 
   describe 'setting creators' do
-    before { Person.destroy_all }
+    let!(:person) { create(:person, given_name: 'Lucy', sur_name: 'Lee') }
+    let!(:lucy)   { create(:alias, display_name: 'Lucy Lee', person: person) }
 
-    let(:collection) do
-      described_class.new do |c|
-        c.title = ['asdf']
-        c.apply_depositor_metadata('asdf')
-      end
+    let(:collection) { create(:collection, creators: attributes) }
+    let(:attributes) do
+      [
+        { 'display_name' => 'Fred Jones', 'given_name' => 'Fred', 'sur_name' => 'Jones' },
+        { 'display_name' => 'Lucy Lee', 'given_name' => 'Lucy', 'sur_name' => 'Lee' }
+      ]
     end
 
-    # Record for Lucy already exists
-    let!(:lucy) { create(:person, given_name: 'Lucy', sur_name: 'Lee') }
-    let(:fred_attrs) { { given_name: 'Fred', sur_name: 'Jones' } }
-
-    it 'finds or creates the Person records' do
-      expect do
-        collection.creators = [lucy, fred_attrs]
-        collection.save!
-      end.to change { Person.count }.by(1)
-
+    it 'finds or creates the Alias record' do
+      expect { collection.save! }
+        .to change { described_class.count }.by(1)
+        .and change { Alias.count }.by(1)
       expect(collection.creators).to include lucy
-      expect(collection.creators.map(&:given_name)).to contain_exactly('Fred', 'Lucy')
+      expect(collection.creators.map(&:display_name)).to contain_exactly('Fred Jones', 'Lucy Lee')
     end
   end
 

--- a/spec/models/generic_work_spec.rb
+++ b/spec/models/generic_work_spec.rb
@@ -35,7 +35,7 @@ describe GenericWork do
       let(:work) { build(:work) }
 
       it 'creates an Alias record' do
-        work.creators.build(display_name: 'Frodo')
+        work.creators.build(display_name: 'Frodo', person: Person.new(given_name: 'Frodo', sur_name: 'Baggins'))
         expect { work.save! }
           .to change { described_class.count }.by(1)
           .and change { Alias.count }.by(1)

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -3,40 +3,19 @@
 require 'rails_helper'
 
 describe Person do
-  describe '::find_or_create' do
-    subject(:person) { described_class.find_or_create(attrs) }
+  subject { build(:person, given_name: 'Given Name', sur_name: 'Sur Name', aliases: [aliaz]) }
 
-    before { described_class.destroy_all }
+  let(:aliaz) { build(:alias) }
 
-    let!(:joe_jones) { create(:person, given_name: 'Joe', sur_name: 'Jones') }
-    let!(:joe_smith) { create(:person, given_name: 'Joe', sur_name: 'Smith') }
+  describe '#given_name' do
+    its(:given_name) { is_expected.to eq('Given Name') }
+  end
 
-    context 'with an ID that matches an existing record' do
-      let!(:attrs) { { id: joe_jones.id, given_name: 'something' } }
+  describe '#sur_name' do
+    its(:sur_name) { is_expected.to eq('Sur Name') }
+  end
 
-      it 'finds the existing record' do
-        expect { person }.to change { described_class.count }.by(0)
-        expect(person).to eq joe_jones
-      end
-    end
-
-    context 'with no ID, but attributes match an existing record' do
-      let!(:attrs) { { given_name: joe_jones.given_name, sur_name: joe_jones.sur_name } }
-
-      it 'finds the existing record' do
-        expect { person }.to change { described_class.count }.by(0)
-        expect(person).to eq joe_jones
-      end
-    end
-
-    context 'attributes dont match any existing record' do
-      let!(:attrs) { { given_name: joe_jones.given_name, sur_name: 'Something Else' } }
-
-      it 'creates a new Person record' do
-        expect { person }.to change { described_class.count }.by(1)
-        expect(person.given_name).to eq 'Joe'
-        expect(person.sur_name).to eq 'Something Else'
-      end
-    end
+  describe '#aliases' do
+    its(:aliases) { is_expected.to contain_exactly(aliaz) }
   end
 end

--- a/spec/presenters/work_show_presenter_spec.rb
+++ b/spec/presenters/work_show_presenter_spec.rb
@@ -64,7 +64,7 @@ describe WorkShowPresenter do
     subject { presenter.facet_mapping(:creator_name) }
 
     let(:work) { build :work }
-    let!(:joe) { work.creators.build(given_name: 'JOE', sur_name: 'SMITH') }
+    let!(:joe) { work.creators.build(display_name: 'JOE SMITH') }
 
     it { is_expected.to eq('JOE SMITH' => 'Joe Smith') }
   end

--- a/spec/services/alias_management_service_spec.rb
+++ b/spec/services/alias_management_service_spec.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe AliasManagementService do
+  let(:service) { described_class.call(attributes) }
+  let(:person) { create(:person, given_name: 'Johnny', sur_name: 'Depp') }
+  let(:missing_person) { I18n.t('scholarsphere.aliases.person_error') }
+  let(:missing_parameter) { I18n.t('scholarsphere.aliases.parameter_error') }
+
+  context 'with missing attributes' do
+    let(:attributes) { {} }
+
+    it 'raises an error' do
+      expect { service }.to raise_error(AliasManagementService::Error, missing_parameter)
+    end
+  end
+
+  context 'when an alias has no person' do
+    let(:alias_without_person) { create(:alias, display_name: 'No Name') }
+
+    context 'using the alias resource' do
+      let(:attributes) { alias_without_person }
+
+      it 'raises an error' do
+        expect { service }.to raise_error(AliasManagementService::Error, missing_person)
+      end
+    end
+
+    context 'using the the id of the alias' do
+      let(:attributes) { { id: alias_without_person.id } }
+
+      it 'raises an error' do
+        expect { service }.to raise_error(AliasManagementService::Error, missing_person)
+      end
+    end
+
+    context 'using the the display name of the alias' do
+      let(:attributes) { { display_name: alias_without_person.display_name } }
+
+      it 'raises an error' do
+        expect { service }.to raise_error(AliasManagementService::Error, missing_person)
+      end
+    end
+  end
+
+  context 'when the alias has a person' do
+    let!(:alias_with_person) { create(:alias, display_name: 'Don Juan', person: person) }
+
+    context 'using the alias resource' do
+      let(:attributes) { alias_with_person }
+
+      it 'returns the alias' do
+        expect { service }.to change { Alias.count }.by(0)
+        expect(service.display_name).to eq('Don Juan')
+      end
+    end
+
+    context 'using the the id of the alias' do
+      let(:attributes) { { id: alias_with_person.id } }
+
+      it 'returns the alias' do
+        expect { service }.to change { Alias.count }.by(0)
+        expect(service.display_name).to eq('Don Juan')
+      end
+    end
+
+    context 'using the the display name of the alias' do
+      let(:attributes) { { display_name: alias_with_person.display_name } }
+
+      it 'returns the alias' do
+        expect { service }.to change { Alias.count }.by(0)
+        expect(service.display_name).to eq('Don Juan')
+      end
+    end
+  end
+
+  context 'when the person exists but the alias does not' do
+    before { Alias.destroy_all }
+
+    context 'with all the required parameters' do
+      let(:attributes) { { display_name: 'Capt. Jack Sparrow', given_name: 'Johnny', sur_name: 'Depp' } }
+
+      it 'returns a new alias for the person' do
+        expect { service }.to change { Alias.count }.by(1).and change { Person.count }.by(0)
+        expect(service.display_name).to eq('Capt. Jack Sparrow')
+      end
+    end
+
+    context 'with a missing given name' do
+      let(:attributes) { { display_name: 'Capt. Jack Sparrow', sur_name: 'Depp' } }
+
+      it 'raises an error' do
+        expect { service }.to raise_error(AliasManagementService::Error, missing_parameter)
+      end
+    end
+
+    context 'with a missing surname' do
+      let(:attributes) { { display_name: 'Capt. Jack Sparrow', given_name: 'Johnny' } }
+
+      it 'raises an error' do
+        expect { service }.to raise_error(AliasManagementService::Error, missing_parameter)
+      end
+    end
+
+    context 'with a missing display name' do
+      let(:attributes) { { given_name: 'Johnny', sur_name: 'Depp' } }
+
+      it 'raises an error' do
+        expect { service }.to raise_error(AliasManagementService::Error, missing_parameter)
+      end
+    end
+  end
+
+  context 'when neither alias nor person exist' do
+    before { Alias.destroy_all && Person.destroy_all }
+
+    context 'with all the required parameters' do
+      let(:attributes) { { display_name: 'Commodore Barbarossa', given_name: 'Geoffrey', sur_name: 'Rush' } }
+
+      it 'returns a new alias linked to a new person' do
+        expect { service }.to change { Alias.count }.by(1).and change { Person.count }.by(1)
+        expect(service.display_name).to eq('Commodore Barbarossa')
+      end
+    end
+
+    context 'with a missing given name' do
+      let(:attributes) { { display_name: 'Commodore Barbarossa', sur_name: 'Rush' } }
+
+      it 'raises an error' do
+        expect { service }.to raise_error(AliasManagementService::Error, missing_parameter)
+      end
+    end
+
+    context 'with a missing surname' do
+      let(:attributes) { { display_name: 'Commodore Barbarossa', given_name: 'Geoffrey' } }
+
+      it 'raises an error' do
+        expect { service }.to raise_error(AliasManagementService::Error, missing_parameter)
+      end
+    end
+
+    context 'with a missing display name' do
+      let(:attributes) { { given_name: 'Geoffrey', sur_name: 'Rush' } }
+
+      it 'raises an error' do
+        expect { service }.to raise_error(AliasManagementService::Error, missing_parameter)
+      end
+    end
+  end
+end

--- a/spec/services/generic_work_to_share_json_service_spec.rb
+++ b/spec/services/generic_work_to_share_json_service_spec.rb
@@ -4,8 +4,8 @@ require 'rails_helper'
 
 describe GenericWorkToShareJSONService do
   let(:name_service) { double }
-
-  let(:creator) { FactoryGirl.create(:person, sur_name: 'Santy', given_name: 'Lorraine C') }
+  let(:person) { create(:person, sur_name: 'Santy', given_name: 'Lorraine C') }
+  let(:creator) { create(:alias, display_name: creator_name, person: person) }
   let(:creator_name) { 'Santy, Lorraine C' }
 
   before do
@@ -50,7 +50,8 @@ describe GenericWorkToShareJSONService do
     let(:date_uploaded) { '2015-07-30T20:15:08Z' }
 
     context 'when the creator exists in ldap' do
-      let(:creator) { FactoryGirl.create(:person, sur_name: 'Cole', given_name: 'Carolyn Ann') }
+      let(:person) { create(:person, sur_name: 'Cole', given_name: 'Carolyn Ann') }
+      let(:creator) { create(:alias, person: person) }
       let(:creator_name) { 'Cole, Carolyn Ann' }
       let(:creator_email) { 'cam156@psu.edu' }
 
@@ -75,7 +76,8 @@ describe GenericWorkToShareJSONService do
     context 'when deleting the file' do
       subject { JSON.parse(described_class.new(file, delete: true).json) }
 
-      let(:creator) { FactoryGirl.create(:person, sur_name: 'Guy', given_name: 'Bad') }
+      let(:person) { create(:person, sur_name: 'Guy', given_name: 'Bad') }
+      let(:creator) { create(:alias, display_name: creator_name, person: person) }
       let(:creator_name) { 'Guy, Bad' }
       let(:creator_email) { 'badguy@trouble.com' }
 

--- a/spec/services/solr_document_groomer_spec.rb
+++ b/spec/services/solr_document_groomer_spec.rb
@@ -3,8 +3,8 @@
 require 'rails_helper'
 
 describe SolrDocumentGroomer do
-  let(:legend)   { create(:creator, given_name: 'I AM', sur_name: 'LEGEND') }
-  let(:will)     { create(:creator, given_name: 'Will I.', sur_name: 'Am') }
+  let(:legend)   { create(:alias, :with_person, display_name: 'I AM LEGEND') }
+  let(:will)     { create(:alias, :with_person, display_name: 'Will I. Am') }
 
   let(:work)     { create(:work, creators: [legend, will], keyword: ['CAPITAL', 'Title.']) }
   let(:document) { SolrDocument.new(work.to_solr) }


### PR DESCRIPTION
This makes two main changes: 1) Creates an Alias resource that stands between a work and its creator; and 2) orders aliases using a membership predicate.

Previously, a work would contain one or more Person objects as creators. In order to allow for different names for the same canonical person, an Alias class holds a display name and a reference to a single canonical user. The `AliasManagementService` is responsible for finding or creating persons and aliases to attach to new or existing works.

Forms for works can now accept either new creators or edit existing ones. When new creators are added, both aliases and persons are created as needed, via the `AliasManagementService`, or if display names are changed, new aliases are added to the existing person, also via the `AliasManagementService`.