### PR TITLE
Collection and Work migration

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -92,6 +92,7 @@ RSpec/NestedGroups:
     - 'spec/models/user_spec.rb'
     - 'spec/rake/scholarsphere/solr_spec.rb'
     - 'spec/views/curations_concerns/base/_items.html.erb_spec.rb'
+    - 'spec/models/migration/creator_list_spec.rb'
 
 # Offense count: 5
 RSpec/ScatteredLet:

--- a/app/models/migration/creator_list.rb
+++ b/app/models/migration/creator_list.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+module Migration
+  class CreatorList
+    attr_reader :uniq_system_creators, :creator_alias_cache
+    def initialize(creator_alias_cache = 'tmp/creator_alias_cache.json')
+      @creator_alias_cache = creator_alias_cache
+      @uniq_system_creators = find_uniq_system_creators
+    end
+
+    def to_alias_hash
+      @agents ||= convert_to_aliases
+    end
+
+    private
+
+      def find_uniq_system_creators
+        creator_facet_resp = ActiveFedora::SolrService.instance.conn.get 'select', params: { rows: 0, 'facet.limit' => 10000, 'facet.field' => 'creator_sim' }
+        creator_facet_resp['facet_counts']['facet_fields']['creator_sim'].select { |creator_or_count| creator_or_count.class == String }.reject { |name_or_url| name_or_url.starts_with?('Http') }
+      end
+
+      def convert_to_aliases
+        aliases = load_cache
+        @uniq_system_creators.map do |creator|
+          next if aliases.key?(creator)
+          aliases[creator] = creator_to_alias(creator)
+        end
+        store_cache(aliases)
+        aliases
+      end
+
+      def load_cache
+        return {} unless File.exist?(creator_alias_cache)
+
+        aliases = {}
+        file = File.open(creator_alias_cache)
+        lines = file.readlines
+        lines.each do |line|
+          creator, alias_id = line.strip.split(cache_separator)
+          aliases[creator] = Alias.find(alias_id)
+        end
+        aliases
+      end
+
+      def store_cache(aliases)
+        file = File.new(creator_alias_cache, 'w')
+        aliases.each_pair do |current_creator, current_alias|
+          file.puts("#{current_creator}#{cache_separator}#{current_alias.id}")
+        end
+        file.close
+        aliases
+      end
+
+      def creator_to_alias(creator)
+        users = LocalUserLookup.find_users(creator)
+        if users.count == 1
+          user = users[0]
+          # validate creator against user
+          # todo Not really sure what to do here
+          # logger.warn("Matching #{creator} with #{user.display_name} #{user.login}")
+          #
+          # user_to_alias(user, creator)
+          if validate_user(creator, user)
+            logger.warn("Matching #{creator} with #{user.display_name} #{user.login}")
+            user_to_alias(user, creator)
+          else
+            logger.warn("No match #{creator} with #{user.display_name} #{user.login} did not validate.  Creating new agent")
+            name_to_alias(creator)
+          end
+        else
+          name_to_alias(creator)
+        end
+      end
+
+      def validate_user(creator, user)
+        # id match is valid
+        return true if creator == user.login
+
+        logger.warn("Matching #{creator} with #{user.display_name} #{user.login}")
+        user_name = parse_name(user.display_name)
+        creator_name = parse_name(creator)
+        user_name.family.downcase!
+        creator_name.family.downcase!
+
+        # family name match is valid
+        return true if user_name.family == creator_name.family
+
+        comparable_name(creator) == comparable_name(user.display_name)
+      end
+
+      def comparable_name(name)
+        name_parts = name.downcase.gsub(',', ' ').squeeze(' ').split(' ')
+        comparable = Hash.new(0)
+        name_parts.each { |v| comparable[v] += 1 }
+        comparable
+      end
+
+      def name_to_alias(full_name)
+        name = parse_name(full_name)
+        AliasManagementService.call(display_name: full_name, given_name: name.given, sur_name: name.family)
+      end
+
+      def parse_name(full_name)
+        name = Namae::Name.parse(full_name)
+        if name.given.blank? || name.family.blank?
+          name.family = full_name
+          name.given = nil
+        end
+        name
+      end
+
+      def user_to_alias(user, creator)
+        agent = Agent.where(psu_id: user.login).first
+        if agent.blank?
+          name = parse_name(user.display_name)
+          agent = Agent.create(given_name: name.given, sur_name: name.family, psu_id: user.login, email: user.email)
+        end
+        Alias.create(display_name: creator, agent: agent)
+      end
+
+      def cache_separator
+        '$$'
+      end
+  end
+end

--- a/app/models/migration/creator_migrator.rb
+++ b/app/models/migration/creator_migrator.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Migration
+  class CreatorMigrator
+    class << self
+       def run(alias_cache_file = 'tmp/creator_alias_cache.json')
+         creator_list = Migration::CreatorList.new(alias_cache_file)
+         alias_hash = creator_list.to_alias_hash
+         Migration::SolrListMigrator.migrate_creators(Migration::SolrWorkList.new, alias_hash)
+         Migration::SolrListMigrator.migrate_creators(Migration::SolrCollectionList.new, alias_hash)
+       end
+    end
+  end
+end

--- a/app/models/migration/local_user_lookup.rb
+++ b/app/models/migration/local_user_lookup.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Migration
+  class LocalUserLookup
+    class << self
+      def find_users(user_name)
+        user = user_by_id(user_name)
+        return [user] if user.present?
+
+        query_parts = name_to_query_parts(user_name)
+        query = name_query(query_parts.count)
+        User.where(query, *query_parts)
+      end
+
+      private
+
+        def user_by_id(id)
+          User.find_by(login: id)
+        end
+
+        def name_to_query_parts(name)
+          name_to_parts(name).map do |part|
+            "%#{handle_initial(part)}%"
+          end
+        end
+
+        def name_query(query_parts_count)
+          Array.new(query_parts_count, 'UPPER(display_name) like ?')
+            .join(' AND ')
+        end
+
+        def name_to_parts(name)
+          name.split(' ').map(&:upcase)
+        end
+
+        def handle_initial(part)
+          return part if part.length > 1
+          " #{part}"
+        end
+      end
+  end
+end

--- a/app/models/migration/solr_collection_list.rb
+++ b/app/models/migration/solr_collection_list.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Migration
+  class SolrCollectionList < SolrObjectList
+    alias_method :collections, :objects
+
+    def initialize
+      super(Collection)
+    end
+  end
+end

--- a/app/models/migration/solr_list_migrator.rb
+++ b/app/models/migration/solr_list_migrator.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module Migration
+  class SolrListMigrator
+    class << self
+      def migrate_creators(solr_object_list, creator_alias_hash)
+        solr_object_list.each_with_load do |object|
+          update(object, creator_alias_hash)
+        end
+      end
+
+      def update(object, creator_alias_hash)
+        return if object.creator_ids.empty?
+        return if already_migrated?(object)
+
+        update_creators(object, creator_alias_hash)
+      end
+
+      private
+
+        def already_migrated?(object)
+          object.creator_ids[0].match(/^[0-9A-F]{8}-[0-9A-F]{4}/i)
+        end
+
+        def update_creators(object, creator_alias_hash)
+          creators = translate_creators(object.creator_ids, creator_alias_hash)
+          object = clear_creators(object)
+          object.creators = creators
+          object.save
+        end
+
+        def translate_creators(creators, creator_alias_hash)
+          alias_list = []
+          creators.each do |creator|
+            creator_alias = lookup_creator(creator, creator_alias_hash)
+            if creator_alias.blank?
+              logger.error "Creator alias could not be found for #{creator}"
+            else
+              alias_list << creator_alias
+            end
+          end
+          alias_list
+        end
+
+        def lookup_creator(creator, creator_alias_hash)
+          clean_creator = creator.strip.squeeze(' ')
+          creator_alias = creator_alias_hash[clean_creator]
+          return creator_alias if creator_alias.present?
+
+          cleaner_creator = clean_creator.gsub(',', '')
+          creator_alias_hash[cleaner_creator]
+        end
+
+        def clear_creators(object)
+          creator_uri = RDF::URI.new('http://purl.org/dc/elements/1.1/creator')
+          update_uri = object.uri.to_s
+          ActiveFedora::SparqlInsert.new(creator_uri => RDF::Graph.new).execute(update_uri)
+          object.reload
+        end
+    end
+  end
+end

--- a/app/models/migration/solr_object_list.rb
+++ b/app/models/migration/solr_object_list.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Migration
+  class SolrObjectList
+    attr_reader :objects, :object_class
+
+    def initialize(object_class)
+      @object_class = object_class
+      @objects = ActiveFedora::SolrService.query(filter, fl: 'id,depositor_tesim', rows: 1000).map(&:id)
+    end
+
+    def each_with_load
+      objects.each do |id|
+        begin
+          yield(load_object(id))
+        rescue ActiveFedora::ObjectNotFoundError => error
+          logger.warn "error finding object to migrate: #{id}; #{error}"
+        end
+      end
+    end
+
+    private
+
+      def filter
+        "has_model_ssim:#{object_class}"
+      end
+
+      def load_object(id)
+        object_class.find(id)
+      end
+  end
+end

--- a/app/models/migration/solr_work_list.rb
+++ b/app/models/migration/solr_work_list.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Migration
+  class SolrWorkList < SolrObjectList
+    alias_method :works, :objects
+
+    def initialize
+      super(GenericWork)
+    end
+  end
+end

--- a/spec/features/migration_spec.rb
+++ b/spec/features/migration_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'feature_spec_helper'
+
+describe 'Migration', type: :feature do
+  let(:collection) { build :collection, id: 'collection_123abc' }
+  let(:collection2) { create :collection, title: ['new format'] }
+  let(:collection_creator) { 'Collection Creator' }
+  let(:work) { build :work, id: 'work_123abc' }
+  let(:work2) { create :work, title: ['new format'] }
+  let(:work_creator) { 'Work Creator' }
+  let(:cache_file) { 'tmp/migrator_cach.txt' }
+  let(:sparql_insert) { instance_double(ActiveFedora::SparqlInsert) }
+
+  before do
+    # need to allow some calls to fedora to go through normally because we are faking the old records
+    allow(Collection).to receive(:find).and_call_original
+    allow(GenericWork).to receive(:find).and_call_original
+    collection2
+    work2
+
+    save_collection_to_solr(collection, collection_creator)
+    save_work_to_solr_and_fake_fedora(work, work_creator)
+    allow(collection).to receive(:creator_ids).and_return([collection_creator])
+    allow(ActiveFedora::SparqlInsert).to receive(:new).and_return(sparql_insert)
+    allow(sparql_insert).to receive(:execute)
+  end
+
+  after do
+    ActiveFedora::Cleaner.cleanout_solr
+    FileUtils.rm_f(cache_file)
+  end
+
+  describe '#run' do
+    subject(:migrator) { Migration::CreatorMigrator.run(cache_file) }
+
+    it 'Calls runs the migration' do
+      expect { migrator }.to change { Alias.count }.by(2).and change { Agent.count }.by(2)
+    end
+  end
+end

--- a/spec/models/migration/creator_list_spec.rb
+++ b/spec/models/migration/creator_list_spec.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Migration::CreatorList do
+  let(:work) { build :work, id: '123abc' }
+  let(:work2) { build :work, id: '567abc' }
+  let(:work3) { build :work, id: '999abc' }
+  let(:conn) { ActiveFedora::SolrService.instance.conn }
+
+  describe '#uniq_system_creators' do
+    before do
+      save_work_to_solr_and_fake_fedora(work, 'abc for me')
+      save_work_to_solr_and_fake_fedora(work2, 'abc for me')
+      save_work_to_solr_and_fake_fedora(work3, 'abc for me too')
+    end
+    after do
+      conn.delete_by_id work.id
+      conn.delete_by_id work2.id
+      conn.delete_by_id work3.id
+      conn.commit
+    end
+
+    subject { described_class.new.uniq_system_creators }
+
+    it { is_expected.to eq ['abc for me', 'abc for me too'] }
+  end
+
+  describe '#to_alias_hash' do
+    subject(:creator_list) { described_class.new(cache_name).to_alias_hash }
+
+    let(:user) { create :user, display_name: 'Frog, Kermit The' }
+    let(:work4) { build :work, id: '999zzz' }
+    let(:work5) { build :work, id: '999idid' }
+    let(:cache_name) { 'tmp/test_cache.txt' }
+    let(:agent1) { Agent.new(sur_name: 'blarg institution for the insane') }
+    let(:alias1) { Alias.new(id: 'alias1', display_name: 'blarg institution for the insane', agent: agent1) }
+    let(:agent2) { Agent.new(sur_name: 'Frog', given_name: 'Kermit The') }
+    let(:alias2) { Alias.new(id: 'alias2', display_name: 'Kermit The Frog', agent: agent2) }
+    let(:alias3) { Alias.new(id: 'alias3', display_name: 'Kermit The Frog', agent: agent2) }
+
+    before do
+      user
+      allow(Agent).to receive(:create).with(sur_name: 'blarg institution for the insane', given_name: nil).and_return(agent1)
+      allow(Agent).to receive(:create).with(sur_name: 'Frog', given_name: 'Kermit The', psu_id: user.login, email: user.email).and_return(agent2)
+      allow(Alias).to receive(:create).with(display_name: 'blarg institution for the insane', agent: agent1).and_return(alias1)
+      allow(Alias).to receive(:create).with(display_name: 'Kermit The Frog', agent: agent2).and_return(alias2)
+      allow(Alias).to receive(:create).with(display_name: user.login, agent: agent2).and_return(alias3)
+      save_work_to_solr_and_fake_fedora(work, 'blarg institution for the insane')
+      save_work_to_solr_and_fake_fedora(work4, 'Kermit The Frog')
+      save_work_to_solr_and_fake_fedora(work5, user.login)
+    end
+    after do
+      ActiveFedora::Cleaner.cleanout_solr
+      FileUtils.rm_f(cache_name)
+    end
+
+    it { is_expected.to eq('blarg institution for the insane' => alias1,
+                           user.login => alias3,
+                           'Kermit The Frog' => alias2) }
+
+    it 'creates a cache and loads it' do
+      creator_list
+      expect(File.exist?(cache_name)).to be_truthy
+      expect(Alias).to receive(:find).with(alias1.id).and_return(alias1)
+      expect(Alias).to receive(:find).with(alias2.id).and_return(alias2)
+      expect(Alias).to receive(:find).with(alias3.id).and_return(alias3)
+      expect(Migration::LocalUserLookup).not_to receive(:find_users)
+      described_class.new(cache_name).to_alias_hash
+    end
+
+    context 'test a Agent' do
+      let(:work_test) { build :work, id: '999testAgent' }
+      let(:agent_test) { Agent.new(sur_name: sur_name, given_name: given_name) }
+      let(:alias_test) { Alias.new(id: 'alias_test', display_name: display_name, agent: agent_test) }
+
+      before do
+        allow(Agent).to receive(:create).with(sur_name: sur_name, given_name: given_name).and_return(agent_test)
+        allow(Alias).to receive(:create).with(display_name: display_name, agent: agent_test).and_return(alias_test)
+        save_work_to_solr_and_fake_fedora(work_test, display_name)
+      end
+
+      context 'display name is a partial name match' do
+        let(:sur_name) { 'og' }
+        let(:given_name) {}
+        let(:display_name) { sur_name }
+
+        it { is_expected.to eq('blarg institution for the insane' => alias1,
+                               user.login => alias3,
+                               'Kermit The Frog' => alias2,
+                               display_name => alias_test) }
+      end
+
+      context 'display name is a backward name match' do
+        let(:sur_name) { 'Kermit the' }
+        let(:given_name) { 'Frog' }
+        let(:display_name) { 'Frog Kermit the' }
+
+        before do
+          allow(Alias).to receive(:create).with(display_name: display_name, agent: agent2).and_return(alias_test)
+        end
+
+        it { is_expected.to eq('blarg institution for the insane' => alias1,
+                               user.login => alias3,
+                               'Kermit The Frog' => alias2,
+                               display_name => alias_test) }
+      end
+    end
+  end
+
+  context 'alias with institution' do
+    subject(:creator_list) { described_class.new(cache_name).to_alias_hash }
+
+    let(:work) { build :work, id: '999maps' }
+    let(:agent) { Agent.new(sur_name: 'blarg institution for the insane') }
+    let(:agent_alias) { Alias.new(id: 'alias1', display_name: 'blarg institution for the insane', agent: agent) }
+    let(:cache_name) { 'tmp/test_cache.txt' }
+
+    before do
+      allow(Agent).to receive(:create).with(sur_name: 'maps', given_name: nil).and_return(agent)
+      allow(Alias).to receive(:create).with(display_name: 'maps', agent: agent).and_return(agent_alias)
+      save_work_to_solr_and_fake_fedora(work, 'maps')
+    end
+    after do
+      ActiveFedora::Cleaner.cleanout_solr
+      FileUtils.rm_f(cache_name)
+    end
+
+    it { is_expected.to eq('maps' => agent_alias) }
+  end
+end

--- a/spec/models/migration/creator_migrator_spec.rb
+++ b/spec/models/migration/creator_migrator_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Migration::CreatorMigrator do
+  let(:collection) { build :collection, id: 'collection_123abc' }
+  let(:collection_creator) { 'Collection Creator' }
+  let(:work) { build :work, id: 'work_123abc' }
+  let(:work_creator) { 'Work Creator' }
+  let(:cache_file) { 'tmp/migrator_cach.txt' }
+  let(:sparql_insert) { instance_double(ActiveFedora::SparqlInsert) }
+
+  before do
+    save_collection_to_solr(collection, collection_creator)
+    save_work_to_solr_and_fake_fedora(work, work_creator)
+    allow(ActiveFedora::SparqlInsert).to receive(:new).and_return(sparql_insert)
+    allow(sparql_insert).to receive(:execute)
+  end
+
+  after do
+    ActiveFedora::Cleaner.cleanout_solr
+    FileUtils.rm_f(cache_file)
+  end
+
+  describe '#run' do
+    subject(:migrator) { described_class.run(cache_file) }
+
+    it 'Calls runs the migration' do
+      expect { migrator }.to change { Alias.count }.by(2).and change { Agent.count }.by(2)
+    end
+  end
+end

--- a/spec/models/migration/local_user_lookup_spec.rb
+++ b/spec/models/migration/local_user_lookup_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Migration::LocalUserLookup, type: :model do
+  subject { described_class.find_users(search_name).map(&:display_name) }
+
+  before do
+    User.create!(login: 'abc@psu.edu', display_name: 'Abc 123')
+    User.create!(login: 'abc2@psu.edu', display_name: 'Abc two 123')
+    User.create!(login: 'kermit@pong.log', display_name: 'Kermit The Frog')
+  end
+
+  let(:search_name) { 'abc' }
+
+  it { is_expected.to contain_exactly('Abc 123', 'Abc two 123') }
+
+  context 'multiple name parts' do
+    let(:search_name) { 'abc 123' }
+
+    it { is_expected.to contain_exactly('Abc 123', 'Abc two 123') }
+
+    context 'with an initial' do
+      let(:search_name) { 'abc t 123' }
+
+      it { is_expected.to contain_exactly('Abc two 123') }
+    end
+
+    context 'with a different initial' do
+      let(:search_name) { 'abc b 123' }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'with the name mixed around' do
+      let(:search_name) { '123 abc t' }
+
+      it { is_expected.to contain_exactly('Abc two 123') }
+    end
+  end
+end

--- a/spec/models/migration/solr_collection_list_spec.rb
+++ b/spec/models/migration/solr_collection_list_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Migration::SolrCollectionList, clean: true do
+  subject { described_class.new.objects }
+
+  let(:collection)  { build :collection, id: '123abc' }
+  let(:collection2) { build :collection, id: '567abc' }
+  let(:collection3) { build :collection, id: '999abc' }
+  let(:conn) { ActiveFedora::SolrService.instance.conn }
+
+  before do
+    save_collection_to_solr(collection, 'abc for me')
+    save_collection_to_solr(collection2, 'abc for me')
+    save_collection_to_solr(collection3, 'abc for me too')
+  end
+  after do
+    ActiveFedora::Cleaner.cleanout_solr
+  end
+
+  it { is_expected.to contain_exactly(collection.id, collection2.id, collection3.id) }
+end

--- a/spec/models/migration/solr_list_migrator_spec.rb
+++ b/spec/models/migration/solr_list_migrator_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Migration::SolrListMigrator do
+  let(:work1) { build :work, id: '123abc' }
+  let(:work2) { build :work, id: '567abc' }
+  let(:work3) { build :work, id: '999abc' }
+  let(:conn) { ActiveFedora::SolrService.instance.conn }
+
+  let(:creator1) { 'Bugs Bunny' }
+  let(:creator2) { 'Bunny, Bugs' }
+  let(:creator3) { 'Tweey E Bird' }
+  let(:alias_hash) { Migration::CreatorList.new(cache_name).to_alias_hash }
+  let(:sparql_insert) { instance_double(ActiveFedora::SparqlInsert) }
+
+  before do
+    allow(ActiveFedora::SparqlInsert).to receive(:new).and_return(sparql_insert)
+    allow(sparql_insert).to receive(:execute)
+  end
+
+  describe '#uniq_system_creators' do
+    before do
+      save_work_to_solr_and_fake_fedora(work1, creator1)
+      save_work_to_solr_and_fake_fedora(work2, creator2)
+      save_work_to_solr_and_fake_fedora(work3, creator3)
+    end
+    after do
+      ActiveFedora::Cleaner.cleanout_solr
+      FileUtils.rm_f(cache_name)
+    end
+
+    subject(:migrator) { described_class.migrate_creators(Migration::SolrWorkList.new, alias_hash) }
+
+    let(:cache_name) { 'tmp/my_cahce' }
+
+    it 'is expected to migrate Aliases' do
+      migrator
+      expect(work1.creator).to contain_exactly(alias_hash[creator1])
+      expect(work2.creator).to contain_exactly(alias_hash[creator2])
+      expect(work3.creator).to contain_exactly(alias_hash[creator3])
+    end
+  end
+end

--- a/spec/models/migration/solr_work_list_spec.rb
+++ b/spec/models/migration/solr_work_list_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Migration::SolrWorkList, clean: true do
+  subject { described_class.new.works }
+
+  let(:work)  { build :work, id: '123abc' }
+  let(:work2) { build :work, id: '567abc' }
+  let(:work3) { build :work, id: '999abc' }
+  let(:conn)  { ActiveFedora::SolrService.instance.conn }
+  let(:creator) { 'abc for me' }
+
+  before do
+    save_work_to_solr_and_fake_fedora(work, 'abc for me')
+    save_work_to_solr_and_fake_fedora(work2, 'abc for me')
+    save_work_to_solr_and_fake_fedora(work3, 'abc for me too')
+  end
+  after do
+    ActiveFedora::Cleaner.cleanout_solr
+  end
+  it { is_expected.to contain_exactly(work.id, work2.id, work3.id) }
+
+  it 'translates to object during each' do
+    described_class.new.each_with_load { |item| expect(item.class).to eq(GenericWork) }
+  end
+end

--- a/spec/support/helpers/solr_objects.rb
+++ b/spec/support/helpers/solr_objects.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+def conn
+  ActiveFedora::SolrService.instance.conn
+end
+
+def save_collection_to_solr(collection, creator)
+  allow(Collection).to receive(:find).with(collection.id).and_return(collection)
+  allow(collection).to receive(:creator_ids).and_return([creator])
+  hash = collection.to_solr
+  hash['creator_sim'] = creator
+  conn.add hash
+  conn.commit
+end
+
+def save_work_to_solr_and_fake_fedora(work, creator)
+  allow(GenericWork).to receive(:find).with(work.id).and_return(work)
+  allow(work).to receive(:creator_ids).and_return([creator])
+  allow(work).to receive(:reload).and_return(work)
+  hash = work.to_solr
+  hash['creator_sim'] = creator
+  conn.add hash
+  conn.commit
+end


### PR DESCRIPTION
I putting this out for comment early.  The work is not complete, but I want to be certain I have broken things up in a logical fashion.  (not just logical to me)

The CreatorMigrator is the main class that calls all the rest to migrate the creators for both Collections and Works.

The SolrListMigrator and the CreatorList are still only partially implemented since we do not have the Alias PR merged.  The CreatorList will convert all the creator Strings to Aliases using the AliasManagementService once that is included into develop.  The SolrListMigrator will use the new Aliases to convert the string creators currently in the system for each object to pointers to Aliases. 

LocalUserLookup is a helper class to identify creators as local users to link or create them with the PSU login information.

SolrObjectlist, SolrWorkList and SolrCollectionList loads all the object ids from solr and then loads each item from fedora as we iterate through the ids.  The idea is to save on memory since Collection.all or GenericWork.all loads all objects into memory when only one is needed at a time.