### PR TITLE
Adding error handeling for missing or deleted objects

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -24,6 +24,9 @@ Lint/UnifiedInteger:
 Metrics/BlockLength:
   Max: 226
 
+Metrics/ClassLength:
+  Max: 112
+
 # Offense count: 38
 RSpec/AnyInstance:
   Exclude:

--- a/spec/services/download_report_spec.rb
+++ b/spec/services/download_report_spec.rb
@@ -39,6 +39,7 @@ describe GoogleAnalytics::DownloadReport do
        OpenStruct.new(eventCategory: 'Files', eventAction: 'Downloaded', eventLabel: '(not set)', date: '20170817', pagePath: '/downloads/3xs55m950', totalEvents: '1'),
        OpenStruct.new(eventCategory: 'Files', eventAction: 'Downloaded', eventLabel: '(not set)', date: '20170819', pagePath: '/downloads/3xs55m950', totalEvents: '1'),
        OpenStruct.new(eventCategory: 'Files', eventAction: 'Downloaded', eventLabel: '(not set)', date: '20170819', pagePath: '/downloads/other_missing', totalEvents: '1'),
+       OpenStruct.new(eventCategory: 'Files', eventAction: 'Downloaded', eventLabel: '(not set)', date: '20170819', pagePath: '/downloads/gone_baby', totalEvents: '1'),
        OpenStruct.new(eventCategory: 'Files', eventAction: 'Downloaded', eventLabel: '(not set)', date: '20170817', pagePath: '/downloads/19953w999z', totalEvents: '1'),
        OpenStruct.new(eventCategory: 'Files', eventAction: 'Downloaded', eventLabel: '(not set)', date: '20170820', pagePath: '/downloads/19953w999z', totalEvents: '1')]
     }
@@ -52,6 +53,7 @@ describe GoogleAnalytics::DownloadReport do
       allow(ActiveFedora::Base).to receive(:find).with('1vh53wt10').once.and_return(GenericWork.new(id: '1vh53wt10', depositor: user2.login))
       allow(ActiveFedora::Base).to receive(:find).with('19953w999z').once.and_return(FileSet.new(id: '19953w999z', depositor: user1.login))
       allow(ActiveFedora::Base).to receive(:find).with('other_missing').and_raise(ActiveFedora::ObjectNotFoundError)
+      allow(ActiveFedora::Base).to receive(:find).with('gone_baby').and_raise(Ldp::Gone)
     end
 
     describe '#work_downloads' do

--- a/spec/services/user_stats_importer_spec.rb
+++ b/spec/services/user_stats_importer_spec.rb
@@ -25,7 +25,9 @@ describe UserStatsImporter do
        OpenStruct.new(date: '20170820', pagePath: '/concern/generic_works/39955m9995', pageviews: '3'),
        OpenStruct.new(date: '20170825', pagePath: '/concern/generic_works/39955m9995', pageviews: '1'),
        OpenStruct.new(date: '20170816', pagePath: '/concern/generic_works/1vh53wt10', pageviews: '4'),
-       OpenStruct.new(date: '20170822', pagePath: '/concern/generic_works/1vh53wt10', pageviews: '5')]
+       OpenStruct.new(date: '20170822', pagePath: '/concern/generic_works/1vh53wt10', pageviews: '5'),
+       OpenStruct.new(date: '20170822', pagePath: '/concern/generic_works/not_found', pageviews: '1'),
+       OpenStruct.new(date: '20170822', pagePath: '/concern/generic_works/gone_baby', pageviews: '1')]
     }
 
     let(:work_downloads) {
@@ -55,6 +57,8 @@ describe UserStatsImporter do
       allow(ActiveFedora::Base).to receive(:find).with('fj67314220').once.and_return(FileSet.new(id: 'fj67314220', depositor: user1.login))
       allow(ActiveFedora::Base).to receive(:find).with('nzs25x853x').once.and_return(FileSet.new(id: 'nzs25x853x', depositor: user2.login))
       allow(ActiveFedora::Base).to receive(:find).with('4f4752g26g').once.and_return(FileSet.new(id: '4f4752g26g', depositor: user1.login))
+      allow(ActiveFedora::Base).to receive(:find).with('not_found').and_raise(ActiveFedora::ObjectNotFoundError)
+      allow(ActiveFedora::Base).to receive(:find).with('gone_baby').and_raise(Ldp::Gone)
     end
 
     describe '#gather_view_stats' do


### PR DESCRIPTION
Added Safe methods to capture Ldp::Gone and ActiveFedora::ObjectNotFound for all the ActiveFedora object finds since in real life people delete things or google analytics has information for outdated/ missing records.