### PR TITLE
Pagination of the filesets for Work Show Page

### DIFF
--- a/app/controllers/curation_concerns/generic_works_controller.rb
+++ b/app/controllers/curation_concerns/generic_works_controller.rb
@@ -16,6 +16,8 @@ class CurationConcerns::GenericWorksController < ApplicationController
   before_action :delete_from_share, only: [:destroy]
   before_action :redirect_when_uploading, only: [:edit, :update, :destroy]
 
+  before_action :pass_page_to_presenter, only: [:show]
+
   def notify_users_of_permission_changes
     return if @curation_concern.nil?
     previous_permissions = @curation_concern.permissions.map(&:to_hash)
@@ -35,6 +37,10 @@ class CurationConcerns::GenericWorksController < ApplicationController
     return if QueuedFile.where(work_id: params[:id]).blank?
     flash[:notice] = 'Edits or deletes not allowed while files are being uploaded to a work'
     redirect_to polymorphic_path([main_app, curation_concern])
+  end
+
+  def pass_page_to_presenter
+    presenter.file_page(params[:file_page])
   end
 
   protected

--- a/app/presenters/work_show_presenter.rb
+++ b/app/presenters/work_show_presenter.rb
@@ -20,9 +20,14 @@ class WorkShowPresenter < Sufia::WorkShowPresenter
     solr_document.fetch('member_ids_ssim', []).length
   end
 
+  def file_page(page)
+    @file_page = page
+  end
+
   # TODO: Remove once https://github.com/projecthydra/sufia/issues/2394 is resolved
   def member_presenters(ids = ordered_ids, presenter_class = composite_presenter_class)
-    super.delete_if { |presenter| current_ability.cannot?(:read, presenter.solr_document) }
+    members = super.delete_if { |presenter| current_ability.cannot?(:read, presenter.solr_document) }
+    Kaminari.paginate_array(members).page(@file_page).per(10)
   end
 
   def uploading?

--- a/app/views/curation_concerns/base/_items.html.erb
+++ b/app/views/curation_concerns/base/_items.html.erb
@@ -3,8 +3,8 @@
 <%= render partial: 'uploading', locals: { presenter: presenter } if can?(:edit, presenter.id) %>
 
 <% if presenter.member_presenters.present? %>
-  <table class="table table-striped related-files">
-    <thead>
+    <table class="table table-striped related-files">
+      <thead>
       <tr>
         <th scope="col" aria-hidden="true"><%= t('.thumbnail') %></th>
         <th scope="col"><%= t('.title') %></th>
@@ -12,9 +12,9 @@
         <th scope="col"><%= t('.visibility') %></th>
         <th scope="col"><%= t('.actions') %></th>
       </tr>
-    </thead>
-    <tbody>
+      </thead>
+      <tbody>
       <%= render partial: 'member', collection: presenter.member_presenters %>
-    </tbody>
-  </table>
+      </tbody>
+    </table>
 <% end %>

--- a/app/views/curation_concerns/base/_paginate.html.erb
+++ b/app/views/curation_concerns/base/_paginate.html.erb
@@ -1,0 +1,11 @@
+<%# Need to pinch the paginator from
+    https://github.com/samvera/curation_concerns/blob/master/app/views/collections/_paginate.html.erb
+    because the fieldsets for works are ordered and not a solr response. Uses the presenter and a
+    new method of file_page to create pages of objects
+%>
+<% if @presenter.member_presenters.total_pages > 1 %>
+    <div class="pager">
+      <%= paginate @presenter.member_presenters, route_set: main_app, param_name: 'file_page',  outer_window: 2, theme: 'blacklight' %>
+      <div class="clearfix"></div>
+    </div><!-- /pager -->
+<% end %>

--- a/app/views/curation_concerns/base/show.html.erb
+++ b/app/views/curation_concerns/base/show.html.erb
@@ -40,6 +40,7 @@
 <div class="row">
   <div class="col-sm-12">
     <%= render 'items', presenter: @presenter %>
+    <%= render 'paginate' %>
     <%# TODO: we may consider adding these partials in the future %>
     <%#= render 'sharing_with', presenter: @presenter %>
     <%= render 'users/activity', presenter: @presenter %>

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -91,6 +91,8 @@ en:
       name: "Penn State"
     base:
       back_to_top: 'Back to Top'
+      items:
+        header: 'Items in this Work'
       social_media:
         facebook: 'Share on Facebook'
         twitter: 'Share on Twitter'

--- a/spec/features/generic_work/work_with_many_files_spec.rb
+++ b/spec/features/generic_work/work_with_many_files_spec.rb
@@ -42,12 +42,20 @@ describe GenericWork, type: :feature do
       visit('/concern/generic_works/bigwork')
     end
 
-    it 'displays the work page with all the files' do
+    it 'displays the work page with pagination and each page has 10 files' do
       within('dl.attributes') do
         expect(page).to have_selector('dd.total_items', text: '100')
       end
       within('table.related-files') do
-        (1..100).each do |id|
+        (1..10).each do |id|
+          expect(page).to have_link("File #{id}")
+        end
+      end
+      within('div.pager') do
+        click_link('2')
+      end
+      within('table.related-files') do
+        (11..20).each do |id|
           expect(page).to have_link("File #{id}")
         end
       end


### PR DESCRIPTION
Updates paginate to use the member presenters and to correct the route for the main app.

Fixes up the paginate partial to display on screen the paginator.

Updates controller to use file_page instead of page because page is being used by something else.

Updates spec test to check for 10 files on page 1 and look for a link for the second page.