### PR TITLE
Allow missing given names in AliasManagementService

### DIFF
--- a/app/services/alias_management_service.rb
+++ b/app/services/alias_management_service.rb
@@ -49,7 +49,7 @@ class AliasManagementService
     end
 
     def all_names_present?
-      display_name.present? && given_name.present? && sur_name.present?
+      display_name.present? && sur_name.present?
     end
 
     def person


### PR DESCRIPTION
If no given name is provided, a new record will be created using only
the surname. Searching for a nil given name returns only records without
that given name present, avoiding the issue of two existing persons with
the same surname, but one with a missing given name.