### PR TITLE
Use WorkShowPresenter for recent and featured works, ref #998

### DIFF
--- a/app/prepends/prepended_controllers/with_recent_presenters.rb
+++ b/app/prepends/prepended_controllers/with_recent_presenters.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Used to return a set of WorkShowPresenters for recent_documents
+module PrependedControllers::WithRecentPresenters
+  protected
+
+    def recent
+      (_, documents) = search_results(q: '', sort: sort_field, rows: 4)
+      @recent_documents = documents.map { |doc| WorkShowPresenter.new(doc, current_ability) }
+    rescue Blacklight::Exceptions::ECONNREFUSED
+      @recent_documents = []
+    end
+end

--- a/app/prepends/prepended_models/with_featured_presenters.rb
+++ b/app/prepends/prepended_models/with_featured_presenters.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Used to return a set of WorkShowPresenters for featured works
+module PrependedModels::WithFeaturedPresenters
+  private
+
+    def work_presenters
+      ability = nil
+      CurationConcerns::PresenterFactory.build_presenters(ids,
+                                                          WorkShowPresenter,
+                                                          ability)
+    end
+end

--- a/app/views/sufia/homepage/_featured_fields.html.erb
+++ b/app/views/sufia/homepage/_featured_fields.html.erb
@@ -1,0 +1,15 @@
+<h3>
+  <span class="sr-only">Title</span>
+  <%= link_to truncate(featured.title.first, length: 28, separator: ' '), featured %>
+</h3>
+<div>
+  <span class="sr-only">Depositor</span>
+  <%= link_to_profile featured.depositor("no depositor value") %>
+</div>
+<div>
+  <%= featured.attribute_to_html(:resource_type, render_as: :faceted) %>
+</div>
+<div>
+<%= featured.attribute_to_html(:keyword, render_as: :translated_facet,
+            mapping: featured.facet_mapping(:keyword)) %>
+</div>

--- a/app/views/sufia/homepage/_recent_document.html.erb
+++ b/app/views/sufia/homepage/_recent_document.html.erb
@@ -1,0 +1,17 @@
+<tr>
+  <td class="col-sm-2">
+    <%= link_to_profile recent_document.depositor("no depositor value") %>
+    <%= link_to recent_document do %>
+      <%= render_thumbnail_tag recent_document, { width: 45 }, false %>
+    <% end %>
+  </td>
+  <td>
+    <h3>
+      <span class="sr-only">Title</span><%= link_to truncate(recent_document.to_s, length: 28, separator: ' '), recent_document  %>
+    </h3>
+    <p>
+      <%= recent_document.attribute_to_html(:keyword, render_as: :translated_facet,
+            mapping: recent_document.facet_mapping(:keyword)) %>
+    </p>
+  </td>
+</tr>

--- a/config/application.rb
+++ b/config/application.rb
@@ -107,6 +107,8 @@ module ScholarSphere
       AttachFilesToWorkJob.prepend PrependedJobs::WithNotification
       CurationConcerns::Renderers::AttributeRenderer.prepend PrependedRenderers::ConfiguredMicrodata
       CurationConcerns::Renderers::AttributeRenderer.prepend PrependedRenderers::WithLists
+      Sufia::HomepageController.prepend PrependedControllers::WithRecentPresenters
+      FeaturedWorkList.prepend PrependedModels::WithFeaturedPresenters
     end
   end
 end

--- a/spec/features/featured_work_spec.rb
+++ b/spec/features/featured_work_spec.rb
@@ -5,7 +5,7 @@ require 'feature_spec_helper'
 describe 'Featured works on the home page', type: :feature do
   let!(:user)         { create(:user) }
   let!(:jill_user)    { create(:jill) }
-  let!(:file1)        { create(:featured_file, depositor: user.login, title: ['file title']) }
+  let!(:file1)        { create(:featured_file, depositor: user.login, title: ['file title'], keyword: ["'55 Chet Atkins"]) }
   let!(:file2)        { create(:featured_file, :with_required_metadata, depositor: user.login) }
   let!(:private_file) { create(:private_file, depositor: jill_user.login, title: ['private_document']) }
 
@@ -17,11 +17,13 @@ describe 'Featured works on the home page', type: :feature do
       visit('/')
     end
 
-    it 'appears as a featured work', js: true do
+    it 'appears as a featured work with translated facets', js: true do
       expect(page).to have_content 'Featured Works'
       within('#featured_container') do
         expect(page).to have_content(file1.title[0])
+        click_link(file1.keyword.first)
       end
+      expect(page).to have_content(file1.title[0])
     end
 
     it 'only public documents appear as recently uploaded files' do

--- a/spec/features/recent_additions_spec.rb
+++ b/spec/features/recent_additions_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'feature_spec_helper'
+
+describe 'Showing recent additions', type: :feature do
+  let(:current_user) { create(:user) }
+  let!(:gf)          { create(:public_file, depositor: current_user.login, keyword: ["'55 Chet Atkins"]) }
+
+  it 'shows the correct links to facets' do
+    sign_in_with_js(current_user)
+    visit '/'
+    click_link 'Recent Additions'
+    expect(page).to have_content(gf.title.first)
+    click_link(gf.keyword.first)
+    expect(page).to have_content(gf.title.first)
+  end
+end


### PR DESCRIPTION
@cam156 @mtribone this alters the views of recent and featured works to make them exactly like the show view. This way, we're using the same renderer code that we use to translate facets. The original problem was identified in #998, but we discovered is also was present in recent and featured works because they weren't using the same renderer process.

The question is, do we need to tweak the layout or display:
![featured](https://user-images.githubusercontent.com/312085/32186017-44d0ea28-bd77-11e7-807a-fa2ef47bfee4.png)
![recent](https://user-images.githubusercontent.com/312085/32186020-486560f6-bd77-11e7-8ca0-8cd2aff2840c.png)
