### PR TITLE
Warning message to user about representative image and visibility options

### DIFF
--- a/app/views/curation_concerns/base/_form_permission.html.erb
+++ b/app/views/curation_concerns/base/_form_permission.html.erb
@@ -14,6 +14,8 @@
       <small>Who should be able to view or download this content?</small>
     </legend>
 
+    <p>If this is or becomes your representative media, this may impact the display of your work in search results.</p>
+
     <div class="form-group">
       <label class="radio">
         <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC %>


### PR DESCRIPTION
Adds guiding message about permissions and display for filesets on the fileset edit page.