### PR TITLE
Single Title and Subtitle for Collections

### DIFF
--- a/app/forms/collection_form.rb
+++ b/app/forms/collection_form.rb
@@ -3,6 +3,7 @@
 class CollectionForm < Sufia::Forms::CollectionForm
   attr_reader :current_ability, :request
 
+  self.terms += [:subtitle]
   self.required_fields = [:title, :description, :keyword]
 
   include WithCreator
@@ -17,8 +18,26 @@ class CollectionForm < Sufia::Forms::CollectionForm
     super(model)
   end
 
+  def self.multiple?(field)
+    if field.to_sym == :title
+      false
+    else
+      super
+    end
+  end
+
+  def self.model_attributes(_)
+    attrs = super
+    attrs[:title] = Array(attrs[:title]) if attrs[:title]
+    attrs
+  end
+
   def model_class_name
     'collection'
+  end
+
+  def title
+    super.first || ''
   end
 
   # @return [Array<WorkShowPresenter>]
@@ -36,7 +55,7 @@ class CollectionForm < Sufia::Forms::CollectionForm
   end
 
   def primary_terms
-    self.class.required_fields
+    [:title, :subtitle, :description, :keyword]
   end
 
   def secondary_terms

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -6,6 +6,10 @@ class Collection < ActiveFedora::Base
   include HasCreators
   self.indexer = CollectionIndexer
 
+  property :subtitle, predicate: ::RDF::Vocab::EBUCore.subtitle, multiple: false do |index|
+    index.as :stored_searchable
+  end
+
   def private_access?
     super unless new_record?
     false

--- a/app/presenters/collection_presenter.rb
+++ b/app/presenters/collection_presenter.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CollectionPresenter < Sufia::CollectionPresenter
+  delegate :subtitle, to: :solr_document
+
   # TODO: Move to Sufia?
   def self.terms
     super + [:date_modified, :date_uploaded]

--- a/app/views/collections/_collection_subtitle.erb
+++ b/app/views/collections/_collection_subtitle.erb
@@ -1,0 +1,3 @@
+<% if presenter.subtitle.present? %>
+    <h2><%= presenter.subtitle.first %></h2>
+<% end %>

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -3,6 +3,7 @@
   <div class="col-sm-10 pull-right">
     <header>
       <%= render 'collection_title', presenter: @presenter %>
+      <%= render 'collection_subtitle', presenter: @presenter %>
     </header>
     <%= render 'collection_description', presenter: @presenter %>
 

--- a/spec/features/collection/create_spec.rb
+++ b/spec/features/collection/create_spec.rb
@@ -7,6 +7,7 @@ include Selectors::Dashboard
 describe Collection, type: :feature do
   let(:current_user) { create(:user, display_name: 'Jill User') }
   let(:title)        { 'Test Collection Title' }
+  let(:subtitle)     { 'Machu Picchu' }
 
   before { sign_in_with_js(current_user) }
 
@@ -17,6 +18,7 @@ describe Collection, type: :feature do
       expect(page).to have_content('Create New Collection')
       within('div#descriptions_display') do
         expect(page).to have_selector('label', class: 'required', text: 'Title')
+        expect(page).to have_selector('label', text: 'Subtitle')
         expect(page).to have_selector('label', class: 'required', text: 'Description')
         expect(page).to have_selector('label', class: 'required', text: 'Keyword')
       end
@@ -30,6 +32,7 @@ describe Collection, type: :feature do
     before do
       visit(new_collection_path)
       fill_in 'Title', with: title
+      fill_in 'Subtitle', with: subtitle
       fill_in 'Description', with: 'description'
       fill_in 'Keyword', with: 'keyword'
     end
@@ -39,6 +42,7 @@ describe Collection, type: :feature do
         click_button 'Create Empty Collection'
         expect(page).to have_content('Collection was successfully created.')
         expect(page).to have_content(title)
+        expect(page).to have_content(subtitle)
 
         # The link to the creator search should look like this
         # with the correct solr key 'creator_name_sim':
@@ -89,6 +93,7 @@ describe Collection, type: :feature do
       click_button 'Add to Collection'
       db_create_populated_collection_button.click
       fill_in 'Title', with: title
+      fill_in 'Subtitle', with: subtitle
       fill_in 'Description', with: 'description'
       fill_in 'Keyword', with: 'keyword'
       within('div.primary-actions') do

--- a/spec/features/collection/edit_spec.rb
+++ b/spec/features/collection/edit_spec.rb
@@ -61,12 +61,14 @@ describe Collection, type: :feature do
   end
 
   describe "editing a collection's metadata" do
-    let!(:collection)           { create(:collection, depositor: current_user.login, description: ['original description']) }
+    let!(:collection)           { create(:collection, depositor: current_user.login, subtitle: 'Vimana', description: ['original description']) }
     let!(:original_title)       { collection.title }
+    let!(:original_subtitle)    { collection.subtitle }
     let!(:original_description) { collection.description }
 
     let(:updated_title)         { 'Updated Title' }
-    let(:updated_description)   { 'Updtaed description text.' }
+    let(:updated_subtitle)      { 'Updated Vimana2' }
+    let(:updated_description)   { 'Updated description text.' }
 
     before { sign_in(current_user) }
 
@@ -76,6 +78,7 @@ describe Collection, type: :feature do
       click_link 'Edit Collection'
       click_link 'Additional Fields'
       expect(page).to have_field 'collection_title', with: original_title.first
+      expect(page).to have_field 'collection_subtitle', with: original_subtitle
       expect(page).to have_field 'collection_description', with: original_description.first
       within('div.collection_date_created') do
         expect(page).to have_content('Published Date')
@@ -83,6 +86,7 @@ describe Collection, type: :feature do
       expect(page).to have_checked_field('Public')
       expect(page).to have_no_checked_field('Private')
       fill_in 'Title', with: updated_title
+      fill_in 'Subtitle', with: updated_subtitle
       fill_in 'Description', with: updated_description
       expect(find('.creator-first-name')['readonly']).to eq('readonly')
       expect(find('.creator-last-name')['readonly']).to eq('readonly')
@@ -91,6 +95,7 @@ describe Collection, type: :feature do
       expect(page).not_to have_content original_title.first
       expect(page).not_to have_content original_description.first
       expect(page).to have_content updated_title
+      expect(page).to have_content updated_subtitle
       expect(page).to have_content updated_description
       expect(page).to have_content 'Mdme. Dorje Trollo'
     end

--- a/spec/forms/collection_form_spec.rb
+++ b/spec/forms/collection_form_spec.rb
@@ -25,7 +25,7 @@ describe CollectionForm do
   describe '#primary_terms' do
     subject { form.primary_terms }
 
-    it { is_expected.to contain_exactly(:title, :description, :keyword) }
+    it { is_expected.to contain_exactly(:title, :subtitle, :description, :keyword) }
   end
 
   describe '#secondary_terms' do


### PR DESCRIPTION
Adds subtitle term to collection form, redefines title method to grab first title, addresses multiple titles, adds subtitle to the primary terms on the form, and adds the subtitle as a new property in the model.

Adds the subtitle field to the collection show page, adds the collection subtitle partial, delegates subtitle to solr in the collection presenter.

Updates create and edit spec test to test for subtitle.

Fixes style error in test for the collection presenter and adds subtitle to the collection form test.