### PR TITLE
Removing options that are no longer used

### DIFF
--- a/lib/tasks/scholarsphere/stats.rake
+++ b/lib/tasks/scholarsphere/stats.rake
@@ -10,7 +10,7 @@ namespace :scholarsphere do
                      Date.parse(args[:start_date])
                    end
       puts "importing stats from google for #{start_date} to #{1.day.ago}"
-      importer = UserStatsImporter.new(start_date, 1.day.ago, verbose: true, logging: true, delay_secs: 1.0, number_of_retries: 5)
+      importer = UserStatsImporter.new(start_date, 1.day.ago)
       importer.import
     end
   end


### PR DESCRIPTION
These options were only useful when we queried Google Analytics one time for each object.  They became an error during the refactoring when the initializer no longer accepted them, but the call in the rake file was not updated
refs #1079 