### PR TITLE
Requiring Display name in creator

### DIFF
--- a/app/assets/javascripts/scholarsphere/creator/creator_behavior.js
+++ b/app/assets/javascripts/scholarsphere/creator/creator_behavior.js
@@ -13,6 +13,7 @@ ScholarSphere.creatorBehavior = {
       var render = Mustache.render(template, creator)
       $('.creator_container').append(render)
       ScholarSphere.creatorBehavior.activateRemoveButton()
+      $('.creator_container').trigger("managed_field:add")
     })
   },
   activateRemoveButton: function () {

--- a/app/views/records/edit_fields/_creator.html.erb
+++ b/app/views/records/edit_fields/_creator.html.erb
@@ -1,5 +1,5 @@
 <h3>Creators</h3>
-<div class="creator_container">
+<div class="form-group multi_value creator_container">
   <div class="find_creator_container">
     <label for="find_creator">Find Creator</label>
     <input type="text"

--- a/app/views/records/edit_fields/_creator_template.html.erb
+++ b/app/views/records/edit_fields/_creator_template.html.erb
@@ -11,7 +11,7 @@
       <label for="<%= @form.model_class_name %>{{index}}_sur_name">Last Name</label>
       <input type="text" {{readonly}} name="<%= @form.model_class_name %>[creators][{{index}}][sur_name]" id="<%= @form.model_class_name %>[creators][{{index}}][sur_name]" class="form-control string required creator-last-name creator" value="{{lastName}}">
       <label for="{{index}}_display_name">Display Name</label>
-      <input type="text" name="<%= @form.model_class_name %>[creators][{{index}}][display_name]" id="<%= @form.model_class_name %>[creators][{{index}}][display_name]" class="form-control string required creator-display-name creator" value="{{displayName}}">
+      <input type="text" name="<%= @form.model_class_name %>[creators][{{index}}][display_name]" id="<%= @form.model_class_name %>[creators][{{index}}][display_name]" class="form-control string required creator-display-name creator" value="{{displayName}}" required="required">
       <label for="{{index}}_display_name">Email</label>
       <input type="text" {{readonly}} name="<%= @form.model_class_name %>[creators][{{index}}][email]" id="<%= @form.model_class_name %>[creators][{{index}}][email]" class="form-control string required creator-email creator" value="{{email}}">
       <label for="{{index}}_display_name">PSU ID</label>

--- a/spec/features/generic_work/edit_work_spec.rb
+++ b/spec/features/generic_work/edit_work_spec.rb
@@ -29,12 +29,14 @@ describe 'Editing a work', js: true do
     expect(page).to have_field('generic_work[creators][1][psu_id]', readonly: true)
 
     # Remove existing creator "Sally"
+    expect(page).not_to have_text('Enter required metadata')
     sally_remove_button = find(:xpath, './/button[../fieldset/input[@value="Sally"]]')
     sally_remove_button.click
     expect(page).to have_selector('.creator_inputs', count: 1)
 
     # Add a new creator "Verity".
     click_button 'Add another Creator'
+    expect(page).to have_text('Enter required metadata')
     expect(page).to have_selector('.creator_inputs', count: 2)
 
     # The index should be 'generic_work[creators][2]' because
@@ -42,6 +44,7 @@ describe 'Editing a work', js: true do
     fill_in 'generic_work[creators][2][given_name]', with: 'Verity'
     fill_in 'generic_work[creators][2][sur_name]', with: 'Brown'
     fill_in 'generic_work[creators][2][display_name]', with: 'Downtown Verity Brown'
+    expect(page).not_to have_text('Enter required metadata')
     fill_in 'generic_work[creators][2][email]', with: 'dvb@gmail.com'
     fill_in 'generic_work[creators][2][psu_id]', with: 'dvb79'
     click_button 'Save'


### PR DESCRIPTION
This fixes one part of #1074 

There is additionally a bug where any required field can be left off the form if the user deletes all of the input forms requiring the field.