### PR TITLE
Enable batch edit with Alias resources

### DIFF
--- a/app/forms/batch_edit_form.rb
+++ b/app/forms/batch_edit_form.rb
@@ -4,26 +4,8 @@ class BatchEditForm < Sufia::Forms::BatchEditForm
   include WithCreator
   include WithCleanerAttributes
 
-  def self.build_permitted_params
-    permitted = super
-    permitted << { creators: [:id, :display_name, :given_name, :sur_name, :_destroy] }
-    permitted << :visibility
-    permitted
-  end
-
   def model_class_name
     'batch_edit_item'
-  end
-
-  def creators
-    # The model.creators association doesn't seem to work
-    # properly with an unpersisted record, so we manually load
-    # the creator records here.
-    if model.new_record? && model.creator_ids.present?
-      agent_records = Agent.find model.creator_ids
-      model.creators = agent_records
-    end
-    super
   end
 
   def initialize_combined_fields

--- a/spec/features/batch_edit_spec.rb
+++ b/spec/features/batch_edit_spec.rb
@@ -20,15 +20,38 @@ describe 'Batch management of works', type: :feature do
 
     it 'edits a field and displays the changes', js: true do
       expect(page).to have_content 'Changes will be applied to the following'
+
+      # Update standard fields
       batch_edit_fields.each do |field|
         fill_in_batch_edit_field(field, with: "Updated batch #{field}")
       end
+
+      # Update creators
+      first('.remove-creator').click
+      fill_in 'batch_edit_item[creators][1][display_name]', with: 'Dr. Creator C. Creator, MD'
+      click_button('Add another Creator')
+      fill_in 'batch_edit_item[creators][2][display_name]', with: 'Another Creator'
+      fill_in 'batch_edit_item[creators][2][given_name]', with: 'Another'
+      fill_in 'batch_edit_item[creators][2][sur_name]', with: 'Creator'
+      click_button('creator_save')
+      within '#form_creator' do
+        sleep 0.1 until page.text.include?('Changes Saved')
+        expect(page).to have_content 'Changes Saved', wait: Capybara.default_max_wait_time * 4
+      end
+
+      # Verify changes
       work1.reload
       work2.reload
       batch_edit_fields.each do |field|
         expect(work1.send(field)).to contain_exactly("Updated batch #{field}")
         expect(work2.send(field)).to contain_exactly("Updated batch #{field}")
       end
+      expect(work1.creators.map(&:display_name)).to contain_exactly('Dr. Creator C. Creator, MD', 'Another Creator')
+      expect(work1.creators.map(&:agent).map(&:sur_name)).to contain_exactly('Creator', 'Creator')
+      expect(work1.creators.map(&:agent).map(&:given_name)).to contain_exactly('Another', 'Creator C.')
+      expect(work2.creators.map(&:display_name)).to contain_exactly('Dr. Creator C. Creator, MD', 'Another Creator')
+      expect(work2.creators.map(&:agent).map(&:sur_name)).to contain_exactly('Creator', 'Creator')
+      expect(work2.creators.map(&:agent).map(&:given_name)).to contain_exactly('Another', 'Creator C.')
     end
 
     it "displays the field's existing value" do

--- a/spec/forms/batch_edit_form_spec.rb
+++ b/spec/forms/batch_edit_form_spec.rb
@@ -7,5 +7,15 @@ describe BatchEditForm do
     subject { described_class }
 
     its(:build_permitted_params) { is_expected.to include(:visibility) }
+    its(:build_permitted_params) { is_expected.to include(creators: [
+                                                            :id,
+                                                            :display_name,
+                                                            :given_name,
+                                                            :sur_name,
+                                                            :psu_id,
+                                                            :email,
+                                                            :orcid_id,
+                                                            :_destroy
+                                                          ]) }
   end
 end


### PR DESCRIPTION
When changing our forms to use Alias objects instead of Agents, the
batch edit form wasn't update to account for the newly added fields.

This updates the batch edit feature test to check that creators can be
removed and added.