### PR TITLE
The Word "Work" Displayed Twice on Same Line in Menu

### DIFF
--- a/app/views/_toolbar.html.erb
+++ b/app/views/_toolbar.html.erb
@@ -26,7 +26,7 @@
               <% classification = CurationConcerns::QuickClassificationQuery.new(current_user) %>
               <% classification.each do |concern| %>
                   <li><%= link_to(
-                              "#{t("sufia.toolbar.works.new")} #{concern.human_readable_type}",
+                              "#{t("sufia.toolbar.works.new")}",
                               new_polymorphic_path([main_app, concern]),
                               class: "item-option contextual-quick-classify #{dom_class(concern, 'new').gsub('_', '-')}",
                               role: 'menuitem'


### PR DESCRIPTION
Removes extra interpolated value for the type of curation concern.

Old
![screen shot 2017-11-14 at 9 02 09 am](https://user-images.githubusercontent.com/4163828/32804616-7754c9c6-c955-11e7-9c14-7557dfad7bb3.png)


New
<img width="644" alt="screen shot 2017-11-14 at 4 02 45 pm" src="https://user-images.githubusercontent.com/4163828/32804633-8771025c-c955-11e7-92b3-eafbe1f044b6.png">
