### PR TITLE
Removing solr extensions from keys

### DIFF
--- a/app/assets/javascripts/scholarsphere/creator/creator_autocomplete.js
+++ b/app/assets/javascripts/scholarsphere/creator/creator_autocomplete.js
@@ -5,7 +5,7 @@ ScholarSphere.creatorAutocomplete = {
   nameQuery: {},
   initBloodhound: function () {
     this.nameQuery = new Bloodhound({
-      datumTokenizer: Bloodhound.tokenizers.obj.whitespace('given_name_tesim','sur_name_tesim'),
+      datumTokenizer: Bloodhound.tokenizers.obj.whitespace('given_name','sur_name'),
       queryTokenizer: Bloodhound.tokenizers.whitespace,
       limit: 10,
       remote: {
@@ -21,28 +21,27 @@ ScholarSphere.creatorAutocomplete = {
     },
       {
         name: 'creators',
-        display: 'given_name_tesim',
         source: this.nameQuery,
         templates: {
           empty: '<p>  Unable to find any results  </p>',
           suggestion: function (data) {
-            return '<p>' + data.display_name_tesim + '</p>'
+            return '<p>' + data.display_name + '</p>'
           }
         },
         display: function (data) {
-          return data.display_name_tesim
+          return data.display_name
         }
       })
   },
   typeaheadSelect: function (index) {
     $('#find_creator').bind('typeahead:select', function (ev, suggestion) {
       var creator = Object.create(ScholarSphere.creator)
-      creator.firstName = suggestion.given_name_tesim
-      creator.lastName = suggestion.sur_name_tesim
-      creator.displayName = suggestion.display_name_tesim
-      creator.email = suggestion.email_ssim
-      creator.psuId = suggestion.psu_id_ssim
-      creator.orcidId = suggestion.orcid_id_ssim
+      creator.firstName = suggestion.given_name
+      creator.lastName = suggestion.sur_name
+      creator.displayName = suggestion.display_name
+      creator.email = suggestion.email
+      creator.psuId = suggestion.psu_id
+      creator.orcidId = suggestion.orcid_id
       creator.index = $('.creator_inputs').length
       creator.id = suggestion.id
       creator.readonly = 'readonly'

--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -11,19 +11,49 @@ class AgentsController < ApplicationController
   private
 
     def search_results(query)
-      aliases = ActiveFedora::SolrService.query(
-        "display_name_tesim:#{query}*",
-        fq: 'has_model_ssim:Alias',
-        fl: ['id', 'display_name_tesim', 'name_ssim'],
-        qt: 'select',
-        rows: 10
-      )
+      solr_search_results(query)
+    end
+
+    # returns solr results in the following format
+    # [{"id"=>"c25dd3ac-518c-428f-96e1-6ce39448c88d",
+    #   "name_ssim"=>["6edd992f-2ed8-4e5e-9908-31812427be87"],
+    #   "display_name"=>["Cole Carolyn Ann"],
+    #   "given_name"=>["CAROLYN ANN"],
+    #   "sur_name"=>["COLE"],
+    #   "psu_id"=>["cam156"],
+    #   "email"=>["cam156@psu.edu"]}]
+    def solr_search_results(query)
+      aliases = solr_aliases(query)
       aliases.each do |agent_alias|
-        agent = ActiveFedora::SolrService.query(
-          "id:#{agent_alias['name_ssim'].first}",
-          fl: ['given_name_tesim', 'sur_name_tesim', 'email_ssim', 'psu_id_ssim', 'orcid_id_ssim']
-        )
-        agent_alias.merge!(agent.first)
+        add_agent_information_to_alias(agent_alias)
+        clean_agent_alias_keys(agent_alias)
       end
+    end
+
+    def solr_aliases(query)
+      ActiveFedora::SolrService.query(
+        "display_name_tesim:#{query}*",
+          fq: 'has_model_ssim:Alias',
+          fl: ['id', 'display_name_tesim', 'name_ssim'],
+          qt: 'select',
+          rows: 10
+      )
+    end
+
+    def add_agent_information_to_alias(agent_alias)
+      agent = ActiveFedora::SolrService.query(
+        "id:#{agent_alias['name_ssim'].first}",
+          fl: ['given_name_tesim', 'sur_name_tesim', 'email_ssim', 'psu_id_ssim', 'orcid_id_ssim']
+      )
+      agent_alias.merge!(agent.first)
+    end
+
+    def clean_agent_alias_keys(agent_alias)
+      agent_alias['given_name'] = agent_alias.delete('given_name_tesim')
+      agent_alias['sur_name'] = agent_alias.delete('sur_name_tesim')
+      agent_alias['email'] = agent_alias.delete('email_ssim')
+      agent_alias['psu_id'] = agent_alias.delete('psu_id_ssim')
+      agent_alias['orcid_id'] = agent_alias.delete('orcid_id_ssim')
+      agent_alias['display_name'] = agent_alias.delete('display_name_tesim')
     end
 end

--- a/spec/controllers/agents_controller_spec.rb
+++ b/spec/controllers/agents_controller_spec.rb
@@ -24,12 +24,12 @@ RSpec.describe AgentsController do
         get :name_query, q: 'Jam'
         results = JSON.parse(response.body)
         expect(results.count).to eq(3)
-        expect(results.map { |x| x['display_name_tesim'] }.flatten).to contain_exactly('Jamie Test', 'Dr. James T. Test', 'Sally James')
-        expect(results.map { |x| x['given_name_tesim'] }.flatten).to contain_exactly('Jamie', 'Jamie', 'Sally')
-        expect(results.map { |x| x['sur_name_tesim'] }.flatten).to contain_exactly('Test', 'Test', 'James')
-        expect(results.map { |x| x['email_ssim'] }.flatten).to contain_exactly('james@gmail.com', 'james@gmail.com', nil)
-        expect(results.map { |x| x['psu_id_ssim'] }.flatten).to contain_exactly('jtt01', 'jtt01', nil)
-        expect(results.map { |x| x['orcid_id_ssim'] }.flatten).to contain_exactly('1234', '1234', nil)
+        expect(results.map { |x| x['display_name'] }.flatten).to contain_exactly('Jamie Test', 'Dr. James T. Test', 'Sally James')
+        expect(results.map { |x| x['given_name'] }.flatten).to contain_exactly('Jamie', 'Jamie', 'Sally')
+        expect(results.map { |x| x['sur_name'] }.flatten).to contain_exactly('Test', 'Test', 'James')
+        expect(results.map { |x| x['email'] }.flatten).to contain_exactly('james@gmail.com', 'james@gmail.com', nil)
+        expect(results.map { |x| x['psu_id'] }.flatten).to contain_exactly('jtt01', 'jtt01', nil)
+        expect(results.map { |x| x['orcid_id'] }.flatten).to contain_exactly('1234', '1234', nil)
       end
     end
   end


### PR DESCRIPTION
This prepares the code to get the information from other places like ldap.  There is no reason to pass around the solr extensions
refs #1041