### PR TITLE
Enable ordered creators with custom predicate, ref #949, #1049

### DIFF
--- a/app/forms/concerns/with_creator.rb
+++ b/app/forms/concerns/with_creator.rb
@@ -7,7 +7,7 @@ module WithCreator
   # If there are no creators, a new CreatorForm is built using the logged-in user
   # @todo add Solr search here or in CreatorForm to user existing Alias record for the user
   def creators
-    if model.creators.blank?
+    if model.creators.empty?
       Array.wrap(CreatorForm.new(Alias.new(display_name: current_display_name)))
     else
       model.creators.map { |c| CreatorForm.new(c) }

--- a/app/models/batch_edit_item.rb
+++ b/app/models/batch_edit_item.rb
@@ -27,7 +27,8 @@ class BatchEditItem < ActiveFedora::Base
     range.first
   end
 
+  # Creators are ActiveTriples::Relation which must be cast to arrays before they can be flattened
   def creators
-    batch.map(&:creator).flatten
+    batch.map(&:creators).map(&:to_a).flatten
   end
 end

--- a/app/models/concerns/has_creators.rb
+++ b/app/models/concerns/has_creators.rb
@@ -1,20 +1,72 @@
 # frozen_string_literal: true
 
+# Mixin for saving ordered creators as Alias objects. Order is preserved via a second
+# property that utilizes a local predicate. The order of the creator ids are stored
+# as a delimited string.
+
 module HasCreators
   extend ActiveSupport::Concern
 
   included do
-    ordered_aggregation :creators,
-                    has_member_relation: ::RDF::Vocab::DC11.creator,
-                    class_name: 'Alias',
-                    type_validator: type_validator,
-                    through: :list_source
+    property :creators, predicate: ::RDF::Vocab::DC11.creator, class_name: 'Alias'
     alias_method :creator, :creators
 
-    def creators=(values)
-      values = values.values if values.is_a? Hash
-      agent_records = values.map { |v| AliasManagementService.call(v) }
-      super(agent_records)
+    property :creator_list, predicate: PSUL.orderedCreators, multiple: false do |index|
+      index.as :symbol
     end
+
+    # @param [Hash,Array] values received from the form or input
+    # Override property setter to save creators as Alias objects and retain their order
+    # using a delimited string of ids.
+    def creators=(values)
+      alias_list = AliasList.new(values)
+      self.creator_list = alias_list.ids.join('##')
+      super(alias_list.uris)
+    end
+
+    # @return [Array<String>]
+    # An ordered list of creator ids taken from the {creator_list} property
+    def creator_ids
+      return [] if creator_list.nil?
+      creator_list.split(/##/)
+    end
+
+    # @return [Array<Alias>]
+    # Use the ids in {creator_ids} to return an array of Alias objects in the correct order
+    def creators
+      creator_ids.map do |id|
+        super.select { |m| m.id == id }.first
+      end
+    end
+  end
+
+  class AliasList
+    attr_reader :values
+
+    def initialize(parameters)
+      @values = determine_values(parameters)
+    end
+
+    def determine_values(parameters)
+      if parameters.is_a?(Hash)
+        parameters.values
+      else
+        parameters
+      end
+    end
+
+    def ids
+      creator_aliases.map(&:id)
+    end
+
+    def uris
+      creator_aliases.map(&:uri)
+    end
+
+    private
+
+      def creator_aliases
+        @creator_aliases ||= values.map { |v| AliasManagementService.call(v) }
+      end
   end
 end

--- a/lib/psul.rb
+++ b/lib/psul.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class PSUL < RDF::StrictVocabulary('http://libraries.psu.edu/ns/')
+  property :orderedCreators,
+    comment: %(A delimited string of creator ids in a specific order.),
+    label: 'Ordered Creators'
+end

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -15,8 +15,8 @@ FactoryGirl.define do
       collection.apply_depositor_metadata((attrs.depositor || attrs.user.user_key))
 
       if attrs.creators.blank?
-        collection.creators.build(display_name: 'creatorcreator',
-                                  agent: Agent.new(given_name: 'Creator C.', sur_name: 'Creator'))
+        creator = create(:alias, display_name: 'creatorcreator', agent: Agent.new(given_name: 'Creator C.', sur_name: 'Creator'))
+        collection.creators = [creator]
       end
     end
 

--- a/spec/factories/file_sets.rb
+++ b/spec/factories/file_sets.rb
@@ -47,5 +47,11 @@ FactoryGirl.define do
         allow(fs).to receive(:file_size).and_return('1234')
       end
     end
+
+    trait :with_file_format do
+      after(:build) do |fs|
+        allow(fs).to receive(:file_format).and_return('plain ()')
+      end
+    end
   end
 end

--- a/spec/factories/works.rb
+++ b/spec/factories/works.rb
@@ -33,8 +33,8 @@ FactoryGirl.define do
 
         after(:build) do |work, evaluator|
           if evaluator.creators.blank?
-            work.creators.build(display_name: 'Joe Contributor',
-                                agent: Agent.new(sur_name: 'Contributor', given_name: 'Joe'))
+            creator = create(:alias, display_name: 'Joe Contributor', agent: Agent.new(sur_name: 'Contributor', given_name: 'Joe'))
+            work.creators = [creator]
           end
         end
       end
@@ -162,8 +162,8 @@ FactoryGirl.define do
 
       after(:build) do |work, evaluator|
         if evaluator.creators.blank?
-          work.creators.build(display_name: 'creatorcreator',
-                              agent: Agent.new(given_name: 'Creator C.', sur_name: 'Creator'))
+          creator = create(:alias, display_name: 'creatorcreator', agent: Agent.new(given_name: 'Creator C.', sur_name: 'Creator'))
+          work.creators = [creator]
         end
       end
     end
@@ -177,8 +177,8 @@ FactoryGirl.define do
 
       after(:build) do |work, evaluator|
         if evaluator.creators.blank?
-          work.creators.build(display_name: 'required creator',
-                              agent: Agent.new(given_name: 'Required T.', sur_name: 'Creator'))
+          creator = create(:alias, display_name: 'required creator', agent: Agent.new(given_name: 'Required T.', sur_name: 'Creator'))
+          work.creators = [creator]
         end
       end
     end

--- a/spec/features/dashboard/dashboard_works_spec.rb
+++ b/spec/features/dashboard/dashboard_works_spec.rb
@@ -9,8 +9,8 @@ describe 'Dashboard Works', type: :feature do
   let(:jill) { create(:jill) }
   let(:work1_creator_name) { 'Work One Creator' }
 
-  let(:creator) { build(:alias, display_name: work1_creator_name,
-                                agent: Agent.new(given_name: 'Work One', sur_name: 'Creator')) }
+  let(:creator) { create(:alias, display_name: work1_creator_name,
+                                 agent: Agent.new(given_name: 'Work One', sur_name: 'Creator')) }
 
   let!(:work1) do
     create(:public_work, :with_complete_metadata,
@@ -289,25 +289,21 @@ describe 'Dashboard Works', type: :feature do
     end
   end
 
-  def create_works(_user, number_of_works)
+  def create_works(user, number_of_works)
     number_of_works.times do |t|
       work = build(:public_work, id: "199#{t}",
                                  title: ["Sample Work #{t}"],
                                  date_uploaded: (Time.now - (t + 1).hours),
-                                 depositor: current_user.login, resource_type: ['Video'],
+                                 depositor: user.login, resource_type: ['Video'],
                                  keyword: ['Keyword1'],
                                  subject: ['Subject1'], language: ['Language1'],
-                                 based_near: ['Location1'], publisher: ['Publisher1'])
+                                 based_near: ['Location1'], publisher: ['Publisher1'],
+                                 representative: build(:file_set, :with_file_format))
 
-      # Since the work isn't persisted, the relationship doesn't
-      # resolve properly for the indexer. Just stub the values
-      # so we can avoid saving the work record for this spec.
+      # Stub ordered creators because we haven't persisted any data
       allow(work).to receive(:creators).and_return([Alias.new(display_name: 'Creator1 Jones')])
 
-      # TODO: how to do we set the work1 format in the objects with build
-      hash = work.to_solr
-      hash[Solrizer.solr_name('file_format', :facetable)] = 'plain ()'
-      conn.add hash
+      conn.add(work.to_solr)
     end
     conn.commit
   end

--- a/spec/forms/batch_edit_form_spec.rb
+++ b/spec/forms/batch_edit_form_spec.rb
@@ -18,4 +18,33 @@ describe BatchEditForm do
                                                             :_destroy
                                                           ]) }
   end
+
+  describe '#initialize_combined_fields' do
+    let(:user) { build(:user) }
+    let(:ability) { Ability.new(user) }
+    let(:work1) { create(:work, :with_complete_metadata, title: ['First batch work']) }
+    let(:work2) { create(:work, :with_complete_metadata, title: ['Second batch work']) }
+    let(:batch) { [work1.id, work2.id] }
+    let(:model) { BatchEditItem.new(batch: batch) }
+    let(:form) { described_class.new(model, ability, batch) }
+
+    it 'sets names and model to a combined set of attributes' do
+      expect(form.names).to contain_exactly('First batch work', 'Second batch work')
+      expect(form.model.creators.map(&:id)).to contain_exactly(work1.creators.first.id, work2.creators.first.id)
+      expect(form.model.admin_set_id).to eq('admin_set/default')
+      expect(form.model.permissions.map(&:to_hash)).to contain_exactly(name: 'user', type: 'person', access: 'edit')
+      expect(form.model.contributor).to contain_exactly('contributorcontributor')
+      expect(form.model.description).to contain_exactly('descriptiondescription')
+      expect(form.model.keyword).to contain_exactly('tagtag')
+      expect(form.model.resource_type).to contain_exactly('resource_typeresource_type')
+      expect(form.model.rights).to contain_exactly('http://creativecommons.org/licenses/by/3.0/us/')
+      expect(form.model.publisher).to contain_exactly('publisherpublisher')
+      expect(form.model.date_created).to contain_exactly('two days after the day before yesterday')
+      expect(form.model.subject).to contain_exactly('subjectsubject')
+      expect(form.model.language).to contain_exactly('languagelanguage')
+      expect(form.model.identifier).to contain_exactly('')
+      expect(form.model.based_near).to contain_exactly('based_nearbased_near')
+      expect(form.model.related_url).to contain_exactly('http://example.org/TheRelatedURLLink/')
+    end
+  end
 end

--- a/spec/forms/generic_work_form_spec.rb
+++ b/spec/forms/generic_work_form_spec.rb
@@ -28,8 +28,8 @@ describe CurationConcerns::GenericWorkForm do
     end
 
     context 'with existing creators' do
-      let(:creator) { build(:alias, :with_agent) }
-      let(:work) { build(:work, creators: [creator]) }
+      let(:creator) { create(:alias, :with_agent) }
+      let(:work) { create(:work, creators: [creator]) }
 
       its(:display_name) { is_expected.to eq(creator.display_name) }
       its(:given_name) { is_expected.to eq(creator.agent.given_name) }

--- a/spec/indexers/work_indexer_spec.rb
+++ b/spec/indexers/work_indexer_spec.rb
@@ -45,19 +45,24 @@ describe WorkIndexer do
       end
     end
 
-    describe 'a groomed document' do
-      before { work.creators.build(display_name: 'BIG. Name') }
+    context 'with creators' do
+      before { allow(work).to receive(:creators).and_return([creator_alias]) }
 
-      it { is_expected.to include('creator_name_sim' => ['Big Name']) }
-      it { is_expected.to include('creator_name_tesim' => ['BIG. Name']) }
-      it { is_expected.to include('keyword_sim' => ['bird']) }
-      it { is_expected.to include('keyword_tesim' => ['Bird']) }
-    end
+      describe 'a groomed document' do
+        let(:creator_alias) { build(:alias, display_name: 'BIG. Name') }
 
-    describe 'creator missing fields' do
-      before { work.creators.build(display_name: 'John') }
-      it { is_expected.to include('creator_name_sim' => ['John']) }
-      it { is_expected.to include('creator_name_tesim' => ['John']) }
+        it { is_expected.to include('creator_name_sim' => ['Big Name']) }
+        it { is_expected.to include('creator_name_tesim' => ['BIG. Name']) }
+        it { is_expected.to include('keyword_sim' => ['bird']) }
+        it { is_expected.to include('keyword_tesim' => ['Bird']) }
+      end
+
+      describe 'creator missing fields' do
+        let(:creator_alias) { build(:alias, display_name: 'John') }
+
+        it { is_expected.to include('creator_name_sim' => ['John']) }
+        it { is_expected.to include('creator_name_tesim' => ['John']) }
+      end
     end
   end
 end

--- a/spec/models/generic_work/ordered_creators_spec.rb
+++ b/spec/models/generic_work/ordered_creators_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe GenericWork do
+  subject { work }
+
+  context 'without any creators' do
+    let(:work) { build(:work) }
+
+    its(:creators) { is_expected.to be_empty }
+    its(:creator_ids) { is_expected.to be_empty }
+  end
+
+  context 'when changing creator order' do
+    let(:creator1) { create(:alias, display_name: 'Huey', agent: Agent.new(given_name: 'Huey', sur_name: 'Duck')) }
+    let(:creator2) { create(:alias, display_name: 'Dewey', agent: Agent.new(given_name: 'Dewey', sur_name: 'Duck')) }
+    let(:creator3) { create(:alias, display_name: 'Louis', agent: Agent.new(given_name: 'Louis', sur_name: 'Duck')) }
+    let(:work) { create(:work, creators: [creator1, creator2, creator3]) }
+
+    it 'saves the original order and changes it after saving' do
+      expect(work.creator_ids).to eq([creator1.id, creator2.id, creator3.id])
+      expect(work.creators).to eq([creator1, creator2, creator3])
+      work.creators = [creator3, creator1, creator2]
+      work.save
+      work.reload
+      expect(work.creator_ids).to eq([creator3.id, creator1.id, creator2.id])
+      expect(work.creators).to eq([creator3, creator1, creator2])
+    end
+  end
+end

--- a/spec/models/generic_work_spec.rb
+++ b/spec/models/generic_work_spec.rb
@@ -31,19 +31,6 @@ describe GenericWork do
       end
     end
 
-    context 'building a creator' do
-      let(:work) { build(:work) }
-
-      it 'creates an Alias record' do
-        work.creators.build(display_name: 'Frodo', agent: Agent.new(given_name: 'Frodo', sur_name: 'Baggins'))
-        expect { work.save! }
-          .to change { described_class.count }.by(1)
-          .and change { Alias.count }.by(1)
-        expect(work.creators.map(&:display_name)).to eq ['Frodo']
-        expect(Alias.first.display_name).to eq 'Frodo'
-      end
-    end
-
     context 'with hash inputs' do
       let!(:agent) { create(:agent, given_name: 'Lucy', sur_name: 'Lee') }
       let!(:lucy) { create(:alias, display_name: 'Lucy Lee', agent: agent) }
@@ -86,7 +73,10 @@ describe GenericWork do
       end
     end
 
-    # When we changed the work's creators to be a Agent model instead of a String, the name of the method to find the work's creators also changed.  It is now 'work.creators' (with an 's') instead of 'work.creator'.  But, there are many places in in scholarsphere, sufia, and curation_concerns that call the 'creator' method, so we need to make sure that method exists.  So we just aliased the method 'creator' to 'creators'.
+    # When we changed the work's creators to be an Alias model instead of a String, the name of the method to find the
+    # work's creators also changed. It is now 'work.creators' (with an 's') instead of 'work.creator'.
+    # Because there are many places in in scholarsphere, sufia, and curation_concerns that call the 'creator' method,
+    # we just aliased the method 'creator' to 'creators'.
     context 'calling "creator" method' do
       let!(:frodo) { create(:alias, display_name: 'Frodo', agent: Agent.new(given_name: 'Frodo', sur_name: 'Baggins')) }
 

--- a/spec/models/migration/solr_list_migrator_spec.rb
+++ b/spec/models/migration/solr_list_migrator_spec.rb
@@ -25,8 +25,10 @@ describe Migration::SolrListMigrator do
       save_work_to_solr_and_fake_fedora(work2, creator2)
       save_work_to_solr_and_fake_fedora(work3, creator3)
     end
+
+    # @note The second test fails unless it is run separately. Cleaning out both Fedora and Solr seems to fix this.
     after do
-      ActiveFedora::Cleaner.cleanout_solr
+      ActiveFedora::Cleaner.clean!
       FileUtils.rm_f(cache_name)
     end
 

--- a/spec/presenters/work_show_presenter_spec.rb
+++ b/spec/presenters/work_show_presenter_spec.rb
@@ -64,7 +64,9 @@ describe WorkShowPresenter do
     subject { presenter.facet_mapping(:creator_name) }
 
     let(:work) { build :work }
-    let!(:joe) { work.creators.build(display_name: 'JOE SMITH') }
+    let(:creator_alias) { build(:alias, display_name: 'JOE SMITH') }
+
+    before { allow(work).to receive(:creators).and_return([creator_alias]) }
 
     it { is_expected.to eq('JOE SMITH' => 'Joe Smith') }
   end

--- a/spec/support/helpers/solr_objects.rb
+++ b/spec/support/helpers/solr_objects.rb
@@ -4,21 +4,29 @@ def conn
   ActiveFedora::SolrService.instance.conn
 end
 
+# @param [Collection] collection
+# @param [String] creator
+# @note allows you to save a collection to Solr using a creator as a string
 def save_collection_to_solr(collection, creator)
   allow(Collection).to receive(:find).with(collection.id).and_return(collection)
   allow(collection).to receive(:creator_ids).and_return([creator])
-  hash = collection.to_solr
-  hash['creator_tesim'] = creator
-  conn.add hash
+  allow(collection).to receive(:creators).and_return([])
+  conn.add document_with_original_creator(collection.to_solr, creator)
   conn.commit
 end
 
+# @param [GenericWork] work
+# @param [String] creator
+# @note allows you to save a work to Solr using a creator as a string
 def save_work_to_solr_and_fake_fedora(work, creator)
   allow(GenericWork).to receive(:find).with(work.id).and_return(work)
   allow(work).to receive(:creator_ids).and_return([creator])
+  allow(work).to receive(:creators).and_return([])
   allow(work).to receive(:reload).and_return(work)
-  hash = work.to_solr
-  hash['creator_tesim'] = creator
-  conn.add hash
+  conn.add document_with_original_creator(work.to_solr, creator)
   conn.commit
+end
+
+def document_with_original_creator(document, creator)
+  document.merge!('creator_tesim' => creator)
 end


### PR DESCRIPTION
Implementing an ordered aggregation for creators was not preserving
their order.

The ordered aggregation is removed in favor of a simpler property and a
second custom predicate that maintains the order of creators as a
delimited string of ids.