### PR TITLE
fixing a few bugs in the migration process

### DIFF
--- a/app/models/migration/solr_object_list.rb
+++ b/app/models/migration/solr_object_list.rb
@@ -6,7 +6,7 @@ module Migration
 
     def initialize(object_class)
       @object_class = object_class
-      @objects = ActiveFedora::SolrService.query(filter, fl: 'id,depositor_tesim', rows: 1000).map(&:id)
+      @objects = ActiveFedora::SolrService.query(filter, fl: 'id,depositor_tesim', rows: 100000).map(&:id)
     end
 
     def each_with_load
@@ -15,6 +15,8 @@ module Migration
           yield(load_object(id))
         rescue ActiveFedora::ObjectNotFoundError => error
           logger.warn "error finding object to migrate: #{id}; #{error}"
+        rescue StandardError => error
+          logger.warn "error migrating object: #{id}; #{error}"
         end
       end
     end


### PR DESCRIPTION
This PR just hardens the migration process.  
* 1000 was a mistake since we have over 7000 items.
* Random errors cause the process to fail so I added a capture
* The creators for some records were blank.  This could be becuase we were removing them, but it seemed good to handle that case
* Added a throw catch so if the alias is not found we do not clear the creators
* Check the Alias database for the display name if it has not been found in the hash
