### PR TITLE
Changing from facet to keep punctuation in names

### DIFF
--- a/app/models/migration/creator_list.rb
+++ b/app/models/migration/creator_list.rb
@@ -15,8 +15,9 @@ module Migration
     private
 
       def find_uniq_system_creators
-        creator_facet_resp = ActiveFedora::SolrService.instance.conn.get 'select', params: { rows: 0, 'facet.limit' => 10000, 'facet.field' => 'creator_sim' }
-        creator_facet_resp['facet_counts']['facet_fields']['creator_sim'].select { |creator_or_count| creator_or_count.class == String }.reject { |name_or_url| name_or_url.starts_with?('Http') }
+        creator_docs = ActiveFedora::SolrService.query('*:*', fq: 'has_model_ssim:GenericWork OR has_model_ssim:Collection', fl: 'creator_tesim', rows: 10000)
+        creators = creator_docs.map { |doc| doc['creator_tesim'] }
+        creators.flatten.uniq.reject(&:blank?).sort
       end
 
       def convert_to_aliases

--- a/spec/support/helpers/solr_objects.rb
+++ b/spec/support/helpers/solr_objects.rb
@@ -8,7 +8,7 @@ def save_collection_to_solr(collection, creator)
   allow(Collection).to receive(:find).with(collection.id).and_return(collection)
   allow(collection).to receive(:creator_ids).and_return([creator])
   hash = collection.to_solr
-  hash['creator_sim'] = creator
+  hash['creator_tesim'] = creator
   conn.add hash
   conn.commit
 end
@@ -18,7 +18,7 @@ def save_work_to_solr_and_fake_fedora(work, creator)
   allow(work).to receive(:creator_ids).and_return([creator])
   allow(work).to receive(:reload).and_return(work)
   hash = work.to_solr
-  hash['creator_sim'] = creator
+  hash['creator_tesim'] = creator
   conn.add hash
   conn.commit
 end


### PR DESCRIPTION
The creator list was using the facet, but that is a normalized form of the name and does not include punctuation in the name so instead of 'Tribone, Michael' we got 'Tribone Michael'

refs #1100 