### PR TITLE
Taking the order from solr

### DIFF
--- a/app/models/migration/solr_list_migrator.rb
+++ b/app/models/migration/solr_list_migrator.rb
@@ -22,12 +22,17 @@ module Migration
         end
 
         def update_creators(object, creator_alias_hash)
-          creators = translate_creators(object.creator, creator_alias_hash)
+          creators = translate_creators(solr_creators(object), creator_alias_hash)
           object = clear_creators(object)
           object.creators = creators
           object.save
         rescue MissingCreator => error
           Rails.logger.error "Creator alias could not be found for #{error} skipping translation of #{object.id}"
+        end
+
+        def solr_creators(object)
+          solr_response = ActiveFedora::SolrService.query("id:#{object.id}", fl: 'creator_tesim').first
+          solr_response[:creator_tesim]
         end
 
         def translate_creators(creators, creator_alias_hash)

--- a/spec/models/migration/solr_list_migrator_spec.rb
+++ b/spec/models/migration/solr_list_migrator_spec.rb
@@ -10,7 +10,7 @@ describe Migration::SolrListMigrator do
 
   let(:creator1) { 'Bugs Bunny' }
   let(:creator2) { 'Bunny, Bugs' }
-  let(:creator3) { 'Tweey E Bird' }
+  let(:creator3) { ['Tweey E Bird', 'Cat, Sylvester', 'Chicken Hawk', 'Wile E Coyote'] }
   let(:alias_hash) { Migration::CreatorList.new(cache_name).to_alias_hash }
   let(:sparql_insert) { instance_double(ActiveFedora::SparqlInsert) }
   let(:cache_name) { 'tmp/my_cahce' }
@@ -39,7 +39,7 @@ describe Migration::SolrListMigrator do
       migrator
       expect(work1.creators).to contain_exactly(alias_hash[creator1])
       expect(work2.creators).to contain_exactly(alias_hash[creator2])
-      expect(work3.creators).to contain_exactly(alias_hash[creator3])
+      expect(work3.creators).to eq(creator3.map { |creator| alias_hash[creator] })
     end
 
     context 'missing creator' do
@@ -58,7 +58,7 @@ describe Migration::SolrListMigrator do
         described_class.migrate_creators(Migration::SolrWorkList.new, local_alias_hash)
         expect(work1.creators).to contain_exactly(alias_hash[creator1])
         expect(work2.creators).to contain_exactly(alias_hash[creator2])
-        expect(work3.creators).to contain_exactly(alias_hash[creator3])
+        expect(work3.creators).to eq(creator3.map { |creator| alias_hash[creator] })
       end
     end
   end

--- a/spec/support/helpers/solr_objects.rb
+++ b/spec/support/helpers/solr_objects.rb
@@ -20,7 +20,7 @@ end
 # @note allows you to save a work to Solr using a creator as a string
 def save_work_to_solr_and_fake_fedora(work, creator)
   allow(GenericWork).to receive(:find).with(work.id).and_return(work)
-  allow(work).to receive(:creator).and_return([creator])
+  allow(work).to receive(:creator).and_return(Array(creator).shuffle)
   allow(work).to receive(:reload).and_return(work)
   conn.add document_with_original_creator(work.to_solr, creator)
   conn.commit


### PR DESCRIPTION
The new version of Active tripples can shuffle the order of the data coming from Fedora.  Solr preserves the order so we are going to use that.