### PR TITLE
Redefines creator method to use creator_name or creator

### DIFF
--- a/app/presenters/work_show_presenter.rb
+++ b/app/presenters/work_show_presenter.rb
@@ -6,8 +6,12 @@ class WorkShowPresenter < Sufia::WorkShowPresenter
 
   delegate :bytes, :subtitle, to: :solr_document
 
+  def creator
+    creator_name
+  end
+
   def creator_name
-    solr_document.fetch('creator_name_tesim', [])
+    solr_document.fetch('creator_name_tesim', nil) || solr_document.fetch('creator_tesim', [])
   end
 
   def size

--- a/spec/presenters/work_show_presenter_spec.rb
+++ b/spec/presenters/work_show_presenter_spec.rb
@@ -90,5 +90,25 @@ describe WorkShowPresenter do
     end
   end
 
+  describe '#creator' do
+    context 'verify that the new creator is an alias' do
+      let(:solr_doc) { SolrDocument.new('creator_name_tesim' => ['Thomas Jefferson']) }
+
+      its(:creator_name) { is_expected.to eq(['Thomas Jefferson']) }
+    end
+
+    context 'verify that the old creator works with the alias' do
+      let(:solr_doc) { SolrDocument.new('creator_tesim' => ['Jefferson, Thomas']) }
+
+      its(:creator_name) { is_expected.to eq(['Jefferson, Thomas']) }
+    end
+
+    context 'verify that the old creator still exists' do
+      let(:solr_doc) { SolrDocument.new('creator_tesim' => ['Jefferson, Thomas']) }
+
+      its(:creator) { is_expected.to eq(['Jefferson, Thomas']) }
+    end
+  end
+
   its(:event_class) { is_expected.to eq(GenericWork) }
 end


### PR DESCRIPTION
This allows to display the creators whether they have been migrated or not on the work show page.
