### PR TITLE
Use canonical name for creator facets, ref #1104

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -40,7 +40,7 @@ RSpec/BeEql:
     - 'spec/controllers/my/works_controller_spec.rb'
     - 'spec/features/collection/view_and_search_spec.rb'
 
-# Offense count: 2
+# Offense count: 4
 RSpec/BeforeAfterAll:
   Exclude:
     - 'spec/spec_helper.rb'
@@ -48,6 +48,7 @@ RSpec/BeforeAfterAll:
     - 'spec/support/**/*.rb'
     - 'spec/models/user_mailer_spec.rb'
     - 'spec/services/zotero_subscription_spec.rb'
+    - 'spec/indexers/with_creators_spec.rb'
 
 # Offense count: 86
 # Configuration parameters: Max.

--- a/app/indexers/indexes_creator.rb
+++ b/app/indexers/indexes_creator.rb
@@ -13,7 +13,13 @@ module IndexesCreator
 
     def index_creator(solr_doc)
       creator_names = object.creators.map(&:display_name)
-      solr_doc[Solrizer.solr_name('creator_name', :facetable)] = creator_names
+      facet_names = object.creators.map { |c| build_facet(c) }
+      solr_doc[Solrizer.solr_name('creator_name', :facetable)] = facet_names
       solr_doc[Solrizer.solr_name('creator_name', :stored_searchable)] = creator_names
+    end
+
+    def build_facet(creator)
+      return creator.display_name if creator.agent.nil?
+      "#{creator.agent.given_name} #{creator.agent.sur_name}".strip
     end
 end

--- a/spec/features/dashboard/dashboard_collections_spec.rb
+++ b/spec/features/dashboard/dashboard_collections_spec.rb
@@ -65,7 +65,7 @@ describe 'Dashboard Collections:', type: :feature do
         click_link('Object Type')
         expect(page).to have_content('Collection (1)')
         click_link('Creator')
-        expect(page).to have_content(creator.display_name)
+        expect(page).to have_content('Given Name Sur Name')
       end
     end
   end

--- a/spec/indexers/with_creators_spec.rb
+++ b/spec/indexers/with_creators_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe IndexesCreator do
+  subject { TestIndexer.new(work).generate_solr_document }
+
+  let(:work)    { build(:work) }
+  let(:creator) { build(:alias, display_name: 'Display Name') }
+
+  before(:all) do
+    class TestIndexer < ActiveFedora::IndexingService
+      include IndexesCreator
+    end
+  end
+
+  after(:all) do
+    ActiveSupport::Dependencies.remove_constant('TestIndexer')
+  end
+
+  before do
+    allow(work).to receive(:creators).and_return([creator])
+    allow(creator).to receive(:agent).and_return(agent)
+  end
+
+  describe '#generate_solr_document' do
+    context 'with a first and last name' do
+      let(:agent) { Agent.new(given_name: 'First', sur_name: 'Last') }
+
+      it { is_expected.to include('creator_name_tesim' => ['Display Name'], 'creator_name_sim' => ['First Last']) }
+    end
+
+    context 'with only a first name' do
+      let(:agent) { Agent.new(given_name: 'First Only') }
+
+      it { is_expected.to include('creator_name_tesim' => ['Display Name'], 'creator_name_sim' => ['First Only']) }
+    end
+
+    context 'with only a last name' do
+      let(:agent) { Agent.new(sur_name: 'Only Last') }
+
+      it { is_expected.to include('creator_name_tesim' => ['Display Name'], 'creator_name_sim' => ['Only Last']) }
+    end
+
+    context 'with no Agent' do
+      let(:agent) { nil }
+
+      it { is_expected.to include('creator_name_tesim' => ['Display Name'], 'creator_name_sim' => ['Display Name']) }
+    end
+  end
+end

--- a/spec/indexers/work_indexer_spec.rb
+++ b/spec/indexers/work_indexer_spec.rb
@@ -45,24 +45,21 @@ describe WorkIndexer do
       end
     end
 
-    context 'with creators' do
-      before { allow(work).to receive(:creators).and_return([creator_alias]) }
+    describe 'a groomed document' do
+      let(:creator) { build(:alias, display_name: 'BIG. DISPLAY Name') }
+      let(:agent)   { Agent.new(given_name: 'BIG.', sur_name: 'Name') }
 
-      describe 'a groomed document' do
-        let(:creator_alias) { build(:alias, display_name: 'BIG. Name') }
-
-        it { is_expected.to include('creator_name_sim' => ['Big Name']) }
-        it { is_expected.to include('creator_name_tesim' => ['BIG. Name']) }
-        it { is_expected.to include('keyword_sim' => ['bird']) }
-        it { is_expected.to include('keyword_tesim' => ['Bird']) }
+      before do
+        allow(work).to receive(:creators).and_return([creator])
+        allow(creator).to receive(:agent).and_return(agent)
       end
 
-      describe 'creator missing fields' do
-        let(:creator_alias) { build(:alias, display_name: 'John') }
+      it { is_expected.to include('creator_name_sim' => ['Big Name'],
+                                  'creator_name_tesim' => ['BIG. DISPLAY Name'],
+                                  'keyword_sim' => ['bird'],
+                                  'keyword_tesim' => ['Bird']) }
 
-        it { is_expected.to include('creator_name_sim' => ['John']) }
-        it { is_expected.to include('creator_name_tesim' => ['John']) }
-      end
+      it { is_expected.not_to include('creator_name_sim' => ['BIG. Name'], 'creator_name_tesim' => ['Big Display Name']) }
     end
   end
 end

--- a/spec/services/solr_document_groomer_spec.rb
+++ b/spec/services/solr_document_groomer_spec.rb
@@ -3,8 +3,8 @@
 require 'rails_helper'
 
 describe SolrDocumentGroomer do
-  let(:legend)   { create(:alias, :with_agent, display_name: 'I AM LEGEND') }
-  let(:will)     { create(:alias, :with_agent, display_name: 'Will I. Am') }
+  let(:legend)   { create(:alias, display_name: 'Do not use', agent: Agent.new(sur_name: 'I AM LEGEND')) }
+  let(:will)     { create(:alias, display_name: 'Do not use', agent: Agent.new(sur_name: 'Will I. Am')) }
 
   let(:work)     { create(:work, creators: [legend, will], keyword: ['CAPITAL', 'Title.']) }
   let(:document) { SolrDocument.new(work.to_solr) }


### PR DESCRIPTION
The display was used for facets, which could change from person to
person. To make the facets unique for each individual, the facets are
created from the concatenation of their given and surnames.