### PR TITLE
treating initials differently depending on where they are

### DIFF
--- a/app/models/migration/local_user_lookup.rb
+++ b/app/models/migration/local_user_lookup.rb
@@ -19,9 +19,14 @@ module Migration
         end
 
         def name_to_query_parts(name)
-          name_to_parts(name).map do |part|
-            "%#{handle_initial(part)}%"
+          name_parts = name_to_parts(name)
+          name_query_parts = name_parts.map do |part|
+            "%#{handle_initial(part, (name_parts.count < 3))}%"
           end
+          if name_query_parts.first.start_with?('% ')
+            name_query_parts[0] = name_query_parts[0].sub('% ', '%')
+          end
+          name_query_parts
         end
 
         def name_query(query_parts_count)
@@ -34,9 +39,11 @@ module Migration
           name_parts.map { |part| part.gsub(',', '').gsub('.', '') }
         end
 
-        def handle_initial(part)
+        def handle_initial(part, ending_space)
           return part if part.length > 1
-          " #{part}"
+          part = " #{part}"
+          part += ' ' if ending_space
+          part
         end
       end
   end

--- a/spec/models/migration/local_user_lookup_spec.rb
+++ b/spec/models/migration/local_user_lookup_spec.rb
@@ -43,5 +43,33 @@ describe Migration::LocalUserLookup, type: :model do
 
       it { is_expected.to contain_exactly('Abc two 123') }
     end
+
+    context 'with only an initial' do
+      before do
+        User.create!(login: 'miss_piggy@pong.log', display_name: 'Miss Wonderful Piggy')
+      end
+      let(:search_name) { 'W. Piggy' }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'with only an initial' do
+      before do
+        User.create!(login: 'miss_piggy@pong.log', display_name: 'Miss Wonderful Piggy')
+      end
+      let(:search_name) { 'M. Wonderful Piggy' }
+
+      it { is_expected.to contain_exactly('Miss Wonderful Piggy') }
+    end
+
+    context 'with an name that includes the initial' do
+      before do
+        User.create!(login: 'HaveAInitial@in.my.name', display_name: 'Have A Initial')
+      end
+
+      let(:search_name) { 'A Name' }
+
+      it { is_expected.to be_empty }
+    end
   end
 end


### PR DESCRIPTION
I'm not sure I am in love with this fix for #1121 but it is better than what we have now.

We are either matching too much, or not enough with the current code.

W. Piggy would match Miss Wonderful Piggy which is not a very accurate match
M. Wonderful Piggy would not match Miss Wonderful Piggy, which seems like it should match.

The fix include adding a space after the initial to match for exact match like "W. Piggy" would match "W Piggy", but would not match "Wilbur Piggy" or "Frances W Piggy"
