### PR TITLE
First name initial matches should not match last character of first name

### DIFF
--- a/app/models/migration/creator_list.rb
+++ b/app/models/migration/creator_list.rb
@@ -78,15 +78,15 @@ module Migration
         return true if creator == user.login
 
         logger.warn("Matching #{creator} with #{user.display_name} #{user.login}")
-        user_name = parse_name(user.display_name)
+        valid_given_and_sur_name?(user.display_name, creator) || (comparable_name(creator) == comparable_name(user.display_name))
+      end
+
+      def valid_given_and_sur_name?(user_display_name, creator)
+        # family name match is valid and the given name initial is at the start
+        user_name = parse_name(user_display_name)
         creator_name = parse_name(creator)
-        user_name.family.downcase!
-        creator_name.family.downcase!
-
-        # family name match is valid
-        return true if user_name.family == creator_name.family
-
-        comparable_name(creator) == comparable_name(user.display_name)
+        user_name.family.casecmp(creator_name.family.downcase).zero? &&
+          (creator_name.given.size > 1 || user_name.given.downcase.start_with?(creator_name.given.downcase))
       end
 
       def comparable_name(name)

--- a/spec/models/migration/creator_list_spec.rb
+++ b/spec/models/migration/creator_list_spec.rb
@@ -112,6 +112,17 @@ describe Migration::CreatorList do
                                display_name => alias_test) }
       end
 
+      context 'display name is a partial name match' do
+        let(:sur_name) { 'Frog' }
+        let(:given_name) { 'T' }
+        let(:display_name) { "#{given_name} #{sur_name}" }
+
+        it { is_expected.to eq('blarg institution for the insane' => alias1,
+                               user.login => alias3,
+                               'Kermit The Frog' => alias2,
+                               display_name => alias_test) }
+      end
+
       context 'display name is a backward name match' do
         let(:sur_name) { 'Kermit the' }
         let(:given_name) { 'Frog' }


### PR DESCRIPTION
We should not match Jessica Moyer with A Moyer just becuase the given name ends with the first initial.  Solr is allowing this to come back so we are filtering it when we validate.