### PR TITLE
Moves Collection Creator Field(s) Above Additional Metadata

### DIFF
--- a/app/forms/collection_form.rb
+++ b/app/forms/collection_form.rb
@@ -55,12 +55,12 @@ class CollectionForm < Sufia::Forms::CollectionForm
   end
 
   def primary_terms
-    [:title, :subtitle, :description, :keyword]
+    [:title, :subtitle, :creator, :description, :keyword]
   end
 
   def secondary_terms
     [
-      :creator, :contributor, :rights, :publisher, :date_created, :subject, :language, :identifier,
+      :contributor, :rights, :publisher, :date_created, :subject, :language, :identifier,
       :based_near, :related_url, :resource_type
     ]
   end

--- a/app/presenters/collection_presenter.rb
+++ b/app/presenters/collection_presenter.rb
@@ -3,9 +3,10 @@
 class CollectionPresenter < Sufia::CollectionPresenter
   delegate :subtitle, to: :solr_document
 
-  # TODO: Move to Sufia?
   def self.terms
-    super + [:date_modified, :date_uploaded]
+    [:creator, :keyword, :size, :total_items, :resource_type, :contributor,
+     :rights, :publisher, :date_created, :subject, :language, :identifier,
+     :based_near, :related_url, :date_modified, :date_uploaded]
   end
 
   def permission_badge_class

--- a/spec/forms/collection_form_spec.rb
+++ b/spec/forms/collection_form_spec.rb
@@ -25,14 +25,13 @@ describe CollectionForm do
   describe '#primary_terms' do
     subject { form.primary_terms }
 
-    it { is_expected.to contain_exactly(:title, :subtitle, :description, :keyword) }
+    it { is_expected.to contain_exactly(:title, :subtitle, :creator, :description, :keyword) }
   end
 
   describe '#secondary_terms' do
     subject { form.secondary_terms }
 
-    it { is_expected.to contain_exactly(:creator,
-                                        :contributor,
+    it { is_expected.to contain_exactly(:contributor,
                                         :rights,
                                         :publisher,
                                         :date_created,

--- a/spec/presenters/collection_presenter_spec.rb
+++ b/spec/presenters/collection_presenter_spec.rb
@@ -6,7 +6,9 @@ describe CollectionPresenter do
   describe '#terms' do
     subject { described_class.terms }
 
-    it { is_expected.to include(:date_modified, :date_uploaded) }
+    it { is_expected.to include(:creator, :keyword, :size, :total_items, :resource_type, :contributor,
+                                :rights, :publisher, :date_created, :subject, :language, :identifier,
+                                :based_near, :related_url, :date_modified, :date_uploaded) }
   end
 
   describe '#size' do


### PR DESCRIPTION
Moves the creator field up in the new/edit form and rearranges the metadata on the collection show page to match work show page. Updates spec test to reflect position change of creator field.

Fixes #1127 and #1016 

![screen shot 2018-01-04 at 12 36 29 pm](https://user-images.githubusercontent.com/4163828/34578128-c170c22a-f151-11e7-9417-b6ea2b1a4be3.png)

