### PR TITLE
Adds required label to Display Name for Creator

### DIFF
--- a/app/views/records/edit_fields/_creator.html.erb
+++ b/app/views/records/edit_fields/_creator.html.erb
@@ -35,7 +35,7 @@
               required: false,
               readonly: creator_form.read_only?,
               id: given_name_id,
-              class: 'form-control string required creator-first-name creator' %>
+              class: 'form-control string creator-first-name creator' %>
 
         <% sur_name_id = "#{id_base}[sur_name]" %>
         <%= label_tag sur_name_id, 'Last Name' %>
@@ -43,12 +43,14 @@
               required: false,
               readonly: creator_form.read_only?,
               id: sur_name_id,
-              class: 'form-control string required creator-last-name creator' %>
+              class: 'form-control string creator-last-name creator' %>
 
         <% display_name_id = "#{id_base}[display_name]" %>
-        <%= label_tag display_name_id, 'Display Name' %>
+        <%= label_tag display_name_id do  %>
+            Display Name <span class="label label-info required-tag">required</span>
+        <% end %>
         <%= text_field_tag display_name_id, creator_form.display_name,
-              required: false,
+              required: true,
               id: display_name_id,
               class: 'form-control string required creator-display-name creator' %>
 
@@ -58,7 +60,7 @@
               required: false,
               readonly: creator_form.read_only?,
               id: email_id,
-              class: 'form-control string required creator-email creator' %>
+              class: 'form-control string creator-email creator' %>
 
         <% psu_id_id = "#{id_base}[psu_id]" %>
         <%= label_tag psu_id_id, 'PSU ID' %>
@@ -66,7 +68,7 @@
               required: false,
               readonly: creator_form.read_only?,
               id: psu_id_id,
-              class: 'form-control string required creator-psu-id creator' %>
+              class: 'form-control string creator-psu-id creator' %>
 
         <%# orcid_id = "#{id_base}[orcid_id]" %>
         <%#= label_tag orcid_id, 'ORCID ID' %>

--- a/spec/features/generic_work/edit_work_spec.rb
+++ b/spec/features/generic_work/edit_work_spec.rb
@@ -68,6 +68,7 @@ describe 'Editing a work', js: true do
     within('.base-terms') do
       expect(page).to have_selector('h2', text: 'Basic Metadata')
       expect(page).to have_selector('label', text: 'Subtitle')
+      expect(page).to have_selector('label', text: 'Display Name required')
     end
 
     within('#work-media') do


### PR DESCRIPTION
Adds the required label by switching the label to a do end block. Handled slightly differently for creator than other default fields in the form because creator is a special thing.


![screen shot 2018-01-05 at 10 38 11 am](https://user-images.githubusercontent.com/4163828/34615989-b2b09eb4-f204-11e7-977a-511fb863f694.png)
