### PR TITLE
Batch Edit for Rights

### DIFF
--- a/app/forms/batch_edit_form.rb
+++ b/app/forms/batch_edit_form.rb
@@ -16,6 +16,22 @@ class BatchEditForm < Sufia::Forms::BatchEditForm
     model.permissions_attributes = combinator.permissions
   end
 
+  # Copies the single value code from the generic work form to be used exclusively for rights in batch edit
+  # https://github.com/samvera/sufia/wiki/Customizing-Metadata#making-a-default-property-non-repeatable
+  def self.multiple?(field)
+    if [:rights].include? field.to_sym
+      false
+    else
+      super
+    end
+  end
+
+  def self.model_attributes(_)
+    attrs = super
+    attrs[:rights] = Array(attrs[:rights]) if attrs[:rights]
+    attrs
+  end
+
   private
 
     # Assigns each of the combined attributes to {model}, creating an empty array for null attributes.

--- a/spec/features/batch_edit_spec.rb
+++ b/spec/features/batch_edit_spec.rb
@@ -39,6 +39,14 @@ describe 'Batch management of works', type: :feature do
         expect(page).to have_content 'Changes Saved', wait: Capybara.default_max_wait_time * 4
       end
 
+      # Update rights for all works to a single value
+      select 'GNU General Public License', from: 'batch_edit_item_rights'
+      click_button('rights_save')
+      within '#form_rights' do
+        sleep 0.1 until page.text.include?('Changes Saved')
+        expect(page).to have_content 'Changes Saved', wait: Capybara.default_max_wait_time * 4
+      end
+
       # Verify changes
       work1.reload
       work2.reload


### PR DESCRIPTION
All other fields in batch edit are multi-value, so the form is expecting rights to be multi-value. 

Copies most of the single value code from the generic work form, per customization instructions, to be used exclusively for rights in batch edit form. Adds test for batch editing the rights.
  
Fixes #1044 