### PR TITLE
Aligns Fieldset Permission Tab with Work Permission Tab

### DIFF
--- a/app/views/curation_concerns/base/_form_share.html.erb
+++ b/app/views/curation_concerns/base/_form_share.html.erb
@@ -1,5 +1,6 @@
 <h2>Sharing With</h2>
 <% depositor = f.object.depositor %>
+<% object_name = I18n.t("scholarsphere.model_display_name.#{f.object_name}") %>
 
 <div class="alert alert-info hidden" id="save_perm_note">Permissions are
   <strong>not</strong> saved until the &quot;Save&quot; button is pressed at the bottom of the page.</div>
@@ -43,7 +44,7 @@
 </table>
 
 
-<h2>Share work with other users</h2>
+<h2>Share <%= object_name %> with other users</h2>
   <ol class="list-inline help-block">
     <li>Search by name or <%= t('sufia.account_label') %>.</li>
     <li>Select the access level you wish to grant</li>
@@ -67,7 +68,7 @@
   </div>
 </div>
 
-<h2>Share work with groups of users</h2>
+<h2>Share <%= object_name %> with groups of users</h2>
 <ol class="list-inline help-block">
   <li>Select the group.</li>
   <li>Select the access level you wish to grant</li>

--- a/app/views/curation_concerns/base/_share_with.html.erb
+++ b/app/views/curation_concerns/base/_share_with.html.erb
@@ -1,0 +1,15 @@
+<h3>Permission Definitions</h3>
+<dl>
+  <dt>View/Download</dt>
+  <dd>this file (both contents and metadata) is accessible from within <%= application_name %>.</dd>
+  <dt>Edit</dt>
+  <dd>this file (both contents and metadata) can be edited. You may only grant this permission
+    to <%= institution_name %> users and/or groups.</dd>
+</dl>
+
+<p>You may grant &ldquo;View/Download&rdquo; or &ldquo;Edit&rdquo; access for specific users and/or groups to files.
+  Enter a valid <%=t('sufia.account_name') %>, one at a time, select the access level for that user and click
+  "Add User."
+</p>
+
+<%= render 'curation_concerns/file_sets/groups_description' %>

--- a/app/views/curation_concerns/file_sets/_permission_form.html.erb
+++ b/app/views/curation_concerns/file_sets/_permission_form.html.erb
@@ -1,0 +1,20 @@
+<% depositor = f.object.depositor %>
+<% public_perm = f.object.permissions.map { |perm| perm.access if perm.agent_name == "public"}.compact.first %>
+<% public_perm = true if params[:controller] == 'batch' %>
+<% registered_perm = f.object.permissions.map { |perm| perm.access if perm.agent_name == "registered"}.compact.first %>
+
+<h2 id="permissions_display"><% if params[:controller] == 'batch' %>Bulk <% end %>Permissions <% if params[:controller] == 'batch' %>
+      <small>(applied to all files just uploaded)</small><% end %>
+</h2>
+
+<div class="alert alert-info hidden" id="save_perm_note">Permissions are <strong>not</strong> saved until the &quot;Save&quot; button is pressed at the bottom of the page.</div>
+
+<div class="alert alert-warning hidden" role="alert" id="permissions_error">
+  <span id="permissions_error_text"></span>
+</div>
+
+<%= render 'curation_concerns/base/form_permission', f: f %>
+<%= render 'curation_concerns/base/share_with' %>
+<div id="share" data-param-key="<%= f.object.model_name.param_key %>">
+  <%= render 'curation_concerns/base/form_share', f: f, object_type: 'file' %>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -55,6 +55,10 @@ en:
           label: 'Filter your results by'
 
   scholarsphere:
+    model_display_name:
+          generic_work: 'work'
+          file_set: 'file'
+          collection: 'collection'
     upload:
       restrictions_html: "<h3>Maximum Upload Restrictions</h3><ul><li>Individual File Size: 500 MB</li><li>Up to 100 files and totaling less than 1GB in size</li></ul><p><a href='/contact'>Need to upload a larger file? Contact us for support.</a></p>"
       content_policy_html: "<h3>Content Policy</h3><p class='content-policy'>Please review <a href='/about#Content_Policy'>ScholarSphere’s Content Policy</a> to make sure you are not depositing materials that are sensitive.</p>"

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -1,5 +1,6 @@
 en:
   sufia:
+    account_name: "Access Account User ID"
     institution_name: "Penn State"
     institution_name_full: "The Pennsylvania State University"
     deposit_agreement:  "deposit agreement"

--- a/spec/features/file_set/permissions_sharing_spec.rb
+++ b/spec/features/file_set/permissions_sharing_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'feature_spec_helper'
+
+describe 'PermissionsSharing:', type: :feature do
+  let(:work)         { create(:public_work_with_png, file_title: ['stonehenge star people'], depositor: current_user.login) }
+  let(:current_user) { create(:user) }
+  let(:file_set)     { work.file_sets.first }
+  let(:filename)     { '4-20-small.png' }
+
+  before do
+    sign_in(current_user)
+    visit "/concern/file_sets/#{file_set.id}"
+  end
+
+  it 'ensures that content still retains a good document outline for accessibility' do
+    click_link('Edit This File')
+    expect(page).to have_selector('h3', text: 'Permission Definitions')
+    expect(page).to have_selector('dt', text: 'View/Download')
+    expect(page).to have_selector('h2', text: 'Share file with other users')
+    expect(page).to have_selector('h2', text: 'Share file with groups of users')
+    expect(page).to have_selector('h2', text: 'Sharing With')
+  end
+end


### PR DESCRIPTION
Refactors the permissions tab for fiieldsets to more closely resemble the permissions, visibility, sharing section of the work form. Addresses accessibility concerns for the ticket, but not overall for the page. Additional tickets need to be created for the bootlint and WAVE errors.

Fixes #1062 
