### PR TITLE
Copies Value of ORCID ID from Profile to Agent ORCR ID

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -252,6 +252,7 @@ Rails/HttpPositionalArguments:
     - 'spec/controllers/qa/terms_controller_spec.rb'
     - 'spec/controllers/sufia/batch_uploads_controller_spec.rb'
     - 'spec/controllers/zotero_controller_spec.rb'
+    - 'spec/controllers/users_controller_spec.rb'
 
 # Offense count: 2
 Rails/OutputSafety:

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,6 +4,7 @@ class UsersController < ApplicationController
   include Sufia::UsersControllerBehavior
 
   before_action :linkedin_url, only: :show
+  after_action :copy_orcid_id, only: :update
 
   def linkedin_url
     @linkedin_url ||= format_linkedin_url
@@ -23,6 +24,14 @@ class UsersController < ApplicationController
     end
     respond_to do |format|
       format.json { render json: users.first(20).to_json }
+    end
+  end
+
+  def copy_orcid_id
+    agent = Agent.where(psu_id: @user.login).first
+    if @user.orcid.present? && agent.present?
+      agent.orcid_id = @user.orcid
+      agent.save
     end
   end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe UsersController, type: :controller do
+  let(:user) { create(:user, login: 'abc123') }
+  let!(:agent) { create(:agent, psu_id: user.login) }
+
+  before { sign_in user }
+  routes { Sufia::Engine.routes }
+
+  describe '#update' do
+    it 'updates the orcid and copies the orcid to the agent' do
+      expect(agent.orcid_id).to eq nil
+      put :update, user: { 'orcid' => 'http://orcid.org/1234-5678-9012-0000', 'twitter_handle' => '',
+                           'facebook_handle' => '', 'googleplus_handle' => '' },
+                   id: user.login
+      expect(response).to be_redirect
+      user.reload.orcid
+      expect(user.orcid).to eq 'http://orcid.org/1234-5678-9012-0000'
+      expect(agent.reload.orcid_id).to eq 'http://orcid.org/1234-5678-9012-0000'
+    end
+  end
+end


### PR DESCRIPTION
Creates new method in the user controller and checks to see if an orcid from User is present and the User login equals the Agent PSU ID and assigns the value from orcid to orcid_id.

Sets a variable for agent, makes sure that an orcid and agent is present and assigns the orcid from user to agent. Saves agent. Adds permitted parameters.

Tests that there is a redirect after profile update, reloads the user ORCID and makes sure that it is present and equals the correct value. Assigns it to the Agent ORCID ID and saves, then checks to make sure that the value is correct.

refs #1101 