### PR TITLE
forcing UTF8 on all text

### DIFF
--- a/app/indexers/file_set_indexer.rb
+++ b/app/indexers/file_set_indexer.rb
@@ -6,6 +6,13 @@ class FileSetIndexer < CurationConcerns::FileSetIndexer
     super.tap do |solr_doc|
       solr_doc.delete(Solrizer.solr_name(:file_size, CurationConcerns::FileSetIndexer::STORED_INTEGER))
       solr_doc[Solrizer.solr_name(:file_size, CurationConcerns::CollectionIndexer::STORED_LONG)] = object.file_size[0]
+      if solr_doc['all_text_timv'].present?
+        begin
+          solr_doc['all_text_timv'].force_encoding('UTF-8')
+        rescue StandardError => e
+          logger.warn "could not convert File Set content to UTF8 #{object.id} #{e}"
+        end
+      end
     end
   end
 end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -16,6 +16,7 @@ describe CatalogController, type: :controller do
   before do
     allow_any_instance_of(User).to receive(:groups).and_return([])
     allow(file_set).to receive(:extracted_text).and_return(text)
+    allow(text).to receive(:force_encoding).and_return(text)
     allow(file_set).to receive(:original_file).and_return(file)
     allow(work3).to receive(:representative).and_return(file_set)
   end

--- a/spec/indexers/file_set_indexer_spec.rb
+++ b/spec/indexers/file_set_indexer_spec.rb
@@ -33,5 +33,36 @@ describe FileSetIndexer do
       it { is_expected.to include('file_size_lts' => nil) }
       its(:keys) { is_expected.not_to include('file_size_is') }
     end
+
+    context 'with all_text' do
+      let(:text) { instance_double(String) }
+      let(:extracted) { instance_double(Hydra::PCDM::File, content: text) }
+
+      before do
+        allow(file_set).to receive(:extracted_text).and_return(extracted)
+      end
+      it 'forces utf8' do
+        expect(text).to receive(:force_encoding).with('UTF-8').and_return('abc123')
+        subject
+      end
+
+      it 'handles errors with forcing utf8' do
+        expect(text).to receive(:force_encoding).with('UTF-8').and_raise(StandardError.new('blarg'))
+        subject
+      end
+    end
+
+    context 'without all_text' do
+      let(:text) { instance_double(String, blank?: true) }
+      let(:extracted) { instance_double(Hydra::PCDM::File, content: text) }
+
+      before do
+        allow(file_set).to receive(:extracted_text).and_return(extracted)
+      end
+      it 'does not force utf8' do
+        expect(text).not_to receive(:force_encoding)
+        subject
+      end
+    end
   end
 end


### PR DESCRIPTION
Solr has been returning an illegal UTF to Ascii error, which we have been missing becuase it happens in the background.  This will eliminate the error