### PR TITLE
Pass current_ability to form instead of current_user, ref #1038

### DIFF
--- a/app/controllers/batch_edits_controller.rb
+++ b/app/controllers/batch_edits_controller.rb
@@ -10,7 +10,7 @@ class BatchEditsController < ApplicationController
     super
     work = BatchEditItem.new(batch: batch)
     work.depositor = current_user.user_key
-    @form = form_class.new(work, current_user, batch)
+    @form = form_class.new(work, current_ability, batch)
   end
 
   def update


### PR DESCRIPTION
BatchEditsController was passing the current_user to the form instead of
the current_ability, which the form expects.

This wasn't causing any errors since the two classes responded similarly
enough, but we want to be consisted and conform to the form's interface
expectations.