### PR TITLE
Deduplicate creators in batch update, ref #1095

### DIFF
--- a/app/forms/batch_edit_form.rb
+++ b/app/forms/batch_edit_form.rb
@@ -11,7 +11,6 @@ class BatchEditForm < Sufia::Forms::BatchEditForm
   def initialize_combined_fields
     assign_combined_attributes_to_model
     @names = combinator.names
-    model.creators = combinator.creators
     model.admin_set_id = AdminSet::DEFAULT_ID
     model.permissions_attributes = combinator.permissions
   end
@@ -45,6 +44,7 @@ class BatchEditForm < Sufia::Forms::BatchEditForm
       @combinator ||= Combinator.new(batch_document_ids, model_class)
     end
 
+    # @note creator is managed in BatchEditItem
     def combined_attributes
       @combined_attributes ||= combinator.attributes(terms - [:creator])
     end
@@ -67,10 +67,6 @@ class BatchEditForm < Sufia::Forms::BatchEditForm
           results[key] = works.map { |work| work[key].to_a }.flatten.uniq
         end
         results
-      end
-
-      def creators
-        works.map(&:creators).flatten
       end
 
       def names

--- a/app/models/batch_edit_item.rb
+++ b/app/models/batch_edit_item.rb
@@ -27,8 +27,10 @@ class BatchEditItem < ActiveFedora::Base
     range.first
   end
 
-  # Creators are ActiveTriples::Relation which must be cast to arrays before they can be flattened
+  # @return [Array<Alias>] with duplicates removed.
+  # @note Creators are ActiveTriples::Relation which must be cast to arrays before they can be flattened.
   def creators
-    batch.map(&:creators).map(&:to_a).flatten
+    creators = batch.map(&:creators).map(&:to_a).flatten
+    creators.uniq(&:id)
   end
 end

--- a/spec/features/batch_edit_spec.rb
+++ b/spec/features/batch_edit_spec.rb
@@ -4,8 +4,26 @@ require 'feature_spec_helper'
 
 describe 'Batch management of works', type: :feature do
   let(:current_user) { create(:user) }
-  let!(:work1)       { create(:public_work, :with_complete_metadata, depositor: current_user.login) }
-  let!(:work2)       { create(:public_work, :with_complete_metadata, depositor: current_user.login) }
+
+  let(:first_creator) do
+    create(:alias, display_name: 'First Creator', agent: Agent.new(given_name: 'First', sur_name: 'Creator'))
+  end
+
+  let(:second_creator) do
+    create(:alias, display_name: 'Second Creator', agent: Agent.new(given_name: 'Second', sur_name: 'Creator'))
+  end
+
+  let!(:work1) do
+    create(:public_work, :with_complete_metadata,
+           creators: [first_creator, second_creator],
+           depositor: current_user.login)
+  end
+
+  let!(:work2) do
+    create(:public_work, :with_complete_metadata,
+           creators: [first_creator, second_creator],
+           depositor: current_user.login)
+  end
 
   before do
     sign_in_with_named_js(:batch_edit, current_user, disable_animations: true)
@@ -56,10 +74,10 @@ describe 'Batch management of works', type: :feature do
       end
       expect(work1.creators.map(&:display_name)).to contain_exactly('Dr. Creator C. Creator, MD', 'Another Creator')
       expect(work1.creators.map(&:agent).map(&:sur_name)).to contain_exactly('Creator', 'Creator')
-      expect(work1.creators.map(&:agent).map(&:given_name)).to contain_exactly('Another', 'Creator C.')
+      expect(work1.creators.map(&:agent).map(&:given_name)).to contain_exactly('Another', 'Second')
       expect(work2.creators.map(&:display_name)).to contain_exactly('Dr. Creator C. Creator, MD', 'Another Creator')
       expect(work2.creators.map(&:agent).map(&:sur_name)).to contain_exactly('Creator', 'Creator')
-      expect(work2.creators.map(&:agent).map(&:given_name)).to contain_exactly('Another', 'Creator C.')
+      expect(work2.creators.map(&:agent).map(&:given_name)).to contain_exactly('Another', 'Second')
     end
 
     it "displays the field's existing value" do
@@ -70,9 +88,12 @@ describe 'Batch management of works', type: :feature do
       expect(page).to have_css "input#batch_edit_item_keyword[value*='tagtag']"
       expect(page).to have_css "input#batch_edit_item_based_near[value*='based_nearbased_near']"
       expect(page).to have_css "input#batch_edit_item_language[value*='languagelanguage']"
-      expect(find_field(id: 'batch_edit_item[creators][0][given_name]').value).to eq('Creator C.')
+      expect(find_field(id: 'batch_edit_item[creators][0][given_name]').value).to eq('First')
       expect(find_field(id: 'batch_edit_item[creators][0][sur_name]').value).to eq('Creator')
-      expect(find_field(id: 'batch_edit_item[creators][0][display_name]').value).to eq('creatorcreator')
+      expect(find_field(id: 'batch_edit_item[creators][0][display_name]').value).to eq('First Creator')
+      expect(find_field(id: 'batch_edit_item[creators][1][given_name]').value).to eq('Second')
+      expect(find_field(id: 'batch_edit_item[creators][1][sur_name]').value).to eq('Creator')
+      expect(find_field(id: 'batch_edit_item[creators][1][display_name]').value).to eq('Second Creator')
       expect(page).to have_css "input#batch_edit_item_publisher[value*='publisherpublisher']"
       expect(page).to have_css "input#batch_edit_item_subject[value*='subjectsubject']"
       expect(page).to have_css "input#batch_edit_item_related_url[value*='http://example.org/TheRelatedURLLink/']"

--- a/spec/models/batch_edit_item_spec.rb
+++ b/spec/models/batch_edit_item_spec.rb
@@ -23,4 +23,24 @@ describe BatchEditItem do
       its(:visibility) { is_expected.to be_nil }
     end
   end
+
+  describe '#creators' do
+    context 'with unique creators' do
+      let(:creator1) { create(:alias, display_name: 'First Creator', agent: Agent.new(given_name: 'First', sur_name: 'Creator')) }
+      let(:creator2) { create(:alias, display_name: 'Second Creator', agent: Agent.new(given_name: 'Second', sur_name: 'Creator')) }
+      let(:work1) { create(:work, title: ['First batch work'], creators: [creator1]) }
+      let(:work2) { create(:work, title: ['Second batch work'], creators: [creator2]) }
+
+      its(:creators) { is_expected.to contain_exactly(creator1, creator2) }
+    end
+
+    context 'with duplicate creators' do
+      let(:creator1) { create(:alias, display_name: 'First Creator', agent: Agent.new(given_name: 'First', sur_name: 'Creator')) }
+      let(:creator2) { create(:alias, display_name: 'Second Creator', agent: Agent.new(given_name: 'Second', sur_name: 'Creator')) }
+      let(:work1) { create(:work, title: ['First batch work'], creators: [creator1, creator2]) }
+      let(:work2) { create(:work, title: ['Second batch work'], creators: [creator1, creator2]) }
+
+      its(:creators) { is_expected.to contain_exactly(creator1, creator2) }
+    end
+  end
 end


### PR DESCRIPTION
When editing creators in batch edit, duplicate creators were present in
the edit form.

Creators are deduplicated in BatchEditItem using their alias ids.