### PR TITLE
Format title and creators for EZId, ref #1160

### DIFF
--- a/app/services/doi_service.rb
+++ b/app/services/doi_service.rb
@@ -14,8 +14,8 @@ class DOIService
     current_doi = doi(object)
     return current_doi.first if current_doi.present?
 
-    response = client.mint_identifier(handle, 'datacite.creator' => object.creator,
-                                              'datacite.title' => object.title,
+    response = client.mint_identifier(handle, 'datacite.creator' => formatted_creators(object),
+                                              'datacite.title' => object.title.first,
                                               'datacite.publisher' => 'ScholarSphere',
                                               'datacite.publicationyear' => '2018',
                                               target: object.url)
@@ -28,5 +28,12 @@ class DOIService
 
     def doi(object)
       object.doi
+    end
+
+    # @note return a list of creators formatted as Surname, Given; Surname, Given
+    def formatted_creators(object)
+      object.creators.map do |aliased_creator|
+        [aliased_creator.agent.sur_name, aliased_creator.agent.given_name].join(', ')
+      end.join('; ')
     end
 end

--- a/spec/services/doi_service_spec.rb
+++ b/spec/services/doi_service_spec.rb
@@ -6,7 +6,9 @@ describe DOIService do
   subject(:run_service) { service.run(work) }
 
   let(:service) { described_class.new('testhandle', 'testuser', 'testpassword') }
-  let(:work) { create(:work, identifier: identifier) }
+  let(:first_creator) { create(:alias, display_name: 'First Creator', agent: Agent.new(given_name: 'First', sur_name: 'Creator')) }
+  let(:second_creator) { create(:alias, display_name: 'Second Creator', agent: Agent.new(given_name: 'Second', sur_name: 'Creator')) }
+  let(:work) { create(:work, title: ['DOI Title'], creators: [first_creator, second_creator], identifier: identifier) }
 
   context 'existing doi' do
     let(:identifier) { ['doi:10.5072/FK2VT1Q90B'] }
@@ -20,8 +22,8 @@ describe DOIService do
     let(:response_body) { 'success: doi:10.5072/FK2VT1Q90B | ark:/b5072/fk2vt1q90b' }
     let(:client) { instance_double(Ezid::Client) }
     let(:response) { instance_double(Ezid::MintIdentifierResponse, id: doi) }
-    let(:metadata) { { 'datacite.creator' => work.creator,
-                       'datacite.title' => work.title,
+    let(:metadata) { { 'datacite.creator' => 'Creator, First; Creator, Second',
+                       'datacite.title' => 'DOI Title',
                        'datacite.publisher' => 'ScholarSphere',
                        'datacite.publicationyear' => '2018',
                        target: work.url } }


### PR DESCRIPTION
We were sending unformatted arrays to EzId which weren't displayed
correctly.

When creating EzId resources, we need to send formatted titles and
creators.