### PR TITLE
Map our resource types to those in EzId, ref #1167

### DIFF
--- a/app/services/doi_service.rb
+++ b/app/services/doi_service.rb
@@ -3,6 +3,27 @@
 class DOIService
   attr_accessor :client, :handle
 
+  EZID_RESOURCE_TYPES = {
+    'Article' => 'Text',
+    'Audio' => 'Sound',
+    'Book' => 'Book',
+    'Capstone Project' => 'Text',
+    'Conference Proceeding' => 'Text',
+    'Dataset' => 'Dataset',
+    'Image' => 'Image',
+    'Journal' => 'Text',
+    'Map or Cartographic Material' => 'Image',
+    'Part of Book' => 'Text',
+    'Poster' => 'Audiovisual',
+    'Presentation' => 'Audiovisual',
+    'Project' => 'Other',
+    'Report' => 'Text',
+    'Research Paper' => 'Text',
+    'Software or Program Code' => 'Software',
+    'Video' => 'Audiovisual',
+    'Other' => 'Other'
+  }.freeze
+
   def initialize(handle = ScholarSphere::Application.config.doi_handle,
                  user = ScholarSphere::Application.config.doi_user,
                  password = ScholarSphere::Application.config.doi_password)
@@ -14,11 +35,7 @@ class DOIService
     current_doi = doi(object)
     return current_doi.first if current_doi.present?
 
-    response = client.mint_identifier(handle, 'datacite.creator' => formatted_creators(object),
-                                              'datacite.title' => object.title.first,
-                                              'datacite.publisher' => 'ScholarSphere',
-                                              'datacite.publicationyear' => '2018',
-                                              target: object.url)
+    response = client.mint_identifier(handle, response_body(object))
     object.identifier += [response.id]
     object.save
     response.id
@@ -28,6 +45,24 @@ class DOIService
 
     def doi(object)
       object.doi
+    end
+
+    def response_body(object)
+      if object.resource_type.empty?
+        base_body(object)
+      else
+        base_body(object).merge!('datacite.resourcetype' => EZID_RESOURCE_TYPES[object.resource_type.first])
+      end
+    end
+
+    def base_body(object)
+      {
+        'datacite.creator' => formatted_creators(object),
+        'datacite.title' => object.title.first,
+        'datacite.publisher' => 'ScholarSphere',
+        'datacite.publicationyear' => '2018',
+        target: object.url
+      }
     end
 
     # @note return a list of creators formatted as Surname, Given; Surname, Given

--- a/spec/services/doi_service_spec.rb
+++ b/spec/services/doi_service_spec.rb
@@ -3,12 +3,19 @@
 require 'rails_helper'
 
 describe DOIService do
-  subject(:run_service) { service.run(work) }
+  subject(:run_service) { service.run(object) }
 
   let(:service) { described_class.new('testhandle', 'testuser', 'testpassword') }
   let(:first_creator) { create(:alias, display_name: 'First Creator', agent: Agent.new(given_name: 'First', sur_name: 'Creator')) }
   let(:second_creator) { create(:alias, display_name: 'Second Creator', agent: Agent.new(given_name: 'Second', sur_name: 'Creator')) }
-  let(:work) { create(:work, title: ['DOI Title'], creators: [first_creator, second_creator], identifier: identifier) }
+
+  let(:object) do
+    create(:work,
+      title: ['DOI Title'],
+      creators: [first_creator, second_creator],
+      identifier: identifier,
+      resource_type: ['Article'])
+  end
 
   context 'existing doi' do
     let(:identifier) { ['doi:10.5072/FK2VT1Q90B'] }
@@ -26,7 +33,8 @@ describe DOIService do
                        'datacite.title' => 'DOI Title',
                        'datacite.publisher' => 'ScholarSphere',
                        'datacite.publicationyear' => '2018',
-                       target: work.url } }
+                       'datacite.resourcetype' => 'Text',
+                       target: object.url } }
 
     before do
       allow(Ezid::Client).to receive(:new).and_return(client)
@@ -34,8 +42,31 @@ describe DOIService do
 
     it 'mints a new id' do
       expect(client).to receive(:mint_identifier).with('testhandle', metadata).and_return(response)
-      minted_id = service.run(work)
-      expect(work.reload.identifier).to eq([identifier.first, doi])
+      minted_id = service.run(object)
+      expect(object.reload.identifier).to eq([identifier.first, doi])
+      expect(minted_id).to eq(doi)
+    end
+  end
+
+  context 'with a collection' do
+    let(:object) { create(:collection, title: ['DOI Collection']) }
+    let(:doi) { 'doi:10.5072/FK2VT1Q90B' }
+    let(:response_body) { 'success: doi:10.5072/FK2VT1Q90B | ark:/b5072/fk2vt1q90b' }
+    let(:client) { instance_double(Ezid::Client) }
+    let(:response) { instance_double(Ezid::MintIdentifierResponse, id: doi) }
+    let(:metadata) { { 'datacite.creator' => 'Creator, Creator C.',
+                       'datacite.title' => 'DOI Collection',
+                       'datacite.publisher' => 'ScholarSphere',
+                       'datacite.publicationyear' => '2018',
+                       target: object.url } }
+
+    before do
+      allow(Ezid::Client).to receive(:new).and_return(client)
+    end
+
+    it 'creates an id without a resource type' do
+      expect(client).to receive(:mint_identifier).with('testhandle', metadata).and_return(response)
+      minted_id = service.run(object)
       expect(minted_id).to eq(doi)
     end
   end


### PR DESCRIPTION
Our resource types are not compatible with those used in EzId.

When sending DOI requests to EzId, we change the resource type sent to
EzId to match their vocabulary.