### PR TITLE
Required Designation on Display Name Field for New/Edit Works

### DIFF
--- a/app/views/records/edit_fields/_creator.html.erb
+++ b/app/views/records/edit_fields/_creator.html.erb
@@ -48,7 +48,7 @@
 
         <% display_name_id = "#{id_base}[display_name]" %>
         <%= label_tag display_name_id do  %>
-            Display Name <span class="label label-info required-tag">required</span>
+          <%= t('simple_form.labels.display_name') %> <span class="label label-info required-tag">required</span>
         <% end %>
         <%= text_field_tag display_name_id, creator_form.display_name,
               required: true,

--- a/app/views/records/edit_fields/_creator_template.html.erb
+++ b/app/views/records/edit_fields/_creator_template.html.erb
@@ -11,7 +11,7 @@
       <input type="text" {{readonly}} name="<%= @form.model_class_name %>[creators][{{index}}][given_name]" id="<%= @form.model_class_name %>[creators][{{index}}][given_name]" class="form-control string required creator-first-name creator" value="{{firstName}}">
       <label for="<%= @form.model_class_name %>{{index}}_sur_name">Last Name</label>
       <input type="text" {{readonly}} name="<%= @form.model_class_name %>[creators][{{index}}][sur_name]" id="<%= @form.model_class_name %>[creators][{{index}}][sur_name]" class="form-control string required creator-last-name creator" value="{{lastName}}">
-      <label for="{{index}}_display_name">Display Name</label>
+      <label for="{{index}}_display_name"><%= t('simple_form.labels.display_name') %> <span class="label label-info required-tag">required</span></label>
       <input type="text" name="<%= @form.model_class_name %>[creators][{{index}}][display_name]" id="<%= @form.model_class_name %>[creators][{{index}}][display_name]" class="form-control string required creator-display-name creator" value="{{displayName}}" required="required">
       <label for="{{index}}_display_name">Email</label>
       <input type="text" {{readonly}} name="<%= @form.model_class_name %>[creators][{{index}}][email]" id="<%= @form.model_class_name %>[creators][{{index}}][email]" class="form-control string required creator-email creator" value="{{email}}">

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -74,6 +74,7 @@ en:
         date_created: "Published Date"
       generic_work:
         date_created: "Published Date"
+      display_name: 'Display Name'
     hints:
       generic_work:
         creator: "The person or group responsible for the work. Usually this is the author of the content. This makes sure that this item can be searched on all the creators' names. Personal names should be entered with the last name first, e.g. &quot;Smith, John.&quot;."


### PR DESCRIPTION
Adds the label for display name to the sufia.en.yml file and adds the required designation to the mustache template for additional creators.


![screen shot 2018-03-12 at 10 20 00 am](https://user-images.githubusercontent.com/4163828/37289532-440e1c60-25e0-11e8-8009-ee0246583deb.png)
