### PR TITLE
Adding ReCAPTCHA to email form to stop spam

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,4 @@ report.json
 migration_report
 user_emails.txt
 public/uploads
+config/application.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ before_install:
   - "ls -l dep_cache"
   - "cp config/travis/solr_wrapper_test.yml config/solr_wrapper_test.yml"
   - "cp config/travis/fcrepo_wrapper_test.yml config/fcrepo_wrapper_test.yml"
+  - "cp config/sample/application.yml config/application.yml"
 services:
   - redis-server
 before_script:

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'mail', '= 2.6.6.rc1'
 gem 'clamav' unless ENV['TRAVIS'] == 'true'
 gem 'coffee-rails'
 gem 'devise', '~> 4.2'
+gem 'ezid-client'
 gem 'figaro'
 gem 'jbuilder', '~> 2.6'
 gem 'jquery-rails', '~> 4.2'
@@ -29,6 +30,7 @@ gem 'newrelic_rpm'
 gem 'rack-maintenance'
 gem 'rainbow'
 gem 'rdf'
+gem 'recaptcha', require: 'recaptcha/rails'
 gem 'resque-pool'
 gem 'rsolr'
 gem 'sass-rails'
@@ -41,12 +43,12 @@ gem 'turbolinks'
 gem 'uglifier'
 gem 'whenever'
 gem 'yaml_db'
-gem 'ezid-client'
 
 group :development, :test do
+  gem 'capybara-screenshot'
   gem 'coveralls', require: false
-  gem 'fcrepo_wrapper'
   gem 'faker'
+  gem 'fcrepo_wrapper'
   gem 'rspec'
   gem 'rspec-its'
   gem 'rspec-rails'
@@ -54,7 +56,6 @@ group :development, :test do
   gem 'rubocop-rspec', '1.18.0'
   gem 'solr_wrapper'
   gem 'sqlite3'
-  gem 'capybara-screenshot'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -571,6 +571,8 @@ GEM
       rdf (>= 2.2, < 4.0)
     rdf-xsd (2.2.0)
       rdf (~> 2.1)
+    recaptcha (4.6.6)
+      json
     redic (1.5.0)
       hiredis
     redis (3.3.2)
@@ -843,6 +845,7 @@ DEPENDENCIES
   rails (= 4.2.7.1)
   rainbow
   rdf
+  recaptcha
   resque-pool
   rsolr
   rspec
@@ -871,4 +874,4 @@ DEPENDENCIES
   yaml_db
 
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/app/controllers/contact_form_controller.rb
+++ b/app/controllers/contact_form_controller.rb
@@ -7,4 +7,12 @@ class ContactFormController < ApplicationController
   def after_deliver
     UserMailer.acknowledgment_email(params).deliver_now
   end
+
+  before_action :check_recaptcha, only: :create
+
+  def check_recaptcha
+    return if verify_recaptcha(model: @contact_form)
+    flash[:error] = @contact_form.errors.full_messages.map(&:to_s).join(', ')
+    render :new
+  end
 end

--- a/app/views/contact_form/new.html.erb
+++ b/app/views/contact_form/new.html.erb
@@ -1,0 +1,54 @@
+<%# Overrides Sufia to add ReCaptcha tags to form %>
+<h1>Contact</h1>
+<div class="alert alert-info">
+  <%= render 'directions' %>
+</div>
+
+<% if user_signed_in? %>
+  <% nm = current_user.name %>
+  <% em = current_user.email %>
+<% else %>
+  <% nm = '' %>
+  <% em = '' %>
+<% end %>
+
+<h2>Contact Form</h2>
+<%= form_for @contact_form, url: sufia.contact_form_index_path,
+                            html: { class: 'form-horizontal' } do |f| %>
+  <%= f.text_field :contact_method, class: 'hide' %>
+  <div class="form-group">
+    <%= f.label :category, 'Issue Type', class: "col-sm-2 control-label" %>
+    <% issue_types = Sufia::ContactForm::ISSUE_TYPES.dup %>
+    <% issue_types.unshift(['Select an Issue Type', nil]) %>
+    <div class="col-sm-10">
+      <%= f.select 'category', options_for_select(issue_types), {}, {class: 'form-control', required: true } %>
+    </div>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :name, 'Your Name', class: "col-sm-2 control-label" %>
+    <div class="col-sm-10"><%= f.text_field :name, value: nm, class: 'form-control', required: true %></div>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :email, 'Your Email', class: "col-sm-2 control-label" %>
+    <div class="col-sm-10"><%= f.text_field :email, value: em, class: 'form-control', required: true %></div>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :subject, 'Subject', class: "col-sm-2 control-label" %>
+    <div class="col-sm-10"><%= f.text_field :subject, class: 'form-control', required: true %></div>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :message, 'Message', class: "col-sm-2 control-label" %>
+    <div class="col-sm-10"><%= f.text_area :message, rows: 4, class: 'form-control', required: true %></div>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :recaptcha, 'ReCaptcha', class: "col-sm-2 control-label" %>
+    <%= recaptcha_tags %>
+  </div>
+
+  <%= f.submit value: "Send", class: "btn btn-primary" %>
+<% end %>

--- a/config/sample/application.yml
+++ b/config/sample/application.yml
@@ -13,6 +13,8 @@ development:
   read_only: "false"
   doi_user: 'ss1'
   doi_password: 'password'
+  RECAPTCHA_SITE_KEY: 'site-key'
+  RECAPTCHA_SECRET_KEY: 'secret-key'
 test:
   ffmpeg_path: "ffmpeg-test"
   service_instance: "example-test"
@@ -20,6 +22,8 @@ test:
   stats_email: "Test email"
   google_analytics_id: "test-id"
   read_only: "false"
+  RECAPTCHA_SITE_KEY: 'site-key'
+  RECAPTCHA_SECRET_KEY: 'secret-key'
 production:
   TMPDIR: "/tmp"
   ffmpeg_path: "ffmpeg-test"
@@ -31,3 +35,5 @@ production:
   read_only: "false"
   doi_user: 'ss1'
   doi_password: 'password'
+  RECAPTCHA_SITE_KEY: 'site-key'
+  RECAPTCHA_SECRET_KEY: 'secret-key'

--- a/lib/scholarsphere/config.rb
+++ b/lib/scholarsphere/config.rb
@@ -20,7 +20,9 @@ class Scholarsphere::Config
         'derivatives_path',
         'read_only',
         'doi_user',
-        'doi_password'
+        'doi_password',
+        'RECAPTCHA_SITE_KEY',
+        'RECAPTCHA_SECRET_KEY'
       ]
     }.freeze
 

--- a/spec/controllers/contact_form_controller_spec.rb
+++ b/spec/controllers/contact_form_controller_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ContactFormController, type: :controller do
+  routes { Sufia::Engine.routes }
+
+  let(:parameters) do
+    {
+      'category' => 'General inquiry or request',
+      'name' => 'Jane Doe',
+      'email' => 'jzd123@psu.edu',
+      'subject' => 'Test subject',
+      'message' => 'Test message'
+    }
+  end
+
+  context 'when ReCaptcha is enabled' do
+    before { Recaptcha.configuration.skip_verify_env.delete('test') }
+
+    after  { Recaptcha.configuration.skip_verify_env.push('test') }
+
+    # rubocop:disable Rails/HttpPositionalArguments
+    it 'prevents the message from being sent' do
+      expect(Sufia::ContactMailer).not_to receive(:contact)
+      put :create, sufia_contact_form: parameters
+      expect(flash[:error]).to eq('reCAPTCHA verification failed, please try again.')
+    end
+    # rubocop:enable Rails/HttpPositionalArguments
+  end
+
+  context 'when ReCaptcha is not enabled' do
+    let(:mock_mailer) { instance_double('ActionMailer::MessageDelivery') }
+
+    # rubocop:disable Rails/HttpPositionalArguments
+    it 'sends the message' do
+      expect(Sufia::ContactMailer).to receive(:contact).and_return(mock_mailer)
+      expect(mock_mailer).to receive(:deliver_now)
+      expect(UserMailer).to receive(:acknowledgment_email)
+      put :create, sufia_contact_form: parameters
+    end
+    # rubocop:enable Rails/HttpPositionalArguments
+  end
+end

--- a/spec/features/contact_form_spec.rb
+++ b/spec/features/contact_form_spec.rb
@@ -39,6 +39,8 @@ describe 'Contact form:', type: :feature do
     fill_in 'sufia_contact_form_message', with: 'I am contacting you regarding ScholarSphere.'
     fill_in 'sufia_contact_form_subject', with: email_subject
     select 'Depositing content', from: 'sufia_contact_form_category'
+    expect(page).to have_content('ReCAPTCHA')
+    expect(page).to have_selector('div.g-recaptcha')
     click_button 'Send'
     expect(page).to have_content('Thank you for your message!')
     expect(admin_message.subject).to eq("ScholarSphere Contact Form - #{email_subject}")


### PR DESCRIPTION
Uses Google's ReCAPTCHA service to stop spam from getting through via our contact form.

Configuration of the service is documented here: http://sites.psu.edu/dltdocs/?p=4084
And the server configs have been updated, as noted in: http://sites.psu.edu/dltdocs/?p=3521

This has been tested in QA, but still requires some UI work and accessibility verification.
![recaptcha](https://user-images.githubusercontent.com/312085/37350766-fd14fc18-26af-11e8-8806-811df539cc96.png)
