### PR TITLE
Updating Sinatra to address CVE-2018-7212

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -509,10 +509,10 @@ GEM
       faraday
       nokogiri (~> 1.6)
       rails (>= 4.2.0, < 6.0)
-    rack (1.6.8)
+    rack (1.6.9)
     rack-maintenance (2.0.1)
       rack (>= 1.0)
-    rack-protection (1.5.3)
+    rack-protection (1.5.5)
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -677,7 +677,7 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    sinatra (1.4.7)
+    sinatra (1.4.8)
       rack (~> 1.5)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
@@ -871,4 +871,4 @@ DEPENDENCIES
   yaml_db
 
 BUNDLED WITH
-   1.16.0
+   1.16.1


### PR DESCRIPTION
This would go out with 3.4 at the end of the month, unless we want to hotfix this and do a release sooner.