### PR TITLE
Using Code Climate for combined coverage stats

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,34 +14,26 @@ env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
     - JS=true
-  matrix:
-    - TEST_SUITE=feature
-    - TEST_SUITE=unit
-    - TEST_SUITE=rubocop
-before_install:
-  - "export PATH=$PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH"
-  - "which phantomjs"
-  - "phantomjs --version"
-  - "if [ $(phantomjs --version) != '2.1.1' ]; then rm -rf $PWD/travis_phantomjs; mkdir -p $PWD/travis_phantomjs; fi"
-  - "if [ $(phantomjs --version) != '2.1.1' ]; then wget https://assets.membergetmember.co/software/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2; fi"
-  - "if [ $(phantomjs --version) != '2.1.1' ]; then tar -xvf $PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis_phantomjs; fi"
-  - "phantomjs --version"
-  - export PATH="$PATH:$(pwd)/fits"
-  - "mkdir -p dep_cache"
-  - "pwd"
-  - "ls -l dep_cache"
-  - "cp config/travis/solr_wrapper_test.yml config/solr_wrapper_test.yml"
-  - "cp config/travis/fcrepo_wrapper_test.yml config/fcrepo_wrapper_test.yml"
-  - "cp config/sample/application.yml config/application.yml"
+    - secure: "kjSxqq3grvFWkaSJdPSBuh50cdw8J3voSlagGnbO6br8soaKIVjYIB0AYj3ublVTKI92Aoh+aqL0C4AA4Ls5LEX/Pr6P8qFJPGoyDey9b38y+2SMMdxb8p0j+g3YA9C6wDth/f4OrLIH2mrMoVkbk4iUL+6VUFM93fqvgB936BY="
+    - secure: "r/1A96TVGqorCSEVw1E0L727V626MIKG7FSVsE4nFYm5+89CTUPwuF1cew71gWqhL1aDACrzbw9iUcGnYvIclaU0li2fVd+YKbUA3xkTb+Aa8pHWC9tmxWtO/Hu+z9ej2Q0bIWnuQEYY3VEMq9Mvf0TqqePpHcjqAqB3RvST2os="
+    - secure: "IqfEX7SSwGtcB73dOF5rYhPJvwvp3/WG8XKacTsWA5qrJK4CQaNb3OdLYup3KJfrfSLbVkZmHzgAI2HfD+Jo7UX/iXTiHlnCQ+HRfkCo5MezM07E4FaVaGTnFZj6/qrbINGulORzSrTF3qZYm0wX/6kgM8wLzWHeRfzmQ60pmlg="
+    - secure: "G2snfK/GK8rk8emiy3a0wqe+rLJkM0abaPIktgjv0P3SDreQzeDNLyy5GsVG4LhM/QCur3qznlDl5c8/fXQpSrzZb9lsJmu/HX4yjiF+5FtAgPlAnfw0H6Dy1N14E4KhBktHS/EZzv7NLhyzn/ADFSiETHiDHWMQuQvWs8w8iJI="
+    - secure: "jLLPH2btu/jQog37DK4TbU/x7wrE/bYpY14fhxuysHousEemJ2hAFl2uK86v3K4ZdpgPBMBznubvgKihXT5JOEm+PGfmi6kKTPZFCp0+M88F/42eruna9Zl15rl1TwgarGdSadCB8ZAq4iCGXVxiIgvQEq7X1rUlpOpj32jBPUk="
 services:
   - redis-server
-before_script:
-  - "cp config/sample/database.yml config/database.yml"
-  - "cp config/sample/hydra-ldap.yml config/hydra-ldap.yml"
-  - "cp config/sample/share_notify.yml config/share_notify.yml"
-  - "cp config/sample/initializers/qa.rb config/initializers/qa.rb"
-  - redis-cli info
-matrix:
-  fast_finish: true
-script:
-  - "bundle exec rake scholarsphere:travis:$TEST_SUITE"
+stages:
+  - rubocop
+  - test
+  - coverage
+jobs:
+  include:
+    - script: ./travis/test.sh
+      env: TEST_SUITE=feature
+    - script: ./travis/test.sh
+      env: TEST_SUITE=unit
+    - stage: coverage
+      install: skip
+      script: ./travis/coverage.sh
+    - stage: rubocop
+      script: bundle exec rake scholarsphere:travis:rubocop
+

--- a/Gemfile
+++ b/Gemfile
@@ -70,6 +70,7 @@ group :development do
   gem 'capistrano-rbenv-install'
   gem 'capistrano-resque', '~> 0.2.1', require: false
 
+  gem 'travis', require: false
   gem 'unicorn-rails'
   gem 'xray-rails'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,7 @@ GEM
     babel-transpiler (0.7.0)
       babel-source (>= 4.0, < 6)
       execjs (~> 2.0)
+    backports (3.11.1)
     bcrypt (3.1.11)
     better_errors (2.1.1)
       coderay (>= 1.0.0)
@@ -189,6 +190,7 @@ GEM
       execjs
     coffee-script-source (1.10.0)
     concurrent-ruby (1.0.5)
+    connection_pool (2.2.1)
     coveralls (0.8.21)
       json (>= 1.8, < 3)
       simplecov (~> 0.14.1)
@@ -282,6 +284,8 @@ GEM
     equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
     erubis (2.7.0)
+    ethon (0.11.0)
+      ffi (>= 1.3.0)
     execjs (2.7.0)
     ezid-client (1.7.1)
       hashie (~> 3.4, >= 3.4.3)
@@ -296,6 +300,8 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday-encoding (0.0.4)
       faraday
+    faraday_middleware (0.12.2)
+      faraday (>= 0.7.4, < 1.0)
     fcrepo_wrapper (0.6.0)
       ruby-progressbar
     ffi (1.9.18)
@@ -307,6 +313,13 @@ GEM
       jquery-rails
     font-awesome-rails (4.7.0.2)
       railties (>= 3.2, < 5.2)
+    gh (0.14.0)
+      addressable
+      backports
+      faraday (~> 0.8)
+      multi_json (~> 1.0)
+      net-http-persistent (>= 2.7)
+      net-http-pipeline
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     google-api-client (0.13.6)
@@ -337,6 +350,7 @@ GEM
     hashie (3.5.7)
     highcharts-rails (5.0.7)
       railties (>= 3.1)
+    highline (1.7.10)
     hiredis (0.6.1)
     htmlentities (4.3.4)
     http_logger (0.5.1)
@@ -466,6 +480,9 @@ GEM
     namae (0.9.3)
     nest (2.1.0)
       redic
+    net-http-persistent (3.0.0)
+      connection_pool (~> 2.2)
+    net-http-pipeline (1.0.1)
     net-ldap (0.16.1)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
@@ -503,6 +520,9 @@ GEM
     power_converter (0.1.2)
     powerpack (0.1.1)
     public_suffix (3.0.0)
+    pusher-client (0.6.2)
+      json
+      websocket (~> 1.0)
     qa (0.11.1)
       activerecord-import
       deprecation
@@ -760,6 +780,15 @@ GEM
     tinymce-rails-imageupload (4.0.17.beta.3)
       railties (>= 3.2, < 6)
       tinymce-rails (~> 4.0)
+    travis (1.8.8)
+      backports
+      faraday (~> 0.9)
+      faraday_middleware (~> 0.9, >= 0.9.1)
+      gh (~> 0.13)
+      highline (~> 1.6)
+      launchy (~> 2.1)
+      pusher-client (~> 0.4)
+      typhoeus (~> 0.6, >= 0.6.8)
     turbolinks (5.0.1)
       turbolinks-source (~> 5)
     turbolinks-source (5.0.0)
@@ -767,6 +796,8 @@ GEM
       actionpack (>= 3.1)
       jquery-rails
       railties (>= 3.1)
+    typhoeus (0.8.0)
+      ethon (>= 0.8.0)
     tzinfo (1.2.4)
       thread_safe (~> 0.1)
     uber (0.1.0)
@@ -788,6 +819,7 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
+    websocket (1.2.5)
     websocket-driver (0.6.4)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
@@ -864,6 +896,7 @@ DEPENDENCIES
   sqlite3
   sufia (= 7.4.1)
   therubyracer
+  travis
   turbolinks
   uglifier
   unicorn-rails

--- a/travis/coverage.sh
+++ b/travis/coverage.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+echo -e "\n\n\033[0;32mTravis coverage.sh script\033[0m"
+
+echo -e "\n\n\033[1;33mInstalling AWS command line tools\033[0m"
+pip install awscli --upgrade --user
+
+echo -e "\n\n\033[1;33mInstalling Code Climate test reporting tool\033[0m"
+if [ ! -f dep_cache/cc-test-reporter ]; then
+  curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./dep_cache/cc-test-reporter
+  chmod +x ./dep_cache/cc-test-reporter
+fi
+export PATH=$PATH:$(pwd)/dep_cache
+
+echo -e "\n\n\033[1;33mSending combined report to Code Climate\033[0m"
+aws s3 sync s3://psu.edu.scholarsphere-qa/coverage/$TRAVIS_BUILD_NUMBER coverage/
+cc-test-reporter sum-coverage --output - --parts 2 coverage/codeclimate.*.json | cc-test-reporter upload-coverage --input -

--- a/travis/test.sh
+++ b/travis/test.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+echo -e "\n\n\033[0;32mTravis test.sh script\033[0m"
+
+echo -e "\n\n\033[1;33mMaking dependency cache directory\033[0m"
+mkdir -p dep_cache
+echo "Listing directory contents:"
+ls -l dep_cache
+
+echo -e "\n\n\033[1;33mInstalling AWS command line tools\033[0m"
+pip install awscli --upgrade --user
+
+echo -e "\n\n\033[1;33mInstalling PhantomJS\033[0m"
+export PATH=$PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH
+echo -n "Path: "
+which phantomjs
+echo -n "Installed version: "
+phantomjs --version
+if [ $(phantomjs --version) != '2.1.1' ]; then
+  echo "Updating PhantomJS..."
+  rm -rf $PWD/travis_phantomjs
+  mkdir -p $PWD/travis_phantomjs
+  wget https://assets.membergetmember.co/software/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2
+  tar -xvf $PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis_phantomjs
+  echo -n "Updated version: "
+  phantomjs --version
+fi
+
+echo -e "\n\n\033[1;33mInstalling Code Climate test reporting tool\033[0m"
+if [ ! -f dep_cache/cc-test-reporter ]; then
+  curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./dep_cache/cc-test-reporter
+  chmod +x ./dep_cache/cc-test-reporter
+fi
+export PATH=$PATH:$(pwd)/dep_cache
+
+echo -e "\n\n\033[1;33mConfiguring Scholarsphere for test\033[0m"
+export PATH=$PATH:$(pwd)/fits
+cp config/travis/solr_wrapper_test.yml config/solr_wrapper_test.yml
+cp config/travis/fcrepo_wrapper_test.yml config/fcrepo_wrapper_test.yml
+cp config/sample/application.yml config/application.yml
+cp config/sample/database.yml config/database.yml
+cp config/sample/hydra-ldap.yml config/hydra-ldap.yml
+cp config/sample/share_notify.yml config/share_notify.yml
+cp config/sample/initializers/qa.rb config/initializers/qa.rb
+
+echo -e "\n\n\033[1;33mListing Redis information\033[0m"
+redis-cli info
+
+echo -e "\n\n\033[1;33mPrepare coverage report and run the RSpec test\033[0m"
+cc-test-reporter before-build
+bundle exec rake scholarsphere:travis:$TEST_SUITE
+
+echo -e "\n\n\033[1;33mUpload coverage results to AWS\033[0m"
+cc-test-reporter format-coverage --output coverage/codeclimate.$TRAVIS_BUILD_ID.$TEST_SUITE.json
+aws s3 sync coverage/ s3://psu.edu.scholarsphere-qa/coverage/$TRAVIS_BUILD_NUMBER


### PR DESCRIPTION
Refactors our travis build configuration to use stages and upload a combined coverage report to Code Climate. Utilizes AWS, Travis's stage build process, and encrypted environment
variables to authenticate and upload data.

This also refactors the `before_script` directive in travis.yml to its own actual script that is hopefully easier to read. It also includes some colorized output for better readability in the Travis log:

![travis-outout](https://user-images.githubusercontent.com/312085/37604496-82727e74-2b67-11e8-9e26-55032dd3e742.png)

Detailed documentation can be found on the [wiki](https://github.com/psu-stewardship/scholarsphere/wiki/Managing-Travis) and in our dltdocs site. I'll post the link to that in private Slack.

The result looks like:
![travis](https://user-images.githubusercontent.com/312085/37604282-038b7c14-2b67-11e8-8ee6-4f4e9bb006c1.png)
Unfortunately, we won't know what the code climate report actually looks like until we merge the PR.