### PR TITLE
Exclude typeahead.js from Code Climate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,2 @@
+exclude_patterns:
+- "app/assets/javascripts/typeahead.js"


### PR DESCRIPTION
This is unmanaged code and reduces our maintainability score in Code Climate.