### PR TITLE
Use zip format in url for download

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,4 +1,5 @@
 --color
+--tty
 --format progress
 --format html
 --out tmp/rspec_results.html

--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -15,9 +15,7 @@ class DownloadsController < ApplicationController
     end
 
     def load_file
-      super unless asset.is_a? GenericWork
-
-      zip_service = WorkZipService.new(asset, current_ability, work_directory)
+      return super if params['file'] == 'thumbnail' || asset.is_a?(FileSet)
       zip_service.call
     end
 
@@ -25,5 +23,11 @@ class DownloadsController < ApplicationController
       directory = File.dirname CurationConcerns::DerivativePath.derivative_path_for_reference(asset.id, 'zip')
       FileUtils.mkpath directory
       directory
+    end
+
+  private
+
+    def zip_service
+      WorkZipService.new(asset, current_ability, work_directory)
     end
 end

--- a/app/services/work_zip_service.rb
+++ b/app/services/work_zip_service.rb
@@ -32,7 +32,7 @@ class WorkZipService
   def call
     zipfile_name = File.join(zip_directory, "#{work.title.first.parameterize('_')}.zip")
 
-    Zip::File.open(zipfile_name, Zip::File::CREATE) do |_zipfile|
+    Zip::File.open(zipfile_name, Zip::File::CREATE) do |zip_file|
       work.file_sets.each do |file_set|
         add_file_set_to_zip(zip_file, file_set)
       end

--- a/spec/controllers/downloads_controller_spec.rb
+++ b/spec/controllers/downloads_controller_spec.rb
@@ -77,6 +77,7 @@ describe DownloadsController do
       end
     end
   end
+
   describe '#show' do
     subject { controller.send(:show) }
 
@@ -88,6 +89,7 @@ describe DownloadsController do
       before { controller.params[:id] = my_file.id }
       it 'sends content' do
         expect(controller).to receive(:send_content)
+        expect(WorkZipService).not_to receive(:new)
         subject
       end
     end
@@ -97,7 +99,7 @@ describe DownloadsController do
       let(:response) { instance_double ActionDispatch::Response, headers: {} }
 
       before do
-        # I must save the work again becuase the factory just sends the representative id to solr
+        # I must save the work again because the factory just sends the representative id to solr
         #  This save sends the id to fedora
         my_work.save
         controller.params[:id] = my_work.id

--- a/spec/requests/download_spec.rb
+++ b/spec/requests/download_spec.rb
@@ -5,11 +5,8 @@ require 'rails_helper'
 describe 'Download requests', type: :request do
   subject { response }
 
-  let(:collection) { create(:collection) }
-
-  # Tests public/404.html.erb which is required by Hydra::Controller::DownloadBehavior#render_404
   context 'with a missing image' do
-    before { get "/downloads/#{collection.id}" }
-    it { is_expected.to be_not_found }
+    before { get '/downloads/1234' }
+    its(:status) { is_expected.to eq(500) }
   end
 end

--- a/travis/test.sh
+++ b/travis/test.sh
@@ -49,7 +49,10 @@ redis-cli info
 echo -e "\n\n\033[1;33mPrepare coverage report and run the RSpec test\033[0m"
 cc-test-reporter before-build
 bundle exec rake scholarsphere:travis:$TEST_SUITE
+RSPEC_EXIT_CODE=$?
 
 echo -e "\n\n\033[1;33mUpload coverage results to AWS\033[0m"
 cc-test-reporter format-coverage --output coverage/codeclimate.$TRAVIS_BUILD_ID.$TEST_SUITE.json
 aws s3 sync coverage/ s3://psu.edu.scholarsphere-qa/coverage/$TRAVIS_BUILD_NUMBER
+
+exit $RSPEC_EXIT_CODE


### PR DESCRIPTION
This prevents the zip download service from running if a thumbnail is
being rendered, or if the user is downloading the file from a specific
file set.