### PR TITLE
Accessibility of Fileset Permissions Visibility 

### DIFF
--- a/app/assets/stylesheets/scholarsphere/form.scss
+++ b/app/assets/stylesheets/scholarsphere/form.scss
@@ -20,3 +20,6 @@ html > body .form-progress .radio input[type="radio"] {
 .remove-creator {
   padding:0;
 }
+
+/* Removes some extra markup from 3 gems and a different setting for the labels and radio buttons */
+html > body .permission-label { padding-left: 0; }

--- a/app/views/curation_concerns/base/_form_permission.html.erb
+++ b/app/views/curation_concerns/base/_form_permission.html.erb
@@ -9,30 +9,39 @@
   <%= render 'form_permission_under_lease', f: f %>
 <% else %>
   <fieldset class="set-access-controls">
-    <legend>
-      Visibility
-      <small>Who should be able to view or download this content?</small>
+    <legend id="choose_visibility">
+      <%= t('curation_concerns.visibility.legend') %>
     </legend>
-
-    <p>If this is or becomes your representative media, this may impact the display of your work in search results.</p>
-
-    <div class="form-group">
-      <label class="radio">
+    <p class="help-block"><%= t('scholarsphere.file_set.permission_help') %></p>
+    <p><%= t('scholarsphere.file_set.representative_media') %></p>
+    <%# Using the unordered list to match the UI from edit works and explicitly sets label 'for' attribute %>
+    <ul role="radiogroup" aria-labelledby="choose_visibility">
+      <li class="radio">
         <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC %>
-        <%= t('curation_concerns.visibility.open.label_html', type: 'work') %>
-      </label>
-      <label class="radio">
+        <label class="permission-label" for="file_set_visibility_open">
+          <%= t('curation_concerns.visibility.open.label_html', type: 'work') %>
+        </label>
+      </li>
+      <li class="radio">
         <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED %>
-        <%= t('curation_concerns.visibility.authenticated.label_html', institution: t('curation_concerns.institution.name')) %>
-      </label>
-      <label class="radio">
+        <label class="permission-label" for="file_set_visibility_authenticated">
+          <%= t('curation_concerns.visibility.authenticated.label_html', institution: t('curation_concerns.institution.name')) %>
+        </label>
+      </li>
+      <li class="radio">
         <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO %>
-        <%= render "form_permission_embargo", f: f %>
-      </label>
-      <label class="radio">
+        <label class="permission-label" for="file_set_visibility_embargo">
+          <%= t('curation_concerns.visibility.embargo.label_html') %>
+        </label>
+        <%= render 'form_permission_embargo', f: f %>
+      </li>
+      <li class="radio">
         <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LEASE %>
-        <%= render "form_permission_lease", f: f %>
-      </label>
-    </div>
+        <label class="permission-label" for="file_set_visibility_lease">
+          <%= t('curation_concerns.visibility.lease.label_html') %>
+        </label>
+        <%= render 'form_permission_lease', f: f %>
+      </li>
+    </ul>
   </fieldset>
 <% end %>

--- a/app/views/curation_concerns/base/_form_permission_embargo.html.erb
+++ b/app/views/curation_concerns/base/_form_permission_embargo.html.erb
@@ -1,0 +1,8 @@
+<%# Overrides the embargo permission partial because of too many nested labels. We've moved the label to
+  # _form_permission.html.erb and have removed the nesting. One label for the radio button and the following
+  # elements can have their labels for the inputs. %>
+<div class="form-inline">
+  <%= f.input :visibility_during_embargo, wrapper: :inline, collection: visibility_options(:restrict), include_blank: false %>
+  <%= f.input :embargo_release_date, wrapper: :inline, input_html: { value: f.object.embargo_release_date || Date.tomorrow, class: 'datepicker' } %>
+  <%= f.input :visibility_after_embargo, wrapper: :inline, collection: visibility_options(:loosen), include_blank: false %>
+</div>

--- a/app/views/curation_concerns/base/_form_permission_lease.html.erb
+++ b/app/views/curation_concerns/base/_form_permission_lease.html.erb
@@ -1,0 +1,8 @@
+<%# Overrides the lease permission partial because of too many nested labels. We've moved the label to
+  # _form_permission.html.erb and have removed the nesting. One label for the radio button and the following
+  # elements can have their labels for the inputs. %>
+<div class="form-inline">
+  <%= f.input :visibility_during_lease, wrapper: :inline, collection: visibility_options(:loosen), include_blank: false %>
+  <%= f.input :lease_expiration_date, wrapper: :inline, input_html: { value: f.object.lease_expiration_date || Date.tomorrow, class: 'datepicker' } %>
+  <%= f.input :visibility_after_lease, wrapper: :inline, collection: visibility_options(:restrict), include_blank: false %>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -85,6 +85,9 @@ en:
     generic_work:
       readme_heading: 'README'
       readme_text: 'How about adding a README file? We currently accept plain text (README.txt) and markdown (README.md) files.'
+    file_set:
+      permission_help: 'Who should be able to view or download this content?'
+      representative_media: 'If this is or becomes your representative media, this may impact the display of your work in search results.'
 
   statistic:
     report:


### PR DESCRIPTION
Moves the labels and radio buttons into an unordered list and makes adjustments to the styles.

Overrides the form permissions embargo and lease partials from Curation Concerns to address the multiple labels and accessibility.

Removes <small> in header with <p> and a help class to address HTML and accessibility for color contrast. Adds i18n for help block and representative media statement.

refs #1142 