### PR TITLE
Adding rake task to dump and truncate search table

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -35,6 +35,7 @@ module ScholarSphere
     config.doi_handle = ENV.fetch('doi_handle', 'doi:10.5072/FK2') # '10.18113/s1')
     config.doi_user = ENV.fetch('doi_user', '')
     config.doi_password = ENV.fetch('doi_password', '')
+    config.backup_directory = Rails.root.join(ENV.fetch('backup_directory', 'backups'))
 
     # Set the  system to read only mode.  Does not allow new uploads, file edits, new collections, and collection edits
     config.read_only = ENV.fetch('read_only', false)

--- a/config/cronjobs/dump_and_truncate_searches.bash
+++ b/config/cronjobs/dump_and_truncate_searches.bash
@@ -1,0 +1,29 @@
+#!/bin/bash
+#============================================================
+#  Date:         March 21, 2017
+#  Script:       dump_and_truncate_searches.bash
+#  Version:      01
+#  Description:  Used to dump and trincate the search table yearly
+#============================================================
+
+
+if [ -d "/opt/heracles/deploy/scholarsphere/current" ]; then
+  cd /opt/heracles/deploy/scholarsphere/current
+  RAILS_ENV=production
+else
+  echo "You appear to be working on a local machine, we'll set for development"
+  echo "Please ensure you're calling this script from the Rails root directory"
+  RAILS_ENV=development
+fi
+export RAILS_ENV
+
+RESULTS=`bundle exec rake scholarsphere:truncate_searches 2>&1`
+
+if [ $? -ne 0 ]; then
+  SUBJECT="`hostname` truncate search"
+  MESSAGE="bundle exec rake scholarsphere:truncate_searches exited with a non-zero status.  $RESULTS"
+  echo $MESSAGE | mail -s "$SUBJECT" umg-up.its.scholarsphere-support@groups.ucs.psu.edu
+fi
+
+echo $RESULTS
+exit 0;

--- a/config/sample/application.yml
+++ b/config/sample/application.yml
@@ -15,6 +15,7 @@ development:
   doi_password: 'password'
   RECAPTCHA_SITE_KEY: 'site-key'
   RECAPTCHA_SECRET_KEY: 'secret-key'
+  backup_directory: 'backups'
 test:
   ffmpeg_path: "ffmpeg-test"
   service_instance: "example-test"
@@ -24,6 +25,7 @@ test:
   read_only: "false"
   RECAPTCHA_SITE_KEY: 'site-key'
   RECAPTCHA_SECRET_KEY: 'secret-key'
+  backup_directory: 'backups_test'
 production:
   TMPDIR: "/tmp"
   ffmpeg_path: "ffmpeg-test"

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -52,3 +52,8 @@ end
 every 10.minutes, roles: [:job] do
   command "#{path}/config/cronjobs/resque-cleanup.bash"
 end
+
+# yearly
+every '0 0 1 1 *', at: '6:00 am', roles: [:job] do
+  command "#{path}/config/cronjobs/dump_and_truncate_searches.bash"
+end

--- a/lib/tasks/scholarsphere/searches.rake
+++ b/lib/tasks/scholarsphere/searches.rake
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+namespace :scholarsphere do
+  desc 'Truncate sreahces table'
+  task truncate_searches: :environment do
+    settings = Rails.configuration.database_configuration[Rails.env || 'test']
+    output_file = File.join(ScholarSphere::Application.config.backup_directory, "#{settings['database']}-#{Time.now.strftime('%Y%m%d-%H:%M')}.sql")
+
+    command = '/usr/bin/env mysqldump'
+    command = "#{command} -h #{settings['host']}" if settings['host'].present?
+    command = "#{command} -u #{settings['username']} -p#{settings['password']} #{settings['database']} searches > #{output_file}"
+    if system(command)
+      conn = ActiveRecord::Base.connection
+      conn.execute('TRUNCATE searches')
+    else
+      abort('Error running dump')
+    end
+  end
+end

--- a/spec/rake/scholarsphere/searches_spec.rb
+++ b/spec/rake/scholarsphere/searches_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rake'
+
+describe 'scholarsphere:searches_truncate' do
+  let(:backup_folder) { 'backups_test' }
+  let(:backup_dir) { Rails.root.join(backup_folder) }
+  let(:task) { Rails.root.join('lib', 'tasks', 'scholarsphere', 'searches.rake') }
+
+  # set up the rake environment
+  before do
+    ScholarSphere::Application.config.backup_directory = backup_dir
+    load_rake_environment [task]
+    Dir.mkdir(backup_dir)
+  end
+
+  after do
+    FileUtils.rm_rf(backup_dir)
+  end
+
+  describe 'truncate searches', unless: travis? do
+    let(:entries) { Dir.new(backup_dir).entries }
+
+    before do
+      Search.create(query_params: { search_field: 'all_fields', q: 'test', controller: 'catalog', action: 'index' })
+      Search.create(query_params: { search_field: 'all_fields', q: 'test2', controller: 'catalog', action: 'index' })
+      Search.create(query_params: { search_field: 'all_fields', q: 'test3', controller: 'catalog', action: 'index' })
+    end
+    it 'includes all users' do
+      expect(Search.count).to eq(3)
+      run_task 'scholarsphere:truncate_searches'
+      expect(Search.count).to eq(0)
+      expect(entries.size).to eq(3)
+      f = File.open(File.join(backup_dir, entries.last))
+      output = f.read
+      expect(output).to include('search_field: all_fields\n:q: test\n:controller: catalog\n:action: index\n')
+      expect(output).to include('search_field: all_fields\n:q: test2\n:controller: catalog\n:action: index\n')
+      expect(output).to include('search_field: all_fields\n:q: test3\n:controller: catalog\n:action: index\n')
+    end
+  end
+end


### PR DESCRIPTION
refs #1025

Additionally adds cronjob to run it yearly

This has not been tested on a server since QA was unavailable for testing, but I want to put the code out for review.