### PR TITLE
Adding canonical name to alias

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -112,7 +112,7 @@ class CatalogController < ApplicationController
       all_names = search_fields.join(' ')
       title_name = solr_name('title', :stored_searchable)
       field.solr_parameters = {
-        qf: "#{all_names} id all_text_timv",
+        qf: "#{all_names} id all_text_timv agent_name_tesim",
         pf: title_name.to_s
       }
     end

--- a/app/indexers/alias_indexer.rb
+++ b/app/indexers/alias_indexer.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AliasIndexer < Hydra::PCDM::ObjectIndexer
+  def generate_solr_document
+    super.tap do |solr_doc|
+      agent = object.agent
+      next if agent.blank?
+      solr_doc[Solrizer.solr_name('agent_name')] = "#{agent.given_name} #{agent.sur_name}"
+    end
+  end
+end

--- a/app/models/alias.rb
+++ b/app/models/alias.rb
@@ -3,6 +3,8 @@
 class Alias < ActiveFedora::Base
   include Hydra::PCDM::ObjectBehavior
 
+  self.indexer = AliasIndexer
+
   belongs_to :agent, class_name: 'Agent', predicate: ::RDF::Vocab::FOAF.name
 
   property :display_name, predicate: ::RDF::Vocab::FOAF.nick, multiple: false do |index|

--- a/app/search_builders/search_builder.rb
+++ b/app/search_builders/search_builder.rb
@@ -23,4 +23,14 @@ class SearchBuilder < Sufia::CatalogSearchBuilder
     return [] if ability.current_user.administrator?
     super
   end
+
+  # the {!lucene} gives us the OR syntax
+  def new_query
+    "{!lucene}#{interal_query(dismax_query)} #{interal_query(join_for_works_from_files)} #{interal_query(join_for_works_from_agents)}"
+  end
+
+  # join from file id to work relationship solrized file_set_ids_ssim
+  def join_for_works_from_agents
+    "{!join from=#{ActiveFedora.id_field} to=creator_list_ssim}#{dismax_query}"
+  end
 end

--- a/spec/indexers/alias_indexer_spec.rb
+++ b/spec/indexers/alias_indexer_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe AliasIndexer do
+  let(:agent) { build :agent, given_name: 'Sue', sur_name: 'Doe' }
+  let(:alias_item) { build :alias, id: '123abc', agent: agent }
+  let(:indexer) { described_class.new(alias_item) }
+
+  describe '#generate_solr_document' do
+    subject { solr_doc }
+
+    let(:solr_doc) { indexer.generate_solr_document }
+
+    it { is_expected.to include('agent_name_tesim' => 'Sue Doe') }
+  end
+end

--- a/spec/models/alias_spec.rb
+++ b/spec/models/alias_spec.rb
@@ -9,6 +9,12 @@ describe Alias do
     its(:display_name) { is_expected.to eq('Some Name') }
   end
 
+  describe '##indexer' do
+    subject { described_class.indexer }
+
+    it { is_expected.to eq(AliasIndexer) }
+  end
+
   describe '#agent' do
     let(:agent) { create(:agent) }
     let(:agent_alias) { create(:alias, display_name: 'The Real Joe Schmoe', agent: agent) }

--- a/spec/search_builders/search_builder_spec.rb
+++ b/spec/search_builders/search_builder_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe SearchBuilder do
       it 'creates a valid solr join for works and files' do
         subject
         expect(solr_params[:user_query]).to eq user_query
-        expect(solr_params[:q]).to eq '{!lucene}_query_:"{!dismax v=$user_query}" _query_:"{!join from=id to=file_set_ids_ssim}{!dismax v=$user_query}"'
+        expect(solr_params[:q]).to eq '{!lucene}_query_:"{!dismax v=$user_query}" _query_:"{!join from=id to=file_set_ids_ssim}{!dismax v=$user_query}" _query_:"{!join from=id to=creator_list_ssim}{!dismax v=$user_query}"'
       end
     end
 


### PR DESCRIPTION
This allows for user to query via the canonical name and find the aliases
A record with a display name "Carolyn Munson" tied to the Carolyn Cole agent will be found when the user queries for "cole"
The opposite is not true though. With a record with a display name "Carolyn Munson" and a record of with a display name of "Carolyn Cole", tied to the Carolyn Cole agent
  only the "Carolyn Munson" record would be  be found when the user queries for "munson"

refs #992