### PR TITLE
Create spaces in text fields for indexing

### DIFF
--- a/solr/config/mapping.txt
+++ b/solr/config/mapping.txt
@@ -1,0 +1,11 @@
+# Performs pattern replacement on strings prior to tokenization, filtering, and indexing.
+#
+# Transform delimiters to spaces to improve search results.
+#
+# Example:
+#   A work title: "Sample_file.txt" will be separated and indexed as "Sample file txt"
+
+"_" => " "
+"-" => " "
+"\." => " "
+"\/" => " "

--- a/solr/config/schema.xml
+++ b/solr/config/schema.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema name="Scholarsphere" version="1.5">
-	<copyField source="*_tesim" dest="suggest"/>
-	<copyField source="*_ssim" dest="suggest"/>
+	<copyField source="*_tesim" dest="all_text_timv"/>
+	<copyField source="*_ssim" dest="all_text_timv"/>
 	<fields>
 		<field name="_version_" type="long" indexed="true" stored="true"/>
 		<field name="id" type="string" stored="true" indexed="true" multiValued="false" required="true"/>
@@ -131,6 +131,7 @@
 		<fieldType name="location_rpt" class="solr.SpatialRecursivePrefixTreeFieldType" geo="true" distErrPct="0.025" maxDistErr="0.000009" distanceUnits="degrees"/>
 		<fieldType name="text" class="solr.TextField" omitNorms="false">
 			<analyzer>
+				<charFilter class="solr.MappingCharFilterFactory" mapping="mapping.txt"/>
 				<tokenizer class="solr.ICUTokenizerFactory"/>
 				<filter class="solr.ICUFoldingFilterFactory"/>
 				<filter class="solr.TrimFilterFactory"/>

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -46,6 +46,7 @@ describe CatalogController, type: :controller do
     let(:work1)    { build(:public_work, title: ['Test 1 Document'], id: '1') }
     let(:work2)    { build(:public_work, title: ['Test 2 Document'], contributor: ['Contrib2'], id: '2') }
     let(:work3)    { build(:public_work, :with_complete_metadata, id: '3', members: [file_set]) }
+    let(:work4)    { build(:public_work, title: ['TAXgg_Xerumbrepts_100m.tif'], id: '4') }
     let(:user)     { 'user' }
     let(:file)     { mock_file_factory(format_label: ['format_labelformat_label'], mime_type: 'application/pdf') }
 
@@ -67,6 +68,7 @@ describe CatalogController, type: :controller do
       index_work(work1)
       index_work(work2)
       index_work(work3)
+      index_work(work4)
     end
 
     describe 'term search' do
@@ -83,6 +85,13 @@ describe CatalogController, type: :controller do
         expect(response).to render_template('catalog/index')
         expect(assigns(:document_list).count).to be(1)
         expect(assigns(:document_list)[0].fetch(solr_field('title'))[0]).to eql('titletitle')
+      end
+      it 'finds a file by partial title' do
+        xhr :get, :index, q: 'xerumbrepts'
+        expect(response).to be_success
+        expect(response).to render_template('catalog/index')
+        expect(assigns(:document_list).count).to be(1)
+        expect(assigns(:document_list)[0].fetch(solr_field('title'))[0]).to eql('TAXgg_Xerumbrepts_100m.tif')
       end
       it 'finds a file by keyword' do
         xhr :get, :index, q: 'tagtag'
@@ -165,13 +174,13 @@ describe CatalogController, type: :controller do
         xhr :get, :index, q: user
         expect(response).to be_success
         expect(response).to render_template('catalog/index')
-        expect(assigns(:document_list).count).to be(3)
+        expect(assigns(:document_list).count).to be(4)
       end
       it 'finds a file by depositor in advanced search' do
         xhr :get, :index, depositor: user, search_field: 'advanced'
         expect(response).to be_success
         expect(response).to render_template('catalog/index')
-        expect(assigns(:document_list).count).to be(3)
+        expect(assigns(:document_list).count).to be(4)
       end
     end
     describe 'facet search' do


### PR DESCRIPTION
Uses Solr's MappingCharFilterFactory to replace underscores and other
characters with spaces so that search on their parts yields search
results.

Text and string fields are copied to the all_text_timv field, removing
the suggest fields, which aren't being used.

Note: This will require reindexing Solr for the fix to take effect.