### PR TITLE
Adding bootsnap to make the load process faster for rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'blacklight_advanced_search', '~> 6.0'
 gem 'mail', '= 2.6.6.rc1'
 
 # Other components
+gem 'bootsnap', require: false
 gem 'clamav' unless ENV['TRAVIS'] == 'true'
 gem 'coderay'
 gem 'coffee-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,6 +139,8 @@ GEM
       blacklight (~> 6.0, >= 6.0.1)
       parslet
     blankslate (3.1.3)
+    bootsnap (1.2.1)
+      msgpack (~> 1.0)
     bootstrap-sass (3.3.7)
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
@@ -502,6 +504,7 @@ GEM
     mini_portile2 (2.3.0)
     minitest (5.11.3)
     mono_logger (1.1.0)
+    msgpack (1.2.4)
     multi_json (1.13.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
@@ -882,6 +885,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   blacklight_advanced_search (~> 6.0)
+  bootsnap
   byebug
   capistrano (~> 3.7)
   capistrano-bundler (~> 1.2)

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -6,3 +6,5 @@ require 'rubygems'
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 
 require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
+
+require 'bootsnap/setup'


### PR DESCRIPTION
It takes running a single test from 15 seconds to 8 seconds.  It is only helping with the load process, by caching load paths.  It will not cut the entire run time of the test suite by half.