### PR TITLE
Refactor Stylesheet Syntax - SCSS Lint

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -10,6 +10,12 @@
  * defined in the other CSS/SCSS files in this directory. It is generally better to create a new
  * file per style scope.
  *
- *= require_tree .
  *= require_self
+ *= require batch_edit
+ *= require blacklight
+ *= require blacklight_gallery
+ *= require browse_everything
+ *= require openseadragon
+ *= require scholarsphere
+ *= require sufia
  */

--- a/app/assets/stylesheets/blacklight_gallery.css.scss
+++ b/app/assets/stylesheets/blacklight_gallery.css.scss
@@ -1,3 +1,3 @@
-/*
- *= require blacklight_gallery/default
- */
+//
+//= require blacklight_gallery/default
+//

--- a/app/assets/stylesheets/browse_everything.scss
+++ b/app/assets/stylesheets/browse_everything.scss
@@ -1,6 +1,6 @@
 @import 'bootstrap-sprockets';
 @import 'bootstrap';
 
-@import "font-awesome";
+@import 'font-awesome';
 
-@import "browse_everything/browse_everything";
+@import 'browse_everything/browse_everything';

--- a/app/assets/stylesheets/scholarsphere.scss
+++ b/app/assets/stylesheets/scholarsphere.scss
@@ -1,0 +1,6 @@
+@charset "UTF-8";
+
+@import 'scholarsphere/variables', 'scholarsphere/add_edit_work', 'scholarsphere/blacklight_gallery',
+'scholarsphere/collection', 'scholarsphere/creator', 'scholarsphere/dashboard', 'scholarsphere/fixedsticky',
+'scholarsphere/footer', 'scholarsphere/form', 'scholarsphere/header', 'scholarsphere/home_page',
+'scholarsphere/search_results', 'scholarsphere/typography', 'scholarsphere/user_profile', 'scholarsphere/work_show';

--- a/app/assets/stylesheets/scholarsphere/add_edit_work.scss
+++ b/app/assets/stylesheets/scholarsphere/add_edit_work.scss
@@ -1,60 +1,64 @@
-/* Inputfile and label are used to style the input like a button, but use the label as the functional element.
-The Bootstrap btn classes interfere with the input functioning like a button, especially when
-tabbing through the interface, so we replicated the look of the Bootstrap button here. The goal of the whole thing
-was to make the input button with type file be accessible to keyboard users and users of assistive technology and
-visually have a focus just like the other form elements.
-*/
+// Inputfile and label are used to style the input like a button, but use the label as the functional element.
+// The Bootstrap btn classes interfere with the input functioning like a button, especially when
+// tabbing through the interface, so we replicated the look of the Bootstrap button here. The goal of the whole thing
+// was to make the input button with type file be accessible to keyboard users and users of assistive technology and
+// visually have a focus just like the other form elements.
 
 .inputfile {
-  position: absolute;
-  z-index: -1;
-  width: .1px;
   height: .1px;
   opacity: 0;
   overflow: hidden;
+  position: absolute;
+  width: .1px;
+  z-index: -1;
+
+  + label {
+    background-color: $btn-upload-color;
+    border: 1px solid $btn-upload-color-border;
+    border-radius: 4px;
+    color: $primary-white;
+    cursor: pointer;
+    display: inline-block;
+    font-size: 1.04em;
+    font-weight: normal;
+    line-height: 1.4em;
+    margin-bottom: 0;
+    padding: 6px 12px;
+    text-align: center;
+    vertical-align: middle;
+  }
 }
 
-.inputfile + label {
-  display: inline-block;
-  color: white;
-  font-size: 1.04em;
-  font-weight: normal;
-  line-height: 1.4em;
-  text-align: center;
-  vertical-align: middle;
-  background-color: #387f38;
-  border: 1px solid #4cae4c;
-  border-radius: 4px;
-  cursor: pointer;
-  margin-bottom: 0;
-  padding: 6px 12px;
-}
 
 .inputfile:focus + label,
 .inputfile + label:hover {
-  background-color: #449d44;
-  border-color: #398439;
+  background-color: $btn-upload-color-hover;
+  border-color: $btn-upload-color-hover-border;
 }
 
 .inputfile:focus + label,
 .inputfile.has-focus + label {
-  border-color: #66aFe9;
-  box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(102,175,233,.6);
+  border-color: $focus-color-border;
+  box-shadow: inset 0 1px 1px $focus-shadow-color-inset, 0 0 8px $focus-shadow-color;
   outline: 2px;
   outline: -webkit-focus-ring-color auto 5px;
 }
 
-/* Needs specific override for form-control and only target the permissions select */
+// Needs specific override for form-control and only target the permissions select //
+// scss-lint:disable QualifyingElement, SelectorFormat
 select.form-control.select_perm {
   display: inline-block;
   width: auto;
 }
+// scss-lint:enable QualifyingElement, SelectorFormat
 
 .name,
 .filename {
   word-break: break-all;
 }
 
+// scss-lint:disable QualifyingElement, SelectorFormat
 form fieldset .doi_label {
   font-weight: normal;
 }
+// scss-lint:enable QualifyingElement, SelectorFormat

--- a/app/assets/stylesheets/scholarsphere/blacklight_gallery.scss
+++ b/app/assets/stylesheets/scholarsphere/blacklight_gallery.scss
@@ -1,13 +1,14 @@
-/* These styles are very specific to override the thumbnails from blacklight gallery */
-
+// These styles are very specific to override the thumbnails from blacklight gallery
+// scss-lint:disable IdSelector, SelectorDepth
 #documents .grid .document .thumbnail {
   padding: 0;
-}
 
-#documents .grid .document .thumbnail > a > img {
-  position: absolute;
-  left: 0;
-  top: 0;
-  max-width: 100%;
-  max-height: none;
+  > a > img {
+    left: 0;
+    max-height: none;
+    max-width: 100%;
+    position: absolute;
+    top: 0;
+  }
 }
+// scss-lint:enable IdSelector, SelectorDepth

--- a/app/assets/stylesheets/scholarsphere/collection.scss
+++ b/app/assets/stylesheets/scholarsphere/collection.scss
@@ -1,12 +1,14 @@
 .collection-icon,
+.collection-icon-small,
 .collection-icon-search {
-  color: #0072bc;
-}
-.collection_doi_controls legend {
-  border: 0;
-  border-bottom: 1px solid #e5e5e5
+  color: $collection-icon-color;
 }
 
-.collection_doi_controls {
+.collection-doi-controls {
   padding-bottom: 1em;
+
+  legend {
+    border: 0;
+    border-bottom: 1px solid $gray-light;
+  }
 }

--- a/app/assets/stylesheets/scholarsphere/creator.scss
+++ b/app/assets/stylesheets/scholarsphere/creator.scss
@@ -1,23 +1,23 @@
 .btn-link.add-creator {
-  padding:0;
   margin-bottom: 2.5em;
+  padding: 0;
   text-decoration: underline;
 }
 
 .btn-link.remove-creator {
-  float:right;
+  color: $required-red;
+  float: right;
+  padding: 0;
   text-decoration: underline;
-  color: #d9534f;
-  padding:0;
 }
-  
+
 .twitter-typeahead {
-  float:none;
+  float: none;
 }
 
-.find_creator_container {
-  margin-top:1em;
-  margin-bottom:1em;
+.find-creator-container {
+  margin-bottom: 1em;
+  margin-top: 1em;
 }
 
-input.creator { margin-bottom: 1rem; }
+.creator { margin-bottom: 1rem; }

--- a/app/assets/stylesheets/scholarsphere/dashboard.scss
+++ b/app/assets/stylesheets/scholarsphere/dashboard.scss
@@ -1,4 +1,4 @@
-.media-heading a.small,
+.media-heading .small,
 .heading-tile a:hover {
   text-decoration: none;
 }

--- a/app/assets/stylesheets/scholarsphere/fixedsticky.scss
+++ b/app/assets/stylesheets/scholarsphere/fixedsticky.scss
@@ -1,4 +1,5 @@
 @media (min-width: 768px) {
+  // scss-lint:disable VendorPrefix
   .fixedsticky {
     position: -webkit-sticky;
     position: -moz-sticky;
@@ -6,17 +7,20 @@
     position: -o-sticky;
     position: static;
   }
+  // scss-lint:enable VendorPrefix
 
-  /* When position: sticky is supported but native behavior is ignored */
+  // When position: sticky is supported but native behavior is ignored
   .fixedsticky-withoutfixedfixed .fixedsticky-off,
   .fixed-supported .fixedsticky-off {
     position: static;
   }
 
+  // scss-lint:disable ImportantRule
   .fixedsticky-withoutfixedfixed .fixedsticky-on,
   .fixed-supported .fixedsticky-on {
     position: static !important;
   }
+  // scss-lint:enable ImportantRule
 
   .fixedsticky-dummy {
     display: none;

--- a/app/assets/stylesheets/scholarsphere/footer.scss
+++ b/app/assets/stylesheets/scholarsphere/footer.scss
@@ -1,13 +1,13 @@
 .footer-wrapper {
-  padding: 1em;
+  background: $psu-dark-blue;
+  color: $primary-white;
   min-height: 4em;
-  background: #036;
-  color: #fff;
+  padding: 1em;
 }
 
 .footer-wrapper a:link,
 .footer-wrapper a:visited {
-  color: #fff;
+  color: $primary-white;
 }
 
 .footer-logo {
@@ -21,10 +21,10 @@
 
 .footer-version {
   padding: .5em;
-}
 
-.footer-version a:link {
-  text-decoration: underline;
+  a:link {
+    text-decoration: underline;
+  }
 }
 
 .footer-service {
@@ -37,8 +37,8 @@
 
 .footer-text-links-list {
   padding-left: 0;
-}
 
-.footer-text-links-list li {
-  display: inline;
+  li {
+    display: inline;
+  }
 }

--- a/app/assets/stylesheets/scholarsphere/form.scss
+++ b/app/assets/stylesheets/scholarsphere/form.scss
@@ -1,10 +1,12 @@
-/* Needs to be overly specific to override Bootstrap styles coming from 3 gems */
+// Needs to be overly specific to override Bootstrap styles coming from 3 gems
+// scss-lint:disable QualifyingElement, SelectorDepth
 html > body .form-progress .radio input[type="radio"] {
   margin-left: 0;
 }
+// scss-lint:enable QualifyingElement, SelectorDepth
 
 .switch-upload-type {
-  padding: 0.5em 0;
+  padding: .5em 0;
 }
 
 .optional-list {
@@ -13,13 +15,13 @@ html > body .form-progress .radio input[type="radio"] {
 }
 
 .add-creator {
-  padding:0;
-  margin-bottom:2.5em;
+  margin-bottom: 2.5em;
+  padding: 0;
  }
 
 .remove-creator {
-  padding:0;
+  padding: 0;
 }
 
-/* Removes some extra markup from 3 gems and a different setting for the labels and radio buttons */
+// Removes some extra markup from 3 gems and a different setting for the labels and radio buttons
 html > body .permission-label { padding-left: 0; }

--- a/app/assets/stylesheets/scholarsphere/header.scss
+++ b/app/assets/stylesheets/scholarsphere/header.scss
@@ -1,16 +1,16 @@
 @media screen and (min-width: 400px) {
 
   a .user-util-text {
-    color: #fff;
+    color: $primary-white;
     text-decoration: none;
   }
 
-  li.open a .user-util-text {
-    color: #000
+  .open .user-util-text {
+    color: $primary-black;
   }
 
   a:hover .user-util-text {
-    color: #000;
+    color: $primary-black;
   }
 
   .lion-logo {
@@ -18,17 +18,19 @@
     width: 125px;
   }
 
-  /* Needs to be very specific to override code from 3 gems */
+  // Needs to be very specific to override code from 3 gems
+  // scss-lint:disable IdSelector, SelectorDepth
   #masthead .navbar-header > .logo-padding-fix {
-    padding-left: 0;
     margin-left: -5px;
+    padding-left: 0;
   }
 
-  /* Needs to be very specific to override code from 3 gems */
+  // Needs to be very specific to override code from 3 gems
   #masthead .navbar-nav > li > a {
-    color: #fff;
+    color: $primary-white;
     text-decoration: none;
   }
+  // scss-lint:enable IdSelector
 
   .navbar-default .navbar-nav {
     margin-top: 0;
@@ -37,20 +39,20 @@
   .navbar-default .navbar-nav > li > a {
     text-align: center;
   }
-
+  // scss-lint:enable SelectorDepth
   .navbar-header {
-    background-color: #036;
+    background-color: $psu-dark-blue;
   }
 
   .ss-logo a:link,
   .ss-logo a:visited,
   .ss-logo a:hover {
+    color: $primary-white;
     display: block;
-    color: #fff;
-    padding-top: .5em;
-    padding-left: .75em;
     font-size: 1.25em;
     font-weight: 300;
+    padding-left: .75em;
+    padding-top: .5em;
     text-decoration: none;
   }
 
@@ -60,7 +62,7 @@
   }
 
   .ss-toolbar {
-    background-color: #2c76c7;
+    background-color: $toolbar-blue;
   }
 }
 
@@ -71,20 +73,22 @@
 }
 
 @media screen and (max-width: 767px) {
-  /* Needs to be very specific to override code from 3 gems */
+  // Needs to be very specific to override code from 3 gems
+  // scss-lint:disable IdSelector, SelectorDepth
   #masthead .navbar-nav .open .dropdown-menu {
-    background-color: #fff;
+    background-color: $primary-white;
   }
 
-  /* Needs to be very specific to override code from 3 gems */
+  // Needs to be very specific to override code from 3 gems
   #masthead .navbar-nav .open .dropdown-menu > li > a {
-    color: #333;
+    color: $gray-dark;
   }
 
-  /* Needs to be very specific to override code from 3 gems */
+  // Needs to be very specific to override code from 3 gems
   #masthead .navbar-nav .open .dropdown-menu > li > a:hover {
-    background-color: #f5f5f5;
+    background-color: $primary-white;
   }
+  // scss-lint:enable IdSelector, SelectorDepth
 }
 
 @media screen and (min-width: 768px) {
@@ -99,8 +103,8 @@
   .ss-logo a:link,
   .ss-logo a:visited,
   .ss-logo a:hover {
-    padding-top: .5em;
     font-size: 1.5em;
+    padding-top: .5em;
   }
 }
 
@@ -116,7 +120,7 @@
   .ss-logo a:link,
   .ss-logo a:visited,
   .ss-logo a:hover {
-    padding-top: .5em;
     font-size: 1.75em;
+    padding-top: .5em;
   }
 }

--- a/app/assets/stylesheets/scholarsphere/home_page.scss
+++ b/app/assets/stylesheets/scholarsphere/home_page.scss
@@ -1,40 +1,49 @@
-/* Override styles coming from Sufia for better contrast */
+// Override styles coming from Sufia for better contrast
+// scss-lint:disable IdSelector, SelectorDepth
 html > body .navbar-default .navbar-nav > li > a {
-  color: #686868;
+  color: $gray-middle;
   text-decoration: none;
 }
+// scss-lint:enable IdSelector, SelectorDepth
 
+// Overrides style coming from Sufia
+// scss-lint:disable ImportantRule, SelectorFormat
 .marketing {
   margin-bottom: 1.5em;
-}
-/* Overrides style coming from Sufia */
-.marketing > .home_marketing_text {
-  text-shadow: none !important;
-}
 
-.home_marketing_text p {
-  font-size: 1.5em;
-}
+  .home_marketing_text {
+    text-shadow: none !important;
 
-/* Overrides style coming from Sufia */
+    p { font-size: 1.5em; }
+  }
+}
+// scss-lint:enable ImportantRule, SelectorFormat
+
+// Overrides style coming from Sufia
 .marketing-share > .home-share-work {
+  background-color: $marketing-white;
+  border-radius: 4px;
   margin-bottom: 0;
   padding: 1em 0;
-  background-color: #ece6d8;
-  border-radius: 4px;
 }
 
 .home-share-work .btn {
-  border: 2px solid #fff;
+  border: 2px solid $primary-white;
   font-size: 1.4em;
 }
 
-.home-tabs .nav a:link { text-decoration: none; }
+.home-tabs {
+  background-color: $tab-background-color;
+
+  .nav a:link {
+    text-decoration: none;
+  }
+}
 
 .home-share-work p a:link,
 .home-tabs .nav a:link,
 .collection-highlights a:link {
-  color: #2d699e;
+  color: $home-blue;
 }
 
 .home-search {
@@ -42,44 +51,51 @@ html > body .navbar-default .navbar-nav > li > a {
 }
 
 .home-content {
+  margin-bottom: 2em;
   margin-top: 1.5em;
+
+  .tab-content {
+    background-color: $primary-white;
+    border-bottom: 1px solid $tab-border-color;
+    border-left: 1px solid $tab-border-color;
+    border-right: 1px solid $tab-border-color;
+    padding: 1em .75em;
+  }
 }
 
-/* Override Very specific set of declarations coming from Sufia */
-
+// Override Very specific set of declarations coming from Sufia
+// scss-lint:disable IdSelector, QualifyingElement
 div#announcement.container-fluid {
-  font-size: 1.25em;
-  text-align: left;
-  color: black;
-  background-color: #00948a;
-  border: none;
-  padding-top: 0;
+  background-color: $home-green;
+  border: 0;
   border-radius: 0;
+  color: $primary-black;
+  font-size: 1.25em;
+  padding-top: 0;
+  text-align: left;
 }
+// scss-lint:enable IdSelector, QualifyingElement
 
 .announcement {
   padding-bottom: 1em;
+
+  h2 {
+    color: $primary-white;
+    display: inline-block;
+    padding-left: .35em;
+    padding-right: .35em;
+  }
+
+  p {
+    color: $primary-white;
+    font-size: 1.4em;
+    font-weight: 300;
+    padding: 0 .5em .5em;
+  }
 }
 
-.announcement h2 {
-  display: inline-block;
-  color: #fff;
-  padding-left: .35em;
-  padding-right: .35em;
-}
-
-.announcement p {
-  color: #fff;
-  font-size: 1.4em;
-  font-weight: 300;
-  padding: 0 .5em .5em .5em;
-}
-
-.home-tabs {
-  background-color: whitesmoke;
-}
-
-/* Overrides specific styles coming from Sufia */
+// Overrides specific styles coming from Sufia
+// scss-lint:disable IdSelector
 html > body #content-wrapper {
   padding-bottom: 2em;
 }
@@ -87,15 +103,4 @@ html > body #content-wrapper {
 #content-wrapper.home-tabs ul {
   margin-bottom: 0;
 }
-
-.home-content {
-  margin-bottom: 2em;
-}
-
-.home-content .tab-content {
-  padding: 1em .75em;
-  background-color: #fff;
-  border-left: 1px solid #ddd;
-  border-right: 1px solid #ddd;
-  border-bottom: 1px solid #ddd;
-}
+// scss-lint:enable IdSelector

--- a/app/assets/stylesheets/scholarsphere/typography.scss
+++ b/app/assets/stylesheets/scholarsphere/typography.scss
@@ -1,5 +1,4 @@
-/* Needs to be overly specific to override Bootstrap styles coming from 3 gems */
-
+// Needs to be overly specific to override Bootstrap styles coming from 3 gems
 html > body h1,
 html > body h2,
 html > body h3 {
@@ -7,12 +6,12 @@ html > body h3 {
 }
 
 html > body a {
-  color: #2d699e;
+  color: $home-blue;
   text-decoration: underline;
 }
 
-/* Overrides that hop onto existing classes where the UI convention is enough */
-a.btn,
+// Overrides that hop onto existing classes where the UI convention is enough
+.btn,
 .breadcrumb a,
 .dropdown-menu > li > a,
 .facets h3 a,
@@ -22,29 +21,33 @@ a.btn,
 .no-underline,
 .visibility-link { text-decoration: none; }
 
-/* Overrides the heavy default underline on H2 titles in the search */
+// Overrides the heavy default underline on H2 titles in the search
 .blacklight-genericwork h3 > a {
-  text-decoration: none;
-  text-shadow: 0 2px #fff;
   border-bottom: 1px solid;
+  text-decoration: none;
+  text-shadow: 0 2px $primary-white;
 }
 
-/* Label and Button overrides for better contrast ratio */
+// Label and Button overrides for better contrast ratio
 html > body .label { font-weight: normal; }
+
 html > body .label-success,
-html > body .btn-success { background-color: #387f38; }
+html > body .btn-success { background-color: $btn-success-color; }
+
 html > body .label-danger,
-html > body .btn-danger { background-color: #d33a35; }
+html > body .btn-danger { background-color: $btn-danger-color; }
+
 html > body .label-info,
-html > body .btn-info { background-color: #2c76c7; }
+html > body .btn-info { background-color: $btn-info-color; }
+
 html > body .label-warning,
-html > body .btn-warning { background-color: #F0AD1B; }
+html > body .btn-warning { background-color: $btn-warning-color; }
 
 .anchor { text-decoration: none; }
 
 .subtitle {
-  line-height: 1.1;
   font-size: 30px;
-  margin-top: 20px;
   font-weight: 300;
+  line-height: 1.1;
+  margin-top: 20px;
 }

--- a/app/assets/stylesheets/scholarsphere/user_profile.scss
+++ b/app/assets/stylesheets/scholarsphere/user_profile.scss
@@ -1,13 +1,13 @@
 .highlighted-works {
   margin-top: 1em;
-}
 
-.highlighted-works td {
-  padding: .5em .5em .35em .25em;
+  td {
+    padding: .5em .5em .35em .25em;
+  }
 }
 
 .profile dd {
-  color: #a3a3a3;
+  color: $gray-light;
 }
 
 .panel-user h2 {

--- a/app/assets/stylesheets/scholarsphere/variables.scss
+++ b/app/assets/stylesheets/scholarsphere/variables.scss
@@ -1,0 +1,38 @@
+// Color variables to be used throughout ScholarSphere.
+
+$primary-white: #fff;
+$primary-black: #000;
+$gray-light: #e5e5e5;
+$gray-middle: #686868;
+$gray-dark: #333;
+$required-red: #d9534f;
+
+// Home Page
+
+$psu-dark-blue: #036;
+$toolbar-blue: #2c76c7;
+$marketing-white: #ece6d8;
+$home-blue: #2d699e; // More accessible color for the foreground color
+$home-green: #00948a;
+$tab-background-color: #f5f5f5;
+$tab-border-color: #ddd;
+
+// Form elements like buttons or labels that look like buttons (Add Files)
+
+$btn-upload-color: #387f38;
+$btn-upload-color-border: #4cae4c;
+$btn-upload-color-hover: #449d44;
+$btn-upload-color-hover-border: #398439;
+
+$btn-success-color: #387f38;
+$btn-danger-color: #d33a35;
+$btn-info-color: #2c76c7;
+$btn-warning-color: #f0ad1b;
+
+$focus-color-border: #66afe9;
+$focus-shadow-color: rgba(102, 175, 233, .6);
+$focus-shadow-color-inset: rgba(0, 0, 0, .075);
+
+// Icons
+
+$collection-icon-color: #0072bc;

--- a/app/assets/stylesheets/scholarsphere/work_show.scss
+++ b/app/assets/stylesheets/scholarsphere/work_show.scss
@@ -1,5 +1,6 @@
+// scss-lint:disable QualifyingElement
 .attribute-term,
-dd.attribute {
+dd.attribute { // Keeping the dd here so that we don't need to override Sufia
   float: left;
   line-height: 1.5em;
 }
@@ -10,19 +11,24 @@ dd.attribute {
   width: 35%;
 }
 
-dd.attribute + dd.attribute::before {
-  content: ", ";
+dd.attribute + dd.attribute::before { // Keeping the dd here so that we don't need to override Sufia
+  content: ', ';
 }
+// scss-lint:enable QualifyingElement
 
 .border-bottom-1px {
-  border-bottom: 1px solid #999;
-  text-shadow: 1px 2px #fff;
+  border-bottom: 1px solid $gray-dark;
+  text-shadow: 1px 2px $primary-white;
 }
 
 .show-download {
   padding-top: 1em;
 }
+
 .readme h1 { font-size: 2.5rem; }
+
 .readme h2 { font-size: 2rem; }
+
 .readme h3 { font-size: 1.75rem; }
+
 .readme h4 { font-size: 1.5rem; }

--- a/app/assets/stylesheets/sufia.scss
+++ b/app/assets/stylesheets/sufia.scss
@@ -1,10 +1,10 @@
-/* ...
- *= require jquery-ui
- *= require select2
- *= require_self
-*/
+// ...
+ //= require jquery-ui
+ //= require select2
+ //= require_self
+//
 
-@import "bootstrap-sprockets";
+@import 'bootstrap-sprockets';
 @import 'bootstrap';
-@import "font-awesome";
+@import 'font-awesome';
 @import 'sufia/sufia';

--- a/app/views/collections/_form.html.erb
+++ b/app/views/collections/_form.html.erb
@@ -27,7 +27,7 @@
   <% end %>
 
   <% if f.object.show_doi_form? %>
-    <div class="collection_doi_controls">
+    <div class="collection-doi-controls">
       <%= render 'curation_concerns/base/form_doi_component', f: f %>
     </div>
   <% end %>

--- a/app/views/records/edit_fields/_creator.html.erb
+++ b/app/views/records/edit_fields/_creator.html.erb
@@ -1,6 +1,6 @@
 <h3>Creators</h3>
 <div class="form-group multi_value creator_container">
-  <div class="find_creator_container">
+  <div class="find-creator-container">
     <label for="find_creator">Find Creator</label>
     <p class="help-block"><%= t('scholarsphere.creators.search_text') %></p>
     <input type="text"


### PR DESCRIPTION
Breaks hex colors into variables, switches to Sass comments, and adds some skip declarations for the linter when you have to override very specific CSS from other gems.

Reworks the application.css file to load files in a specific order so that the variables load first and then the rest of the files.