### PR TITLE
Enforce scss-lint with Travis

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,0 +1,14 @@
+# scss-lint config file
+
+# Lint all scss files
+scss_files: "**/*.scss"
+
+# Files to exclude
+exclude: 'vendor/*'
+
+# List of gem names to load custom linters from (make sure they are already
+# installed)
+plugin_gems: []
+
+# Default severity of all linters.
+severity: warning

--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,7 @@ group :development, :test do
   gem 'coveralls', require: false
   gem 'faker'
   gem 'fcrepo_wrapper'
-  gem 'niftany', github: 'psu-libraries/niftany', branch: 'master'
+  gem 'niftany'
   gem 'rspec'
   gem 'rspec-its'
   gem 'rspec-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,3 @@
-GIT
-  remote: git://github.com/psu-libraries/niftany.git
-  revision: affb79c583a43e943792243e091e1001e975d1f9
-  branch: master
-  specs:
-    niftany (0.0.1)
-      erb_lint (~> 0.0.22)
-      rubocop (~> 0.51, <= 0.52.1)
-      rubocop-rspec (~> 1.22, <= 1.22.2)
-      scss_lint (~> 0.55)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -520,6 +509,11 @@ GEM
       net-ssh (>= 2.6.5)
     net-ssh (4.1.0)
     newrelic_rpm (3.17.1.326)
+    niftany (0.0.1)
+      erb_lint (~> 0.0.22)
+      rubocop (~> 0.51, <= 0.52.1)
+      rubocop-rspec (~> 1.22, <= 1.22.2)
+      scss_lint (~> 0.55)
     noid (0.9.0)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
@@ -917,7 +911,7 @@ DEPENDENCIES
   namae (= 0.9.3)
   nest
   newrelic_rpm
-  niftany!
+  niftany
   poltergeist (~> 1.9)
   rack-maintenance
   rails (= 4.2.7.1)

--- a/app/views/collections/_show_actions.html.erb
+++ b/app/views/collections/_show_actions.html.erb
@@ -28,7 +28,7 @@
   <%= link_to main_app.download_path(presenter),
               target: :_blank,
               data: { turbolinks: false },
-              class: "btn btn-default" do %>
+              class: 'btn btn-default' do %>
     <%= t('sufia.collection.actions.collection_zip_link') %>
   <% end %>
 </div>

--- a/travis/niftany.sh
+++ b/travis/niftany.sh
@@ -10,6 +10,10 @@ echo -e "\n\n\033[1;33mRunning erb-lint\033[0m"
 bundle exec erblint --lint-all
 ERBLINT_EXIT_CODE=$?
 
+echo -e "\n\n\033[1;33mRunning scss-lint\033[0m"
+bundle exec scss-lint
+SCSSLINT_EXIT_CODE=$?
+
 if [ ! $RUBOCOP_EXIT_CODE -eq 0 ]; then
   echo -e "\n\n\033[1;Rubocop failed!\033[0m"
   exit $RUBOCOP_EXIT_CODE
@@ -18,4 +22,9 @@ fi
 if [ ! $ERBLINT_EXIT_CODE -eq 0 ]; then
   echo -e "\n\n\033[1;erb-lint failed!\033[0m"
   exit $ERBLINT_EXIT_CODE
+fi
+
+if [ ! $SCSSLINT_EXIT_CODE -eq 0 ]; then
+  echo -e "\n\n\033[1;scss-lint failed!\033[0m"
+  exit $SCSSLINT_EXIT_CODE
 fi


### PR DESCRIPTION
Runs scss-lint during the niftany travis build stage to fail builds that have improperly linted sass files.