### PR TITLE
Limit total size of all files uploaded

### DIFF
--- a/app/assets/javascripts/sufia/save_work/uploaded_files.es6
+++ b/app/assets/javascripts/sufia/save_work/uploaded_files.es6
@@ -1,5 +1,6 @@
 // Overrides Sufia to add the fileuploaddestroyed callback so the form re-checks that the file requirement
 // is met. Avoids a bug where works could be created without files if the file was uploaded then deleted.
+
 export class UploadedFiles {
     // Monitors the form and runs the callback when files are added
     // Adds a fileuploaddestroyed callback which is not present in the source code
@@ -22,12 +23,45 @@ export class UploadedFiles {
 
     get hasFiles() {
         let fileField = this.form.find('input[name="uploaded_files[]"]')
-        return fileField.size() > 0
+        this.updatePercentageLimit
+        if (fileField.size() > 0) {
+            if (this.totalUploadSize <= this.totalLimit) {
+                this.element.find("#sizealert").addClass("hidden")
+                return true
+            }
+            else {
+                this.element.find("#sizealert").removeClass("hidden")
+                return false
+            }
+        }
+        else {
+            this.element.find("#sizealert").addClass("hidden")
+            return false
+        }
     }
 
     get hasNewFiles() {
         // In a future release hasFiles will include files already on the work plus new files,
         // but hasNewFiles() will include only the files added in this browser window.
         return this.hasFiles
+    }
+
+    get totalUploadSize() {
+        let total = 0
+        this.form.find('.size').map(function() {
+            if (!isNaN($(this).data('size')))
+                total = total + $(this).data('size')
+        })
+        return total
+    }
+
+    get totalLimit() {
+        return this.element.data('limit')
+    }
+
+    get updatePercentageLimit() {
+        let percentage_value = Math.round((this.totalUploadSize * 100 / this.totalLimit)) + '%'
+        $('#sizeprogress').css('width', percentage_value)
+        $('#sizeprogress').text(percentage_value)
     }
 }

--- a/app/views/curation_concerns/base/_form_files.html.erb
+++ b/app/views/curation_concerns/base/_form_files.html.erb
@@ -2,8 +2,9 @@
         make span an label
         Add aria-hidden to empty spans
         Put help text above the file list
+        Add total upload limit data element in bytes
 # %>
-<div id="fileupload">
+<div id="fileupload" data-limit="<%= Rails.application.config.upload_limit %>">
   <div class="alert alert-success">
     <%= t('sufia.upload.cloud_timeout_message_html', contact_href: link_to(t('sufia.upload.alert.contact_href_text'), sufia.contact_form_index_path)) %>
   </div>
@@ -52,8 +53,20 @@
 
   <!-- The table listing the files available for upload/download -->
   <h2><%= t('scholarsphere.upload.available') %></h2>
+  <h3><%= t('scholarsphere.upload.limit.heading') %></h3>
+  <div class="progress">
+    <div id="sizeprogress" class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" style="width: 0%;">
+      0 bytes
+    </div>
+  </div>
+  <div id="sizealert" class="alert alert-danger hidden" role="alert" aria-live="assertive">
+    <%= t('scholarsphere.upload.limit.warning') %>
+  </div>
   <table class="table table-striped" aria-live="assertive">
-    <caption><%= t('scholarsphere.upload.caption') %></caption>
+    <caption>
+      <%= t('scholarsphere.upload.caption',
+          upload_limit: number_to_human_size(Rails.application.config.upload_limit)) %>
+      </caption>
     <thead>
       <tr>
         <th scope="col">File</th>

--- a/app/views/sufia/uploads/_js_templates.html.erb
+++ b/app/views/sufia/uploads/_js_templates.html.erb
@@ -53,7 +53,7 @@
               {% if (file.error) { %}
                   <div><span class="label label-danger">Error</span> {%=file.error%}</div>
               {% } %}
-              <span class="size">{%=o.formatFileSize(file.size)%}</span>
+              <span class="size" data-size="{%=file.size%}">{%=o.formatFileSize(file.size)%}</span>
               <button class="btn btn-danger delete pull-right" data-type="{%=file.deleteType%}" data-url="{%=file.deleteUrl%}"{% if (file.deleteWithCredentials) { %} data-xhr-fields='{"withCredentials":true}'{% } %}>
                   <i class="glyphicon glyphicon-trash"></i>
                   <span>Delete</span>
@@ -106,7 +106,7 @@
             {% } %}
         </td>
         <td>
-            <span class="size">{%=o.formatFileSize(file.size)%}</span>
+            <span class="size" data-size="{%=file.size%}">{%=o.formatFileSize(file.size)%}</span>
         </td>
         <td>
             <button class="btn btn-danger delete" aria-label="Delete file from uploads"

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,6 +36,7 @@ module ScholarSphere
     config.doi_user = ENV.fetch('doi_user', '')
     config.doi_password = ENV.fetch('doi_password', '')
     config.backup_directory = Rails.root.join(ENV.fetch('backup_directory', 'backups'))
+    config.upload_limit = ENV.fetch('upload_limit', 10.gigabyte.to_s)
 
     # Set the  system to read only mode.  Does not allow new uploads, file edits, new collections, and collection edits
     config.read_only = ENV.fetch('read_only', false)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,8 +73,11 @@ en:
       content_policy_html: "<h3>Content Policy</h3><p class='content-policy'>Please review <a href='/about#Content_Policy'>ScholarSphere’s Content Policy</a> to make sure you are not depositing materials that are sensitive.</p>"
       progress: "Saving your work. This may take a few moments"
       available: "Files Available for Upload"
-      caption: "Listing of files ready to be uploaded"
+      caption: "Listing of files ready to be uploaded. Total size for all combined files is restricted to %{upload_limit}."
       local: "Files must be added before they can be uploaded"
+      limit:
+        heading: 'Total Upload Size'
+        warning: "Selected size exceeds the maximum allowed for upload. Please remove some files before continuing."
     batch_edit:
       permissions_warning: "Warning! Making changes to visibility or sharing permissions will remove any existing permissions on the files in this batch and replace them with the ones specified here."
     import_url:

--- a/spec/config/application_spec.rb
+++ b/spec/config/application_spec.rb
@@ -40,4 +40,10 @@ describe 'Application configuration' do
 
     it { is_expected.to eq('test-id') }
   end
+
+  describe 'Upload limit' do
+    subject { config.upload_limit }
+
+    it { is_expected.to eq('10737418240') }
+  end
 end

--- a/spec/features/generic_work/restricted_upload_spec.rb
+++ b/spec/features/generic_work/restricted_upload_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'feature_spec_helper'
+
+describe GenericWork, type: :feature do
+  include Selectors::Dashboard
+
+  context 'when restricting total upload size' do
+    let(:current_user) { create(:user) }
+
+    before do
+      Rails.application.config.upload_limit = '30'
+      sign_in_with_named_js(:restricted_upload, current_user, disable_animations: true)
+      visit('/concern/generic_works/new')
+    end
+
+    after { Rails.application.config.upload_limit = '1000000' }
+
+    it 'prevents submitting the form' do
+      # Verify file requirement is not met and no limit error is shown
+      click_on 'Files'
+      expect(page).to have_selector('#sizealert', visible: false)
+      within('#required-files') do
+        expect(page).to have_link('Add files')
+      end
+      expect(page).to have_content('Total size for all combined files is restricted to 30 Bytes.')
+
+      # Attach a file larger than the limit
+      attach_file('files[]', test_file_path('readme.md'), visible: false)
+      check 'agreement'
+      click_on 'Upload all local files'
+      sleep(5)
+
+      # Verify error messages
+      expect(page).to have_selector('#sizeprogress', text: '133%')
+      expect(page).to have_selector('#sizealert', text: 'Selected size exceeds the maximum allowed for upload',
+                                                  visible: true)
+      within('#required-files') do
+        expect(page).to have_link('Add files')
+      end
+
+      # Delete and add smaller file
+      click_on 'Delete'
+      sleep(2)
+      expect(page).to have_selector('#sizealert', visible: false)
+      within('#required-files') do
+        expect(page).to have_link('Add files')
+      end
+      attach_file('files[]', test_file_path('little_file.txt'), visible: false)
+      click_on 'Upload all local files'
+      sleep(5)
+
+      # Verify file requirement is met and no errors are present
+      expect(page).to have_selector('#sizeprogress', text: '20%')
+      expect(page).to have_selector('#sizealert', visible: false)
+      within('#required-files') do
+        expect(page).to have_link('Required files complete')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Enforces a limit when uploading files to a work. Total size of all files
uploaded via BrowseEverything and local files cannot exceed a configured
amount in bytes.

Monitors the total size with a progress bar:
![exceeded](https://user-images.githubusercontent.com/312085/38274412-bc5211d0-375c-11e8-957c-9fe334691a18.png)
And shows an error when the limit is exceeded:
![exceeded_2](https://user-images.githubusercontent.com/312085/38274438-c7290f8c-375c-11e8-8ab0-1ec95a0f66f2.png)

