### PR TITLE
Adds the Collection Info to the Work in the My Works List

### DIFF
--- a/app/assets/stylesheets/scholarsphere/work_show.scss
+++ b/app/assets/stylesheets/scholarsphere/work_show.scss
@@ -16,6 +16,14 @@ dd.attribute + dd.attribute::before { // Keeping the dd here so that we don't ne
 }
 // scss-lint:enable QualifyingElement
 
+.list-style { padding-left: 0; }
+
+.inline-list { display: inline; }
+
+.part-of:not(:first-child)::before {
+  content: ', ';
+}
+
 .border-bottom-1px {
   border-bottom: 1px solid $gray-dark;
   text-shadow: 1px 2px $primary-white;

--- a/app/views/my/_index_partials/_list_works.html.erb
+++ b/app/views/my/_index_partials/_list_works.html.erb
@@ -23,10 +23,6 @@
           <a href="#" class="small" title="Click for more details">
             <span id="expand_<%= document.id %>" class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
           </a>
-
-          <br />
-          <%= render_collection_links(document) %>
-
         </div>
       </div>
     </div>
@@ -46,11 +42,11 @@
   </td>
 </tr>
 <tr id="detail_<%= document.id %>">
-  <td colspan="6">
+  <td colspan="5">
     <dl class="expanded-details row">
-      <dt class="col-xs-3 col-lg-2">Creator:</dt>
+      <dt class="col-xs-3 col-lg-2"><%= t('sufia.dashboard.my.creator') %></dt>
       <dd class="col-xs-9 col-lg-10"><%= document.creator.to_a.to_sentence %></dd>
-      <dt class="col-xs-3 col-lg-2">Depositor:</dt>
+      <dt class="col-xs-3 col-lg-2"><%= t('sufia.dashboard.my.depositor') %></dt>
       <dd class="col-xs-9 col-lg-10"><%= link_to_profile document.depositor %></dd>
       <dt class="col-xs-3 col-lg-2"><%= t('sufia.dashboard.my.collection_list.edit_access') %></dt>
       <dd class="col-xs-9 col-lg-10">
@@ -60,6 +56,7 @@
         <% end %>
         <%= t('sufia.dashboard.my.collection_list.users') %> <%= document.edit_people.join(', ') %>
       </dd>
+        <%= render 'my/part_of_collection', collection_presenters: presenter.collection_presenters %>
     </dl>
   </td>
 </tr>

--- a/app/views/my/_part_of_collection.html.erb
+++ b/app/views/my/_part_of_collection.html.erb
@@ -1,0 +1,12 @@
+<% if collection_presenters.present? %>
+<dt class="col-xs-3 col-lg-2"><%= t('sufia.dashboard.my.collection') %></dt>
+  <dd class="col-xs-9 col-lg-10">
+    <ul class="list-style">
+      <% collection_presenters.each do |collection| %>
+        <li class="part-of inline-list">
+          <%= link_to collection.to_s, main_app.collection_path(collection) %>
+        </li>
+      <% end %>
+    </ul>
+  </dd>
+<% end %>

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -26,6 +26,11 @@ en:
       transfer_files_link: "Select files to transfer"
       my:
         shares: 'Shared with Me'
+        creator: 'Creator'
+        depositor: 'Depositor'
+        collection: 'Collection'
+        collection_list:
+          edit_access: 'Edit Access'
     homepage:
       recently_uploaded:
         tab_label: 'Recent Additions'

--- a/spec/views/my/_part_of_collection.html.erb_spec.rb
+++ b/spec/views/my/_part_of_collection.html.erb_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'my/_part_of_collection.html.erb', type: :view do
+  let(:collection1) { build :collection, title: ['Collection Uno'], id: '123' }
+  let(:collection2) { build :collection, title: ['Collection Dos'], id: '133' }
+
+  before do
+    render 'my/part_of_collection', collection_presenters: collection_presenters
+  end
+
+  context 'when the work is a part of collections' do
+    let(:collection_presenters) { [CollectionPresenter.new(collection1, nil),
+                                   CollectionPresenter.new(collection2, nil)] }
+
+    it 'displays the list of collections the work is a part of' do
+      expect(rendered).to have_selector('ul')
+      expect(rendered).to have_selector('li', text: 'Collection Uno')
+      expect(rendered).to have_selector('li', text: 'Collection Dos')
+    end
+  end
+
+  context 'when the work is not part of any collections' do
+    let(:collection_presenters) { nil }
+
+    it 'does not display the list' do
+      expect(rendered).to eq ''
+    end
+  end
+end


### PR DESCRIPTION
Reuses the collection presenter from the work show page to display an inline list of collections. Adding the if statement back into the block just like in the work show view so that works without collections do not show the part of empty statement.

Moves the collection information to the metadata details under the disclosure triangle. Adds the description terms to the sufia yml file.