### PR TITLE
Require zip

### DIFF
--- a/app/services/work_zip_service.rb
+++ b/app/services/work_zip_service.rb
@@ -12,6 +12,8 @@
 #
 #   zip_file_name = service.call
 #
+require 'zip'
+
 class WorkZipService
   attr_reader :resource, :ability, :zip_directory
 


### PR DESCRIPTION
Downloading zips from our server environment was failing because the Zip
module was not being loaded. Because the error was not occurring during
local development, the issue is likely due to the eager loading in
development that is not present in production Rails environments.