### PR TITLE
Add .zip extension to zipped collections

### DIFF
--- a/app/services/collection_zip_service.rb
+++ b/app/services/collection_zip_service.rb
@@ -10,7 +10,7 @@ class CollectionZipService < WorkZipService
     def add_files_to_zip(zipfile, work)
       return unless ability.can? :read, work.id
 
-      zipfile.add(work.title.first, WorkZipService.new(work, ability, zip_directory).call) do
+      zipfile.add("#{work.title.first}.zip", WorkZipService.new(work, ability, zip_directory).call) do
         true
       end
     end

--- a/spec/services/collection_zip_service_spec.rb
+++ b/spec/services/collection_zip_service_spec.rb
@@ -46,7 +46,7 @@ describe CollectionZipService do
 
       it 'creates a zip and filters the files we do not have access to read' do
         is_expected.to eq('tmp/collection_with_works.zip')
-        expect(zip_file.entries.map(&:name)).to contain_exactly(work1.title.first, work2.title.first)
+        expect(zip_file.entries.map(&:name)).to contain_exactly('First Work.zip', 'Second Work.zip')
       end
     end
 


### PR DESCRIPTION
The .zip extension was missing to files of zipped works that were in a
collection. As a result, when the collection zip was expanded, the files
in it had no extension and could not be opened.

This adds the extension to all work zip files created in a zipped
collection.