### PR TITLE
Adding indexing of other aliases to current alias

### DIFF
--- a/app/indexers/alias_indexer.rb
+++ b/app/indexers/alias_indexer.rb
@@ -5,7 +5,10 @@ class AliasIndexer < Hydra::PCDM::ObjectIndexer
     super.tap do |solr_doc|
       agent = object.agent
       next if agent.blank?
-      solr_doc[Solrizer.solr_name('agent_name')] = "#{agent.given_name} #{agent.sur_name}"
+      aliases = object.other_aliases_for_my_agent
+      name =  agent.display_name
+      name = "#{name}, #{aliases.map(&:display_name).join(', ')}" if aliases.present?
+      solr_doc[Solrizer.solr_name('agent_name')] = name
     end
   end
 end

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -22,4 +22,8 @@ class Agent < ActiveFedora::Base
   property :orcid_id, predicate: ::RDF::URI('http://dbpedia.org/ontology/orcidId'), multiple: false do |index|
     index.as :stored_searchable, :symbol
   end
+
+  def display_name
+    "#{given_name} #{sur_name}"
+  end
 end

--- a/app/models/alias.rb
+++ b/app/models/alias.rb
@@ -7,7 +7,21 @@ class Alias < ActiveFedora::Base
 
   belongs_to :agent, class_name: 'Agent', predicate: ::RDF::Vocab::FOAF.name
 
+  after_save :update_alias_indexes
+
   property :display_name, predicate: ::RDF::Vocab::FOAF.nick, multiple: false do |index|
     index.as :stored_searchable, :symbol
+  end
+
+  def update_alias_indexes
+    others_aliases = other_aliases_for_my_agent
+    return if others_aliases.blank? || previous_changes.exclude?('display_name')
+
+    others_aliases.each(&:update_index)
+  end
+
+  def other_aliases_for_my_agent
+    return if agent.blank?
+    agent.reload.aliases.reject { |current_alias| current_alias.id == id }
   end
 end

--- a/spec/indexers/alias_indexer_spec.rb
+++ b/spec/indexers/alias_indexer_spec.rb
@@ -3,8 +3,8 @@
 require 'rails_helper'
 
 describe AliasIndexer do
-  let(:agent) { build :agent, given_name: 'Sue', sur_name: 'Doe' }
-  let(:alias_item) { build :alias, id: '123abc', agent: agent }
+  let(:agent) { create :agent, given_name: 'Sue', sur_name: 'Doe' }
+  let(:alias_item) { create :alias, agent: agent }
   let(:indexer) { described_class.new(alias_item) }
 
   describe '#generate_solr_document' do
@@ -13,5 +13,15 @@ describe AliasIndexer do
     let(:solr_doc) { indexer.generate_solr_document }
 
     it { is_expected.to include('agent_name_tesim' => 'Sue Doe') }
+
+    context 'additional aliases' do
+      let(:alias2) { create :alias, agent: agent, display_name: 'mickey mouse' }
+
+      before do
+        alias_item
+        alias2
+      end
+      it { is_expected.to include('agent_name_tesim' => 'Sue Doe, mickey mouse') }
+    end
   end
 end

--- a/spec/models/alias_spec.rb
+++ b/spec/models/alias_spec.rb
@@ -23,5 +23,17 @@ describe Alias do
       expect(agent_alias.agent.id).to eq(agent.id)
       expect(agent.aliases).to contain_exactly(agent_alias)
     end
+
+    context 'agent has additional aliases' do
+      let(:other_alias) { create(:alias, display_name: 'Jane Doe too', agent: agent) }
+
+      before { other_alias }
+
+      it 'links to the agent' do
+        expect(agent_alias.agent.id).to eq(agent.id)
+        expect(agent.aliases).to contain_exactly(agent_alias, other_alias)
+        expect(described_class.where(Solrizer.solr_name('agent_name') => agent.display_name)).to contain_exactly(agent_alias, other_alias)
+      end
+    end
   end
 end


### PR DESCRIPTION
refs #992 

I am not entirely certain the performance impact re indexing all aliases on an Agent when one alias changes has.  Not sure if we should or should not include this with the current release...

This does allow for 
Carolyn Cole linked to Carolyn Munson as a alias
Work1 - Display name Carolyn Cole
Work2 - Display name Carolyn Munson
Search for Cole returns work1 & work2
Search for Munson returns work2 & work1 # this is the part this PR is fixing