### PR TITLE
Unbold Description Terms and Bold Description Definitions

### DIFF
--- a/app/assets/stylesheets/scholarsphere/typography.scss
+++ b/app/assets/stylesheets/scholarsphere/typography.scss
@@ -51,3 +51,7 @@ html > body .btn-warning { background-color: $btn-warning-color; }
   line-height: 1.1;
   margin-top: 20px;
 }
+
+// Overrides default Bootstrap styles for description lists and needs to be overly specific
+html > body dt { font-weight: normal; }
+html > body dd { font-weight: bold; }


### PR DESCRIPTION
Overrides Bootstrap styles system-wide for description lists, so that the term is no longer bold and the definition is now bold. This one's for @olendorf because we like him.