### PR TITLE
Remove the link to the statistics

### DIFF
--- a/app/views/sufia/admin/_sidebar.html.erb
+++ b/app/views/sufia/admin/_sidebar.html.erb
@@ -1,0 +1,30 @@
+<ul class="admin-sidebar nav nav-pills nav-stacked">
+  <li class="<%= 'active' if current_page? sufia.admin_features_path %>">
+    <%= link_to sufia.admin_features_path do %>
+      <span class="fa fa-cog"></span> <%= t('sufia.admin.sidebar.settings') %>
+    <% end %>
+  </li>
+  <li class="<%= 'active' if current_page? sufia.admin_admin_sets_path %>">
+    <%= link_to sufia.admin_admin_sets_path do %>
+      <span class="fa fa-sitemap"></span> <%= t('sufia.admin.sidebar.admin_sets') %>
+    <% end %>
+  </li>
+  <li>
+    <a role="button" class="collapsed collapse-toggle" data-toggle="collapse" href="#collapseWorkflows" aria-expanded="false" aria-controls="collapseWorkflows">
+      <span class="fa fa-code-fork"></span>
+      <span><%= t('sufia.admin.sidebar.workflow') %></span>
+    </a>
+    <ul class="collapse nav nav-pills nav-stacked" id="collapseWorkflows">
+      <li class="<%= 'active' if current_page? curation_concerns.admin_workflow_path %>">
+        <%= link_to curation_concerns.admin_workflow_path do %>
+          <span class="fa fa-flag"></span> <%= t('sufia.admin.sidebar.workflow_review') %>
+        <% end %>
+      </li>
+      <li class="<%= 'active' if current_page? curation_concerns.admin_workflow_roles_path %>">
+        <%= link_to curation_concerns.admin_workflow_roles_path do %>
+          <span class="fa fa-users"></span> <%= t('sufia.admin.sidebar.workflow_roles') %>
+        <% end %>
+      </li>
+    </ul>
+  </li>
+</ul>


### PR DESCRIPTION
Removes the statistics link until the statistics can work properly. To @DanCoughlin from the Repo Team. 

<img width="1093" alt="screen shot 2018-05-23 at 6 38 17 pm" src="https://user-images.githubusercontent.com/4163828/40454996-f6ce1f42-5eb8-11e8-9fee-8176b0c6c4ae.png">
 