### PR TITLE
Fix Color Contrast Error for User Profile

### DIFF
--- a/app/assets/stylesheets/scholarsphere/user_profile.scss
+++ b/app/assets/stylesheets/scholarsphere/user_profile.scss
@@ -7,7 +7,7 @@
 }
 
 .profile dd {
-  color: $gray-light;
+  color: $gray-middle;
 }
 
 .panel-user h2 {

--- a/app/views/curation_concerns/base/_guts4form.html.erb
+++ b/app/views/curation_concerns/base/_guts4form.html.erb
@@ -45,3 +45,4 @@
       <%= render 'form_progress', f: f %>
     </div>
   </div>
+</div>


### PR DESCRIPTION
Ends an open <div> from develop and uses the middle gray for the user profile to improve the contrast ratio.


![screen shot 2018-05-24 at 8 58 26 am](https://user-images.githubusercontent.com/4163828/40486979-c9205484-5f30-11e8-8135-a86079507fce.png)
