### PR TITLE
APPINT-2119: Added dce_fedora deploy target

### DIFF
--- a/config/deploy/dce_fedora.rb
+++ b/config/deploy/dce_fedora.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# Simple Role Syntax
+# ==================
+# Supports bulk-adding hosts to roles, the primary server in each group
+# is considered to be the first unless any hosts have the primary
+# property set.  Don't declare `role :all`, it's a meta role.
+
+# role :app, %w{deploy@example.com}
+# role :web, %w{deploy@example.com}
+# role :db,  %w{deploy@example.com}
+
+# Extended Server Syntax
+# ======================
+# This can be used to drop a more detailed server definition into the
+# server list. The second argument is a, or duck-types, Hash and is
+# used to set extended properties on the server.
+server 'dce-fedora.vmhost.psu.edu:1855', user: 'deploy', roles: %w(web app db job), primary: true
+# server 'dce-fedora.vmhost.psu.edu:1855', user: 'deploy', roles: %w(web app db)
+# server 'dce-fedora.vmhost.psu.edu:1855', user: 'deploy', roles: %w(app job)
+# server 'example.com', user: 'deploy', roles: %w{web app}, my_property: :my_value
+
+# Custom SSH Options
+# ==================
+# You may pass any option but keep in mind that net/ssh understands a
+# limited set of options, consult[net/ssh documentation](http://net-ssh.github.io/net-ssh/classes/Net/SSH.html#method-c-start).
+#
+# Global options
+# --------------
+#  set :ssh_options, {
+#    keys: %w(/home/rlisowski/.ssh/id_rsa),
+#    forward_agent: false,
+#    auth_methods: %w(password)
+#  }
+#
+# And/or per server (overrides global)
+# ------------------------------------
+# server 'example.com',
+#   user: 'user_name',
+#   roles: %w{web app},
+#   ssh_options: {
+#     user: 'user_name', # overrides user setting above
+#     keys: %w(/home/user_name/.ssh/id_rsa),
+#     forward_agent: false,
+#     auth_methods: %w(publickey password)
+#     # password: 'please use keys'
+#   }


### PR DESCRIPTION
I've added a deploy file `config/deploy/dce_fedora.rb` for the `dce-fedora.vmhost.psu.edu` server. My understanding is that it would be better practice to merge this in and then remove it once the server goes away than leaving the change in a long-term feature branch, but any feedback is welcome (maybe this is a special case since it's a small, isolated change that isn't likely to have other associated code changes).