### PR TITLE
APPINT-622: Added newrelic code for updated deployment tags

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'new_relic/recipes'
-after 'deploy:updated', 'newrelic:notice_deployment'
 
 # lock '3.6'
 
@@ -112,7 +111,7 @@ namespace :deploy do
       end
     end
   end
-  after :updated, :check_configs
+  after :updated, :check_configs, 'newrelic:notice_deployment'
 
   desc 'set up the shared directory to have the symbolic links to the appropriate directories shared between servers'
   task :symlink_shared_directories do

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'new_relic/recipes'
+after 'deploy:updated', 'newrelic:notice_deployment'
+
 # lock '3.6'
 
 # Set assets roles to occur on jobs as well as web


### PR DESCRIPTION
This PR adds code which allows the newrelic gem to automatically tag deployments within the newrelic rpm portal.