### PR TITLE
Index the README file in Solr

### DIFF
--- a/app/indexers/work_indexer.rb
+++ b/app/indexers/work_indexer.rb
@@ -9,6 +9,7 @@ class WorkIndexer < Sufia::WorkIndexer
       solr_doc[Solrizer.solr_name('resource_type', :facetable)] = object.resource_type
       solr_doc[Solrizer.solr_name('file_format', :stored_searchable)] = representative.file_format
       solr_doc[Solrizer.solr_name('file_format', :facetable)] = representative.file_format
+      solr_doc['readme_file_ss'] = readme_content
       solr_doc[Solrizer.solr_name(:bytes, CurationConcerns::CollectionIndexer::STORED_LONG)] = object.bytes
       SolrDocumentGroomer.call(solr_doc)
     end
@@ -20,10 +21,37 @@ class WorkIndexer < Sufia::WorkIndexer
       object.representative || NullRepresentative.new
     end
 
+    def readme_file
+      @readme_file ||= ReadmeFile.new(object.readme_file)
+    end
+
+    def readme_content
+      return unless readme_file.content?
+      readme_file.content.encode('utf-8', invalid: :replace, undef: :replace)
+    rescue StandardError => e
+      "#{I18n.t('scholarsphere.generic_work.readme_error')}: #{e}"
+    end
+
     # Use the naught gem if this gets bigger
     class NullRepresentative
       def file_format
         nil
+      end
+    end
+
+    class ReadmeFile
+      attr_reader :file
+
+      def initialize(file)
+        @file = file
+      end
+
+      def content?
+        !file.nil? && file.original_file.respond_to?(:content)
+      end
+
+      def content
+        file.original_file.content
       end
     end
 end

--- a/app/models/generic_work.rb
+++ b/app/models/generic_work.rb
@@ -38,6 +38,11 @@ class GenericWork < ActiveFedora::Base
     sizes.compact.map { |fs| fs[file_size_field] }.reduce(0, :+)
   end
 
+  # @return [FileSet]
+  def readme_file
+    file_sets.select { |file| file.label =~ /^readme/i }.first
+  end
+
   private
 
     def file_set_size(fs_id)

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -46,6 +46,10 @@ class SolrDocument
     self[Solrizer.solr_name('subtitle')]
   end
 
+  def readme_file
+    self['readme_file_ss']
+  end
+
   private
 
     def ul_start_tags

--- a/app/presenters/work_show_presenter.rb
+++ b/app/presenters/work_show_presenter.rb
@@ -4,7 +4,7 @@ class WorkShowPresenter < Sufia::WorkShowPresenter
   include ActionView::Helpers::NumberHelper
   include Sufia::WithEvents
 
-  delegate :bytes, :subtitle, to: :solr_document
+  delegate :bytes, :subtitle, :readme_file, to: :solr_document
 
   def creator
     creator_name
@@ -27,19 +27,9 @@ class WorkShowPresenter < Sufia::WorkShowPresenter
   end
 
   def readme
-    readme_file = file_set_presenters.select { |presenter| presenter.label =~ /^readme/i }.first
-    return if readme_file.blank?
-    file_set = FileSet.find(readme_file.id)
-    return unless file_set.original_file.respond_to?(:content)
-    content = file_set.original_file.content
-    begin
-      content = content.encode('UTF-8')
-    rescue Encoding::UndefinedConversionError => e
-      return "#{I18n.t('scholarsphere.generic_work.readme_error')}: #{e}"
-    end
+    return if readme_file.nil?
     renderer = Redcarpet::Render::HTML.new(safe_links_only: true, hard_wrap: true)
-    markdown = Redcarpet::Markdown.new(renderer)
-    markdown.render(content)
+    Redcarpet::Markdown.new(renderer).render(readme_file)
   end
 
   # TODO: Remove once https://github.com/projecthydra/sufia/issues/2394 is resolved

--- a/spec/fixtures/bad_readme.md
+++ b/spec/fixtures/bad_readme.md
@@ -1,0 +1,3 @@
+# Sample readme with bad characters
+
+incorrect dashes — are replaced with default characters.

--- a/spec/indexers/work_indexer_spec.rb
+++ b/spec/indexers/work_indexer_spec.rb
@@ -5,6 +5,8 @@ require 'rails_helper'
 describe WorkIndexer do
   include FactoryHelpers
 
+  subject { solr_doc }
+
   let(:file_set) { build(:file_set) }
   let(:work)     { build(:work, representative: file_set,
                                 keyword: ['Bird']) }
@@ -20,46 +22,90 @@ describe WorkIndexer do
     )
   end
 
-  describe '#generate_solr_document' do
-    subject { solr_doc }
+  let(:solr_doc) { indexer.generate_solr_document }
 
-    let(:solr_doc) { indexer.generate_solr_document }
+  it { is_expected.to include('bytes_lts' => 0) }
 
-    it { is_expected.to include('bytes_lts' => 0) }
+  describe 'the file format field' do
+    subject { solr_doc[Solrizer.solr_name('file_format', :facetable)] }
 
-    describe 'file_format' do
-      subject { solr_doc[Solrizer.solr_name('file_format', :facetable)] }
+    context 'with a file containing technical metadata' do
+      before { allow(file_set).to receive(:original_file).and_return(file) }
+      it { is_expected.to eq('jpeg (JPEG Image)') }
+    end
 
-      context 'with a file containing technical metadata' do
-        before { allow(file_set).to receive(:original_file).and_return(file) }
-        it { is_expected.to eq('jpeg (JPEG Image)') }
+    context 'without a file' do
+      it { is_expected.to be_nil }
+    end
+
+    context 'without a representative' do
+      before { allow(work).to receive(:representative).and_return(nil) }
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe 'a groomed document' do
+    let(:creator) { build(:alias, display_name: 'BIG. DISPLAY Name') }
+    let(:agent)   { Agent.new(given_name: 'BIG.', sur_name: 'Name') }
+
+    before do
+      allow(work).to receive(:creators).and_return([creator])
+      allow(creator).to receive(:agent).and_return(agent)
+    end
+
+    it { is_expected.to include('creator_name_sim' => ['Big Name'],
+                                'creator_name_tesim' => ['BIG. DISPLAY Name'],
+                                'keyword_sim' => ['bird'],
+                                'keyword_tesim' => ['Bird']) }
+
+    it { is_expected.not_to include('creator_name_sim' => ['BIG. Name'], 'creator_name_tesim' => ['Big Display Name']) }
+  end
+
+  describe 'the readme file' do
+    before { allow(work).to receive(:readme_file).and_return(readme_file) }
+
+    subject { solr_doc['readme_file_ss'] }
+
+    context 'with no readme file' do
+      let(:readme_file) { nil }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when the readme file as no content' do
+      let(:readme_file) { build(:file_set) }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'with a README file in non-UTF-8 format' do
+      let(:readme_file) { build(:file_set) }
+
+      # @note reading the file in binary mode results in an ASCII-8BIT
+      let(:file) do
+        mock_file_factory(
+          mime_type: 'text/plain',
+          content: File.open(File.join(fixture_path, 'bad_readme.md'), 'rb').read
+        )
       end
 
-      context 'without a file' do
-        it { is_expected.to be_nil }
-      end
+      before { allow(readme_file).to receive(:original_file).and_return(file) }
 
-      context 'without a representative' do
-        before { allow(work).to receive(:representative).and_return(nil) }
-        it { is_expected.to be_nil }
+      it 'encodes the content using UTF-8 replacing invalid characters with a ?' do
+        expect(file.content.encoding.name).to eq('ASCII-8BIT')
+        expect(solr_doc['readme_file_ss'].encoding.name).to eq('UTF-8')
+        expect(solr_doc['readme_file_ss']).to include('incorrect dashes ��� are replaced with default characters.')
       end
     end
 
-    describe 'a groomed document' do
-      let(:creator) { build(:alias, display_name: 'BIG. DISPLAY Name') }
-      let(:agent)   { Agent.new(given_name: 'BIG.', sur_name: 'Name') }
+    context 'with an invalid README file' do
+      let(:readme_file) { build(:file_set) }
 
       before do
-        allow(work).to receive(:creators).and_return([creator])
-        allow(creator).to receive(:agent).and_return(agent)
+        allow(readme_file).to receive(:original_file).and_raise(StandardError, 'bad encoding')
       end
 
-      it { is_expected.to include('creator_name_sim' => ['Big Name'],
-                                  'creator_name_tesim' => ['BIG. DISPLAY Name'],
-                                  'keyword_sim' => ['bird'],
-                                  'keyword_tesim' => ['Bird']) }
-
-      it { is_expected.not_to include('creator_name_sim' => ['BIG. Name'], 'creator_name_tesim' => ['Big Display Name']) }
+      it { is_expected.to eq('Error encoding readme as UTF-8: bad encoding') }
     end
   end
 end

--- a/spec/models/generic_work_spec.rb
+++ b/spec/models/generic_work_spec.rb
@@ -127,4 +127,17 @@ describe GenericWork do
   describe '#upload_set' do
     its(:upload_set) { is_expected.to be_blank }
   end
+
+  describe '#readme_file' do
+    context 'with a readme file' do
+      let(:file_set) { build(:file_set, label: 'README') }
+
+      before { allow(work).to receive(:file_sets).and_return([file_set]) }
+      its(:readme_file) { is_expected.to eq(file_set) }
+    end
+
+    context 'with no file sets' do
+      its(:readme_file) { is_expected.to be_nil }
+    end
+  end
 end

--- a/spec/presenters/work_show_presenter_spec.rb
+++ b/spec/presenters/work_show_presenter_spec.rb
@@ -111,62 +111,30 @@ describe WorkShowPresenter do
   end
 
   describe '#readme' do
-    include FactoryHelpers
     subject { presenter.readme }
 
-    let(:file_set_presenters) { [FileSetPresenter.new(SolrDocument.new(file_set.to_solr), nil)] }
+    before { allow(presenter).to receive(:readme_file).and_return(readme_content) }
 
-    context "when there isn't a readme" do
-      it { is_expected.to be_nil }
-    end
-
-    context 'when there is a text file' do
-      let(:file_set) { create(:file_set, :public, label: 'README.txt') }
-      let(:file) { mock_file_factory(mime_type: 'text/plain', content: 'some readme content for the test') }
-
-      before do
-        allow(presenter).to receive(:file_set_presenters).and_return(file_set_presenters)
-        allow(file_set).to receive(:original_file).and_return(file)
-        allow(FileSet).to receive(:find).with(file_set.id).and_return(file_set)
-      end
+    context 'when there is text' do
+      let(:readme_content) { 'some readme content for the test' }
 
       it { is_expected.to include '<p>some readme content for the test</p>' }
     end
 
-    context 'when there is a markdown file' do
-      let(:file_set) { create(:file_set, :public, label: 'README.md') }
-      let(:file) { mock_file_factory(mime_type: 'text/markdown', content: 'other readme content that is in a markdown file') }
+    context 'when there is markdown' do
+      let(:readme_content) { '# other readme content that is in a markdown file' }
 
-      before do
-        allow(presenter).to receive(:file_set_presenters).and_return(file_set_presenters)
-        allow(file_set).to receive(:original_file).and_return(file)
-        allow(FileSet).to receive(:find).with(file_set.id).and_return(file_set)
-      end
-
-      it { is_expected.to include '<p>other readme content that is in a markdown file</p>' }
+      it { is_expected.to include '<h1>other readme content that is in a markdown file</h1>' }
     end
 
     context 'when there is a blank readme file' do
-      let(:file_set) { create(:file_set, :public, label: 'ReadMe.txt') }
-      let(:file) { mock_file_factory(content: '') }
-
-      before do
-        allow(presenter).to receive(:file_set_presenters).and_return(file_set_presenters)
-        allow(file_set).to receive(:original_file).and_return(file)
-        allow(FileSet).to receive(:find).with(file_set.id).and_return(file_set)
-      end
+      let(:readme_content) { '' }
 
       it { is_expected.to include '' }
     end
 
     context 'when there is no content in the readme file' do
-      let(:file_set) { create(:file_set, :public, label: 'ReadMe.txt') }
-
-      before do
-        allow(presenter).to receive(:file_set_presenters).and_return(file_set_presenters)
-        allow(file_set).to receive(:original_file).and_return(nil)
-        allow(FileSet).to receive(:find).with(file_set.id).and_return(file_set)
-      end
+      let(:readme_content) { nil }
 
       it { is_expected.to be_nil }
     end


### PR DESCRIPTION
Indexing the README file in Solr improves performance because we don't have to pull files from Fedora each time a show page is displayed. Furthermore, we can correct any encoding errors in the indexed copy of the README file.

We're using the `force_encoding` option to convert to UTF-8. Any errors that result are reported when the page displays.

I can confirm this fixes the issue with this README https://scholarsphere.psu.edu/concern/generic_works/qz20ss67z which is currently not displaying correctly.