### PR TITLE
[WIP] Display all available collections in the work dropdown

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -20,5 +20,6 @@
 //= require scholarsphere/creator/creator_index
 //= require scholarsphere/creator/creator_autocomplete
 //= require scholarsphere/creator/creator_behavior
+//= require scholarsphere/work_relationships.js
 //= require mustache
 //= require sufia

--- a/app/assets/javascripts/scholarsphere/work_relationships.js
+++ b/app/assets/javascripts/scholarsphere/work_relationships.js
@@ -1,0 +1,5 @@
+Blacklight.onLoad(function() {
+  $(document).ready(function() {
+    $('#generic_work_collection_ids').select2();
+  });
+});

--- a/app/assets/stylesheets/scholarsphere/add_edit_work.scss
+++ b/app/assets/stylesheets/scholarsphere/add_edit_work.scss
@@ -62,3 +62,11 @@ form fieldset .doi_label {
   font-weight: normal;
 }
 // scss-lint:enable QualifyingElement, SelectorFormat
+
+// Overrides the form-control styles that javascript adds since there is already an input box with border
+// scss-lint:disable SelectorFormat
+.generic_work_collection_ids .form-control {
+  border: 0;
+  box-shadow: none;
+}
+// scss-lint:enable SelectorFormat

--- a/app/search_builders/collection_search_builder.rb
+++ b/app/search_builders/collection_search_builder.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class CollectionSearchBuilder < CurationConcerns::CollectionSearchBuilder
+  # Defines which search_params_logic should be used when searching for Collections
+  def initialize(*)
+    super
+    @rows = ScholarSphere::Application.config.max_collection_query_rows
+  end
+end

--- a/app/views/curation_concerns/base/_form_relationships.html.erb
+++ b/app/views/curation_concerns/base/_form_relationships.html.erb
@@ -7,13 +7,12 @@
 <div id="collection-widget">
   <%= f.input :collection_ids, as: :select, selected: params.fetch(:collection_ids, f.object.collection_ids),
                                collection: available_collections(nil),
-                               input_html: { class: 'form-control', multiple: true } %>
+                               input_html: { multiple: true } %>
 
-  <%# Doing this so the javascript will be happy becuase it needs an admin_set_id selector %>
+  <%# Doing this so the javascript will be happy because it needs an admin_set_id selector %>
   <div style="display: none">
     <%= f.input :admin_set_id, as: :select,
                                collection: Sufia::AdminSetService.new(controller).select_options(:deposit),
-                               include_blank: true,
-                               input_html: { class: 'form-control' } %>
+                               include_blank: true %>
   </div>
 </div>

--- a/config/initializers/collections.rb
+++ b/config/initializers/collections.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Overrides Curation Concerns to display more than 100 rows for Collections in the Work relationship tab
+begin
+  ScholarSphere::Application.config.max_collection_query_rows = Collection.count + 1000
+rescue RSolr::Error::ConnectionRefused
+  ScholarSphere::Application.config.max_collection_query_rows = 500000
+end
+# CurationConcerns::CollectionsService.list_search_builder_class = CollectionSearchBuilder

--- a/spec/search_builders/collection_search_builder_spec.rb
+++ b/spec/search_builders/collection_search_builder_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CollectionSearchBuilder do
+  let(:context) { double }
+  let(:builder) { described_class.new(context).with(blacklight_params) }
+  let(:solr_params) { Blacklight::Solr::Request.new }
+  let(:blacklight_params) { { q: user_query, search_field: 'all_fields' } }
+  let(:user_query) { 'find me' }
+
+  describe '#show_works_or_works_that_contain_files' do
+    subject { builder.rows }
+
+    it { is_expected.to eq(1000) }
+    it 'counts collections' do
+      allow(ScholarSphere::Application.config).to receive(:max_collection_query_rows).and_return(5)
+      expect(builder.rows).to eq(5)
+    end
+  end
+end

--- a/spec/support/cleanup.rb
+++ b/spec/support/cleanup.rb
@@ -16,6 +16,12 @@ RSpec.configure do |config|
     ActiveFedora::Cleaner.clean!
   end
 
+  # Ensure we end with a blank slate
+  config.after :suite do
+    DatabaseCleaner.clean_with(:truncation)
+    ActiveFedora::Cleaner.clean!
+  end
+
   # Only clean Fedora and Solr unless explicitly requested
   config.before do |example|
     if example.metadata.fetch(:clean, nil)


### PR DESCRIPTION
Removes form-control classes and adds the JS for the multi-select. Override the the CSS for the form control, create a new search builder to override 100 rows returned for the select2 list and pass Collections.count + 1000, adds new initializers for override from Curation Concerns, and some tests.