### PR TITLE
Don't display zip download link for collections, fixes #1222

### DIFF
--- a/app/views/collections/_show_actions.html.erb
+++ b/app/views/collections/_show_actions.html.erb
@@ -1,34 +1,36 @@
 <h2 class="sr-only"><%= t('sufia.collection.actions.header') %></h2>
 <div class="actions-controls-collections">
-    <% if can? :edit, presenter.solr_document %>
-      <%= link_to t('sufia.collection.actions.edit.label'),
-                  edit_collection_path(presenter),
-                  title: t('sufia.collection.actions.edit.desc'),
-                  class: 'btn btn-default' %>
-      <%= link_to t('sufia.collection.actions.add_works.label'),
-                  sufia.dashboard_works_path(add_files_to_collection: presenter.id),
-                  title: t('sufia.collection.actions.add_works.desc'),
-                  class: 'btn btn-default' %>
+  <% if can? :edit, presenter.solr_document %>
+    <%= link_to t('sufia.collection.actions.edit.label'),
+                edit_collection_path(presenter),
+                title: t('sufia.collection.actions.edit.desc'),
+                class: 'btn btn-default' %>
+    <%= link_to t('sufia.collection.actions.add_works.label'),
+                sufia.dashboard_works_path(add_files_to_collection: presenter.id),
+                title: t('sufia.collection.actions.add_works.desc'),
+                class: 'btn btn-default' %>
 
-      <%# Overrides Sufia adding button link to the batch upload form with this collection selected %>
-      <%= link_to t('sufia.collection.actions.add_new_works.label'),
-                  sufia.new_batch_upload_path(collection_ids: [presenter.id], payload_concern: 'GenericWork'),
-                  title: t('sufia.collection.actions.add_new_works.desc'),
-                  class: 'btn btn-default' %>
-    <% end %>
+    <%# Overrides Sufia adding button link to the batch upload form with this collection selected %>
+    <%= link_to t('sufia.collection.actions.add_new_works.label'),
+                sufia.new_batch_upload_path(collection_ids: [presenter.id], payload_concern: 'GenericWork'),
+                title: t('sufia.collection.actions.add_new_works.desc'),
+                class: 'btn btn-default' %>
+  <% end %>
 
-    <% if can? :destroy, presenter.solr_document %>
-      <%= link_to t('sufia.collection.actions.delete.label'),
-                  collection_path(presenter),
-                  title: t('sufia.collection.actions.delete.desc'),
-                  class: 'btn btn-danger',
-                  data: { confirm: t('sufia.collection.actions.delete.confirmation'),
-                          method: :delete } %>
-    <% end %>
-  <%= link_to main_app.download_path(presenter),
-              target: :_blank,
-              data: { turbolinks: false },
-              class: 'btn btn-default' do %>
-    <%= t('sufia.collection.actions.collection_zip_link') %>
+  <% if can? :destroy, presenter.solr_document %>
+    <%= link_to t('sufia.collection.actions.delete.label'),
+                collection_path(presenter),
+                title: t('sufia.collection.actions.delete.desc'),
+                class: 'btn btn-danger',
+                data: { confirm: t('sufia.collection.actions.delete.confirmation'),
+                        method: :delete } %>
+  <% end %>
+
+  <% if member_docs.present? %>
+    <%= link_to t('sufia.collection.actions.collection_zip_link'),
+                main_app.download_path(presenter),
+                target: :_blank,
+                data: { turbolinks: false },
+                class: 'btn btn-default' %>
   <% end %>
 </div>

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -14,7 +14,7 @@
   <div class="col-sm-2">
     <%= render 'collections/media_display', presenter: @presenter %>
     <% unless has_collection_search_parameters? %>
-        <%= render 'collections/show_actions', presenter: @presenter %>
+        <%= render 'collections/show_actions', presenter: @presenter, member_docs: @member_docs %>
     <% end %>
   </div>
 </div>

--- a/spec/views/collections/_show_actions.html.erb_spec.rb
+++ b/spec/views/collections/_show_actions.html.erb_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'collections/_show_actions.html.erb' do
+  include Devise::Test::ControllerHelpers
+
+  let(:collection) { build(:collection, id: '1') }
+  let(:presenter) { CollectionPresenter.new(SolrDocument.new(collection.to_solr), Ability.new(nil)) }
+
+  before do
+    render 'collections/show_actions.html.erb', presenter: presenter, member_docs: member_docs
+  end
+
+  context 'when there are no members of the collection available to display' do
+    let(:member_docs) { [] }
+
+    it 'does not show the zip download link' do
+      expect(rendered).not_to include('Download Collection as Zip')
+    end
+  end
+
+  context 'with collection members present' do
+    let(:member_docs) { ['doc'] }
+
+    it 'shows the zip download link' do
+      expect(rendered).to include('Download Collection as Zip')
+    end
+  end
+end


### PR DESCRIPTION
When there are no items in the collection, either because it is empty or
because the user has no access to them, then we should show the zip
download link.

Closes #1222 