### PR TITLE
Test for UTF-8 conversion in actor

### DIFF
--- a/app/indexers/work_indexer.rb
+++ b/app/indexers/work_indexer.rb
@@ -9,7 +9,7 @@ class WorkIndexer < Sufia::WorkIndexer
       solr_doc[Solrizer.solr_name('resource_type', :facetable)] = object.resource_type
       solr_doc[Solrizer.solr_name('file_format', :stored_searchable)] = representative.file_format
       solr_doc[Solrizer.solr_name('file_format', :facetable)] = representative.file_format
-      solr_doc['readme_file_ss'] = readme_content
+      solr_doc['readme_file_ss'] = readme_file.content
       solr_doc[Solrizer.solr_name(:bytes, CurationConcerns::CollectionIndexer::STORED_LONG)] = object.bytes
       SolrDocumentGroomer.call(solr_doc)
     end
@@ -23,13 +23,6 @@ class WorkIndexer < Sufia::WorkIndexer
 
     def readme_file
       @readme_file ||= ReadmeFile.new(object.readme_file)
-    end
-
-    def readme_content
-      return unless readme_file.content?
-      readme_file.content.encode('utf-8', invalid: :replace, undef: :replace)
-    rescue StandardError => e
-      "#{I18n.t('scholarsphere.generic_work.readme_error')}: #{e}"
     end
 
     # Use the naught gem if this gets bigger
@@ -51,7 +44,8 @@ class WorkIndexer < Sufia::WorkIndexer
       end
 
       def content
-        file.original_file.content
+        return unless content?
+        EncodingService.call(file.original_file.content)
       end
     end
 end

--- a/app/services/encoding_service.rb
+++ b/app/services/encoding_service.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class EncodingService
+  def self.call(content)
+    content.encode('utf-8', invalid: :replace, undef: :replace)
+  rescue StandardError => e
+    "#{I18n.t('scholarsphere.encoding.error')}: #{e}"
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -89,10 +89,11 @@ en:
     generic_work:
       readme_heading: 'README'
       readme_text: 'How about adding a README file? We currently accept plain text (README.txt) and markdown (README.md) files.  Note: You may need to refresh to see an README file you just uploaded.'
-      readme_error: 'Error encoding readme as UTF-8'
     file_set:
       permission_help: 'Who should be able to view or download this content?'
       representative_media: 'If this is or becomes your representative media, this may impact the display of your work in search results.'
+    encoding:
+      error: 'Error encoding readme as UTF-8'
 
   statistic:
     report:

--- a/spec/actors/curation_concerns/generic_work_actor_spec.rb
+++ b/spec/actors/curation_concerns/generic_work_actor_spec.rb
@@ -61,4 +61,14 @@ describe CurationConcerns::Actors::GenericWorkActor do
 
     its(:depositor) { is_expected.to eq(other_user.login) }
   end
+
+  context 'with non-UTF-8 encoding' do
+    let(:string) { "# Sample readme with bad characters\n\nincorrect dashes ��� are replaced with default characters.\n" }
+    let(:attributes) { { description: [File.open(File.join(fixture_path, 'bad_readme.md'), 'rb').read] } }
+
+    it 'converts the content to UTF-8' do
+      expect(work.description).to contain_exactly(string)
+      expect(work.description.first.encoding.name).to eq('UTF-8')
+    end
+  end
 end

--- a/spec/indexers/work_indexer_spec.rb
+++ b/spec/indexers/work_indexer_spec.rb
@@ -97,15 +97,5 @@ describe WorkIndexer do
         expect(solr_doc['readme_file_ss']).to include('incorrect dashes ��� are replaced with default characters.')
       end
     end
-
-    context 'with an invalid README file' do
-      let(:readme_file) { build(:file_set) }
-
-      before do
-        allow(readme_file).to receive(:original_file).and_raise(StandardError, 'bad encoding')
-      end
-
-      it { is_expected.to eq('Error encoding readme as UTF-8: bad encoding') }
-    end
   end
 end

--- a/spec/services/encoding_service_spec.rb
+++ b/spec/services/encoding_service_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe EncodingService do
+  context 'with an encodable string' do
+    let(:string) { File.open(File.join(fixture_path, 'bad_readme.md'), 'rb').read }
+
+    it 'encodes the characters to UTF-8' do
+      expect(string.encoding.name).to eq('ASCII-8BIT')
+      expect(described_class.call(string).encoding.name).to eq('UTF-8')
+    end
+  end
+
+  context 'with an unencodeable string' do
+    let(:string) { instance_double(String) }
+
+    before { allow(string).to receive(:encode).and_raise(StandardError, 'bad encoding') }
+
+    it 'returns a string with the error' do
+      expect(described_class.call(string)).to eq('Error encoding readme as UTF-8: bad encoding')
+    end
+  end
+end


### PR DESCRIPTION
Includes refactoring the README encoding conversion into EncodingService
which uses the same features and error reporting for both encoding in
forms (via the actor) and in the README (via Solr indexing).