### PR TITLE
Comments out the link to the admin stats from the dashboard

### DIFF
--- a/app/views/dashboard/_index_partials/_heading_greetings.html.erb
+++ b/app/views/dashboard/_index_partials/_heading_greetings.html.erb
@@ -2,10 +2,5 @@
   <h1><%= t('sufia.dashboard.title') %></h1>
 </div>
 <div class="col-xs-9">
-  <h2><%= t('sufia.dashboard.greeting') + ' ' + current_user.name %>
-    <span class="small"><%= if can? :admin_stats, current_user
-                              link_to('System Statistics', sufia.admin_stats_path,
-                    class: 'admin_stats_link')
-                            end %></span>
-  </h2>
+  <h2><%= t('sufia.dashboard.greeting') + ' ' + current_user.name %></h2>
 </div>

--- a/spec/views/dashboard/heading_greetings.html.erb_spec.rb
+++ b/spec/views/dashboard/heading_greetings.html.erb_spec.rb
@@ -18,7 +18,6 @@ describe 'dashboard/_index_partials/_heading_greetings.html.erb', type: :view do
       render
       page = Capybara::Node::Simple.new(rendered)
       expect(page).to have_content('Hello')
-      expect(page).to have_selector('a.admin_stats_link', text: 'System Statistics')
     end
   end
 
@@ -30,7 +29,6 @@ describe 'dashboard/_index_partials/_heading_greetings.html.erb', type: :view do
       render
       page = Capybara::Node::Simple.new(rendered)
       expect(page).to have_content('Hello')
-      expect(page).not_to have_selector('a.admin_stats_link', text: 'System Statistics')
     end
   end
 end


### PR DESCRIPTION
I've decided to comment out the code that links to the admin stats in the dashboard from the greeting instead of remove it completely, so that we can uncomment it out when the code has been fixed.

Fixes #1246 