### PR TITLE
Order of Collection Metadata to Match Work Show Page

### DIFF
--- a/app/presenters/collection_presenter.rb
+++ b/app/presenters/collection_presenter.rb
@@ -4,9 +4,8 @@ class CollectionPresenter < Sufia::CollectionPresenter
   delegate :subtitle, to: :solr_document
 
   def self.terms
-    [:creator, :keyword, :size, :total_items, :resource_type, :contributor,
-     :rights, :publisher, :date_created, :subject, :language, :identifier,
-     :based_near, :related_url, :date_modified, :date_uploaded]
+    [:creator, :keyword, :rights, :resource_type, :contributor, :publisher, :date_created, :date_uploaded,
+     :date_modified, :subject, :language, :identifier, :based_near, :related_url, :size, :total_items]
   end
 
   def permission_badge_class


### PR DESCRIPTION
Reorders the metadata fields to match the order of the attribute rows from the work show partial. You can use the attribute rows as a list for guidance. 

Fixes #1016 

https://github.com/psu-stewardship/scholarsphere/blob/develop/app/views/curation_concerns/base/_attribute_rows.html.erb

![screen shot 2018-06-05 at 5 15 38 pm](https://user-images.githubusercontent.com/4163828/41003323-78a8f318-68e4-11e8-9b00-a83195bf34ca.png)
