### PR TITLE
Delete Collection Message

### DIFF
--- a/app/views/collections/_show_actions.html.erb
+++ b/app/views/collections/_show_actions.html.erb
@@ -22,7 +22,7 @@
                 collection_path(presenter),
                 title: t('sufia.collection.actions.delete.desc'),
                 class: 'btn btn-danger',
-                data: { confirm: t('sufia.collection.actions.delete.confirmation'),
+                data: { confirm: t('sufia.dashboard.my.action.collection_confirmation', application_name: application_name),
                         method: :delete } %>
   <% end %>
 


### PR DESCRIPTION
Reuses the same confirmation message for the delete action on the collection show page as the my collections listing page.

Fixes #995 

Collection Listing

![screen shot 2018-06-05 at 5 19 35 pm](https://user-images.githubusercontent.com/4163828/41003486-e4ef8fa0-68e4-11e8-97e8-141260b71d86.png)

Collection Show Page

![screen shot 2018-06-05 at 5 19 57 pm](https://user-images.githubusercontent.com/4163828/41003494-f0d510b0-68e4-11e8-8ef3-9b3293dd4f77.png)

