### PR TITLE
Prepend CollectionSeachBuilder to increase number of rows

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -20,5 +20,6 @@
 //= require scholarsphere/creator/creator_index
 //= require scholarsphere/creator/creator_autocomplete
 //= require scholarsphere/creator/creator_behavior
+//= require scholarsphere/work_relationships.js
 //= require mustache
 //= require sufia

--- a/app/assets/javascripts/scholarsphere/work_relationships.js
+++ b/app/assets/javascripts/scholarsphere/work_relationships.js
@@ -1,0 +1,5 @@
+Blacklight.onLoad(function() {
+  $(document).ready(function() {
+    $('#generic_work_collection_ids').select2();
+  });
+});

--- a/app/assets/stylesheets/scholarsphere/add_edit_work.scss
+++ b/app/assets/stylesheets/scholarsphere/add_edit_work.scss
@@ -62,3 +62,11 @@ form fieldset .doi_label {
   font-weight: normal;
 }
 // scss-lint:enable QualifyingElement, SelectorFormat
+
+// Overrides the form-control styles that javascript adds since there is already an input box with border
+// scss-lint:disable SelectorFormat
+.generic_work_collection_ids .form-control {
+  border: 0;
+  box-shadow: none;
+}
+// scss-lint:enable SelectorFormat

--- a/app/prepends/prepended_search_builders/with_more_rows.rb
+++ b/app/prepends/prepended_search_builders/with_more_rows.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module PrependedSearchBuilders::WithMoreRows
+  def initialize(*)
+    super
+    @rows = Collection.count + 1000
+  end
+end

--- a/app/views/curation_concerns/base/_form_relationships.html.erb
+++ b/app/views/curation_concerns/base/_form_relationships.html.erb
@@ -7,13 +7,12 @@
 <div id="collection-widget">
   <%= f.input :collection_ids, as: :select, selected: params.fetch(:collection_ids, f.object.collection_ids),
                                collection: available_collections(nil),
-                               input_html: { class: 'form-control', multiple: true } %>
+                               input_html: { multiple: true } %>
 
-  <%# Doing this so the javascript will be happy becuase it needs an admin_set_id selector %>
+  <%# Doing this so the javascript will be happy because it needs an admin_set_id selector %>
   <div style="display: none">
     <%= f.input :admin_set_id, as: :select,
                                collection: Sufia::AdminSetService.new(controller).select_options(:deposit),
-                               include_blank: true,
-                               input_html: { class: 'form-control' } %>
+                               include_blank: true %>
   </div>
 </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -115,6 +115,7 @@ module ScholarSphere
       CurationConcerns::Renderers::AttributeRenderer.prepend PrependedRenderers::WithLists
       Sufia::HomepageController.prepend PrependedControllers::WithRecentPresenters
       FeaturedWorkList.prepend PrependedModels::WithFeaturedPresenters
+      CurationConcerns::CollectionSearchBuilder.prepend PrependedSearchBuilders::WithMoreRows
       CurationConcerns::MemberPresenterFactory.file_presenter_class = FileSetPresenter
     end
   end

--- a/spec/features/generic_work/upload_and_delete_spec.rb
+++ b/spec/features/generic_work/upload_and_delete_spec.rb
@@ -94,6 +94,10 @@ describe 'Generic File uploading and deletion:', type: :feature do
         find('#new_user_permission_skel').find(:xpath, 'option[2]').select_option
         click_on('add_new_user_skel')
         within('#share') { expect(page).to have_content(other_user.user_key) }
+
+        # Test Collections tab for select2 container
+        within('ul.nav-tabs') { click_link('Collections') }
+        expect(page).to have_css('.select2-container-multi')
       end
     end
 


### PR DESCRIPTION
Prepends a new module to CurationConcerns::CollectionSearchBuilder to
increase the number of rows returned. Adds the select2 features to the
select box to enable searching of collections in the work edit form.

Fixes #863 

Co-authored by Carolyn Cole <cam156@psu.edu>
Co-authored by Adam Wead <amsterdamos@gmail.com>


![screen shot 2018-06-06 at 1 29 45 pm](https://user-images.githubusercontent.com/4163828/41054953-e34e25e0-698d-11e8-9757-9b1e5505f085.png)
