### PR TITLE
Proxy Depositor - On Behalf Of to Use Name instead of Access ID

### DIFF
--- a/app/views/curation_concerns/base/_form_progress.html.erb
+++ b/app/views/curation_concerns/base/_form_progress.html.erb
@@ -52,7 +52,7 @@
       <div class="list-group-item">
         <label for="generic_work_on_behalf_of"><%= t('curation_concerns.base.form_progress.on_behalf_of') %></label>
         <p class="help-block"><%= t('curation_concerns.base.form_progress.on_behalf_of_help') %></p>
-        <%= f.input :on_behalf_of, label: false, collection: current_user.can_make_deposits_for.map(&:user_key), prompt: 'Yourself' %>
+        <%= f.input :on_behalf_of, label: false, collection: current_user.can_make_deposits_for.map { |proxy| [proxy.name, proxy.user_key] }, prompt: 'Yourself' %>
       </div>
     <% end %>
   </div>

--- a/spec/views/curations_concerns/base/_form_progress.html.erb_spec.rb
+++ b/spec/views/curations_concerns/base/_form_progress.html.erb_spec.rb
@@ -11,7 +11,7 @@ describe 'curation_concerns/base/_form_progress.html.erb' do
   end
 
   let(:work)  { build(:work) }
-  let(:proxy) { create(:first_proxy) }
+  let(:proxy) { create(:first_proxy, id: 'abc123', display_name: 'Chuck Treece') }
   let(:form)  { CurationConcerns::GenericWorkForm.new(work, Ability.new(user)) }
 
   before { allow(controller).to receive(:current_user).and_return(user) }
@@ -36,7 +36,11 @@ describe 'curation_concerns/base/_form_progress.html.erb' do
     context 'when the user is a proxy' do
       let(:user) { create(:user, :with_proxy, proxy_for: proxy) }
 
-      it { is_expected.to have_selector('#generic_work_on_behalf_of') }
+      it do
+        is_expected.to have_selector('#generic_work_on_behalf_of')
+        is_expected.to have_selector('option', text: 'Chuck Treece')
+        is_expected.not_to have_selector('option', text: 'abc123')
+      end
     end
 
     context 'when the user is not a proxy' do


### PR DESCRIPTION
Passing key value options to the collection to display the person's name instead of the userid in the on behalf of dropdown in the create new work form.

Fixes #587 

Adam is my proxy

<img width="1268" alt="screen shot 2018-06-07 at 7 02 44 am" src="https://user-images.githubusercontent.com/4163828/41096049-5c04ca78-6a21-11e8-8627-5bbb360d8b5f.png">

Proxy deposit display in My Works

<img width="1272" alt="screen shot 2018-06-07 at 7 02 58 am" src="https://user-images.githubusercontent.com/4163828/41096073-75be011e-6a21-11e8-9287-49de0d9cb867.png">

Displays Correctly in Work Show

<img width="1274" alt="screen shot 2018-06-07 at 7 03 58 am" src="https://user-images.githubusercontent.com/4163828/41096097-8daf3478-6a21-11e8-8be5-da548bb96fd5.png">

Displays Correctly in Recent Additions

<img width="1268" alt="screen shot 2018-06-07 at 7 04 36 am" src="https://user-images.githubusercontent.com/4163828/41096109-9da6f384-6a21-11e8-9cc9-e25639908663.png">

