### PR TITLE
Add a rake task to run thge ExternalFilesConversion class

### DIFF
--- a/app/services/external_files_conversion.rb
+++ b/app/services/external_files_conversion.rb
@@ -10,7 +10,7 @@ class ExternalFilesConversion
   def convert
     @work.all.each do |work|
       begin
-        if work.file_sets.first.original_file.nil? == false
+        if !original_file?(work) && existing_redirect?(work) == true
           IngestFileJob.perform_now(work.file_sets.first, working_file(work.file_sets.first.original_file, work.file_sets.first.id), User.batch_user, filename: work.file_sets.first.original_file.original_name)
         end
       rescue OpenURI::HTTPError
@@ -25,5 +25,13 @@ class ExternalFilesConversion
 
     def working_file(file, id)
       CurationConcerns::WorkingDirectory.copy_repository_resource_to_working_directory(file, id)
+    end
+
+    def original_file?(work)
+      work.file_sets.first.original_file.nil?
+    end
+
+    def existing_redirect?(work)
+      open(work.file_sets.first.uri).status[0] == '200'
     end
 end

--- a/lib/tasks/scholarsphere.rake
+++ b/lib/tasks/scholarsphere.rake
@@ -221,4 +221,17 @@ namespace :scholarsphere do
     result = work.save
     puts "Work #{work_id} marked as private: #{result}"
   end
+
+  desc 'Convert files stored internally in Fedora to externally on the filesystem'
+  task 'internal_to_external_files' => :environment do
+    puts 'This task will create a new version of all the works.'
+    puts "The process will place the content in the #{ENV['REPOSITORY_FILESTORE']} directory."
+    puts 'Are you sure you want to do this? (y/n)'
+
+    if STDIN.gets.strip == 'y'
+      ExternalFilesConversion.new(GenericWork).convert
+    else
+      puts 'You didn\'t reply with (y) so this rake task is exiting'
+    end
+  end
 end


### PR DESCRIPTION
This commit introduces a rake task that creates a new versions of
a file in order to create a copy of the file that exists on external
storage.

To run the rake task:

`rake scholarsphere:internal_to_external_files`

It will iterate over all the `GenericWork`s in the repository.