### PR TITLE
Store files in bags on the filesystem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'blacklight_advanced_search', '~> 6.0'
 gem 'mail', '= 2.6.6.rc1'
 
 # Other components
+gem 'bagit'
 gem 'bootsnap', require: false
 gem 'clamav' unless ENV['TRAVIS'] == 'true'
 gem 'coderay'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,9 @@ GEM
       babel-source (>= 4.0, < 6)
       execjs (~> 2.0)
     backports (3.11.1)
+    bagit (0.4.1)
+      docopt (~> 0.5.0)
+      validatable (~> 1.6)
     bcrypt (3.1.11)
     better_errors (2.1.1)
       coderay (>= 1.0.0)
@@ -254,6 +257,7 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.2.5)
     docile (1.1.5)
+    docopt (0.5.0)
     dropbox-sdk (1.6.5)
       json
     dry-configurable (0.7.0)
@@ -855,6 +859,7 @@ GEM
     unicorn-rails (2.2.1)
       rack
       unicorn
+    validatable (1.6.7)
     vcr (3.0.3)
     vegas (0.1.11)
       rack (>= 1.0.0)
@@ -884,6 +889,7 @@ PLATFORMS
 
 DEPENDENCIES
   active-fedora (~> 11.5)
+  bagit
   better_errors
   binding_of_caller
   blacklight_advanced_search (~> 6.0)

--- a/app/jobs/ingest_file_job.rb
+++ b/app/jobs/ingest_file_job.rb
@@ -23,7 +23,7 @@ class IngestFileJob < ActiveJob::Base
     local_file[:original_name] = File.basename(@filepath)
 
     if ENV['REPOSITORY_EXTERNAL_FILES'] == 'true'
-      Scholarsphere::Pairtree.new(@file_set).create_repository_files(@filepath)
+      Scholarsphere::Pairtree.new(@file_set, Scholarsphere::Bagger).create_repository_files(@filepath)
     end
 
     # Wrap in an IO decorator to attach passed-in options
@@ -58,10 +58,10 @@ class IngestFileJob < ActiveJob::Base
     def add_file(relation, local_file)
       if ENV['REPOSITORY_EXTERNAL_FILES'] == 'true'
         Hydra::Works::AddExternalFileToFileSet.call(@file_set,
-                                                  Scholarsphere::Pairtree.new(@file_set).http_path(@filepath),
+                                                  Scholarsphere::Pairtree.new(@file_set, Scholarsphere::Bagger).http_path(@filepath),
                                                   relation,
                                                   versioning: false)
-        Scholarsphere::Pairtree.new(@file_set).http_path(@filepath)
+        Scholarsphere::Pairtree.new(@file_set, Scholarsphere::Bagger).http_path(@filepath)
       else
         Hydra::Works::AddFileToFileSet.call(@file_set,
                                           local_file,

--- a/lib/scholarsphere/bagger.rb
+++ b/lib/scholarsphere/bagger.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Scholarsphere
+  class Bagger
+    def initialize(full_path: base_path, working_file: file)
+      current_directory = Dir.pwd
+      Dir.chdir(full_path)
+      @bag = BagIt::Bag.new(full_path)
+      @bag.add_file(working_file) do |io|
+        io.puts File.open(working_file).read
+      end
+      @bag.manifest!
+      Dir.chdir(current_directory)
+    end
+  end
+end

--- a/spec/features/remote_download_spec.rb
+++ b/spec/features/remote_download_spec.rb
@@ -19,6 +19,6 @@ describe GenericWork, type: :feature do
     visit(polymorphic_path(work))
     click_on 'Download'
     downloaded_file = open("http://localhost:4000/downloads/#{work.file_sets.first.id}").read
-    expect(downloaded_file.size).to eq(4218)
+    expect(downloaded_file.size).to eq(4219)
   end
 end

--- a/spec/lib/scholarsphere/pairtree_spec.rb
+++ b/spec/lib/scholarsphere/pairtree_spec.rb
@@ -8,7 +8,8 @@ describe Scholarsphere::Pairtree do
     let(:user)     { create(:user) }
     let(:file_set) { create(:file_set, :with_png, depositor: user.login, id: 'mst3kabc') }
     let(:filepath) { File.join(fixture_path, 'world.png') }
-    let!(:pairtree) { described_class.new(file_set) }
+    let(:bagger) { Scholarsphere::Bagger }
+    let!(:pairtree) { described_class.new(file_set, bagger) }
 
     before do
       ENV['REPOSITORY_EXTERNAL_FILES'] = 'true'


### PR DESCRIPTION
This commit changes the `Pairtree` class so
that it stores files in a bag structure. The structure looks like:

```
/repository/ms/t3/ka/bc/mst3kabc
1528492618/
├── bag-info.txt
├── bagit.txt
├── data
│   └── world.png
├── manifest-md5.txt
├── manifest-sha1.txt
├── tagmanifest-md5.txt
└── tagmanifest-sha1.txt                                                            
```

So you have as root repistory folder, a pairtree for the idenitifier,
a unix timestamp for versioning, which is a bag.

This change uses the ruby bagit library to create the bag:
https://github.com/tipr/bagit