### PR TITLE
Dashboard Color Contrast Errors

### DIFF
--- a/app/assets/stylesheets/scholarsphere/dashboard.scss
+++ b/app/assets/stylesheets/scholarsphere/dashboard.scss
@@ -2,3 +2,9 @@
 .heading-tile a:hover {
   text-decoration: none;
 }
+
+// Overrides the badges from Bootstrap and Sufia for better color contrast
+.panel-user .badge {
+  background-color: $gray-middle;
+  border-radius: 8px;
+}

--- a/app/assets/stylesheets/scholarsphere/typography.scss
+++ b/app/assets/stylesheets/scholarsphere/typography.scss
@@ -43,6 +43,8 @@ html > body .btn-info { background-color: $btn-info-color; }
 html > body .label-warning,
 html > body .btn-warning { background-color: $btn-warning-color; }
 
+.select2-container .select2-choice > .select2-chosen { color: $gray-middle; }
+
 .anchor { text-decoration: none; }
 
 .subtitle {


### PR DESCRIPTION
Adjusts the color contrast of the badges on the user dashboard and the text color of the placeholder text of the user search when adding collaborators. Fixes #1232 

ALL CLEAR!

![screen shot 2018-06-12 at 2 03 20 pm](https://user-images.githubusercontent.com/4163828/41308441-dd8f9c40-6e49-11e8-8f32-3ea7edc0f658.png)
