### PR TITLE
Changing attribute_to_html to be more efficient

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -94,6 +94,12 @@ class ApplicationController < ActionController::Base
     new_id
   end
 
+  def render(*args)
+    start = Time.now
+    super(*args)
+    timing_logger.log(action: "#{self.class} render", start_time: start)
+  end
+
   protected
 
     def user_logged_in?
@@ -121,5 +127,9 @@ class ApplicationController < ActionController::Base
     def nil_request
       logger.warn('Request is Nil, how weird!!!')
       nil
+    end
+
+    def timing_logger
+      @timing_logger ||= TimingLogger.new
     end
 end

--- a/app/controllers/curation_concerns/generic_works_controller.rb
+++ b/app/controllers/curation_concerns/generic_works_controller.rb
@@ -44,6 +44,18 @@ class CurationConcerns::GenericWorksController < ApplicationController
     presenter.file_page(params[:file_page])
   end
 
+  def update
+    start = Time.now
+    super
+    timing_logger.log(action: 'update generic work', start_time: start)
+  end
+
+  def show
+    start = Time.now.to_f
+    super
+    timing_logger.log(action: 'show generic work', start_time: start)
+  end
+
   protected
 
     def after_update_response

--- a/app/presenters/work_show_presenter.rb
+++ b/app/presenters/work_show_presenter.rb
@@ -67,6 +67,13 @@ class WorkShowPresenter < Sufia::WorkShowPresenter
     super(size)
   end
 
+  # override curation concerns to return immediatly if the field is blank
+  def attribute_to_html(field, options = {})
+    value = send(field)
+    return if value.blank?
+    super
+  end
+
   private
 
     # Override to add rows parameter
@@ -86,5 +93,17 @@ class WorkShowPresenter < Sufia::WorkShowPresenter
       selected_presenters = member_presenters.select { |presenter| presenter.id == representative_id }
       return NullRepresentativePresenter.new(current_ability, request) if selected_presenters.empty?
       selected_presenters.first
+    end
+
+    # cache the know renderes so we do not need to search for the class, whcih can be slow
+    def find_renderer_class(name)
+      @cache ||= { translated_facet: TranslatedFacetRenderer,
+                   translated_doi: TranslatedDoiRenderer,
+                   faceted: CurationConcerns::Renderers::FacetedAttributeRenderer,
+                   date: CurationConcerns::Renderers::DateAttributeRenderer,
+                   linked: CurationConcerns::Renderers::LinkedAttributeRenderer,
+                   external_link: CurationConcerns::Renderers::ExternalLinkAttributeRenderer }
+      return @cache[name] if @cache.include?(name)
+      @cache[name] = super
     end
 end

--- a/app/renderers/translated_doi_renderer.rb
+++ b/app/renderers/translated_doi_renderer.rb
@@ -3,7 +3,7 @@
 # Translate the DOI from a DOI formatted value into a clickable link for the users
 #  doi:blah => https://doi.org/blah
 #
-class TranslatedDoiAttributeRenderer < CurationConcerns::Renderers::ExternalLinkAttributeRenderer
+class TranslatedDoiRenderer < CurationConcerns::Renderers::ExternalLinkAttributeRenderer
   def li_value(value)
     if value.start_with?('doi:')
       value = value.gsub('doi:', 'https://doi.org/')

--- a/app/renderers/translated_facet_renderer.rb
+++ b/app/renderers/translated_facet_renderer.rb
@@ -4,7 +4,7 @@
 # for facets. This allows us to display a faceted search link using the text that the user
 # originally entered while using the normalized text that was created when the facet was
 # "cleaned" using the SolrDocumentGroomer.
-class TranslatedFacetAttributeRenderer < CurationConcerns::Renderers::FacetedAttributeRenderer
+class TranslatedFacetRenderer < CurationConcerns::Renderers::FacetedAttributeRenderer
   private
 
     def li_value(value)

--- a/app/services/timing_logger.rb
+++ b/app/services/timing_logger.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class TimingLogger
+  attr_accessor :log_instance
+
+  def initialize(logdev = Rails.root.join('log', 'timing.log'), shift_age = 7, shift_size = 1048576)
+    @log_instance = Logger.new(logdev, shift_age, shift_size) if enabled?
+  end
+
+  def log(action:, start_time:)
+    return unless enabled?
+    end_time = Time.now.to_f
+    log_instance.info("#{action} #{end_time - start_time.to_f}")
+  end
+
+  private
+
+    def enabled?
+      @enabled ||= ENV.fetch('timing_enabled', 'false').casecmp('true').zero?
+    end
+end

--- a/app/views/records/show_fields/_identifier.html.erb
+++ b/app/views/records/show_fields/_identifier.html.erb
@@ -1,4 +1,4 @@
-<% renderer = TranslatedDoiAttributeRenderer.new(:identifier, record.identifier) %>
+<% renderer = TranslatedDoiRenderer.new(:identifier, record.identifier) %>
 <% record.identifier.each do |identifier| %>
   <span itemprop="identifier" itemscope itemtype=" http://schema.org/identifier">
     <%= renderer.li_value(identifier) %>

--- a/config/sample/application.yml
+++ b/config/sample/application.yml
@@ -20,6 +20,7 @@ development:
   REPOSITORY_FILESTORE: <%= Rails.root.join('public', 'repository').to_s %>
   REPOSITORY_FILESTORE_HOST: 'http://localhost:8000/repository'
   REPOSITORY_EXTERNAL_FILES: 'true'
+  timing_enabled: 'false'
 test:
   ffmpeg_path: "ffmpeg-test"
   service_instance: "example-test"
@@ -34,6 +35,7 @@ test:
   REPOSITORY_FILESTORE:  <%= Rails.root.join('public', 'repository').to_s %>
   REPOSITORY_FILESTORE_HOST: 'http://localhost:4000/repository'
   REPOSITORY_EXTERNAL_FILES: 'true'
+  timing_enabled: 'false'
 production:
   TMPDIR: "/tmp"
   ffmpeg_path: "ffmpeg-test"
@@ -51,3 +53,4 @@ production:
   REPOSITORY_FILESTORE: '/opt/heracles/binaries'
   REPOSITORY_FILESTORE_HOST: 'https://dce-fedora.vmhost.psu.edu/binaries'
   REPOSITORY_EXTERNAL_FILES: 'true'
+  timing_enabled: 'false'

--- a/spec/renderers/translated_doi_attribute_renderer_spec.rb
+++ b/spec/renderers/translated_doi_attribute_renderer_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe TranslatedDoiAttributeRenderer do
+describe TranslatedDoiRenderer do
   let(:field) { :identifier }
 
   describe '#attribute_to_html' do

--- a/spec/renderers/translated_facet_attribute_renderer_spec.rb
+++ b/spec/renderers/translated_facet_attribute_renderer_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe TranslatedFacetAttributeRenderer do
+describe TranslatedFacetRenderer do
   let(:field)   { :name }
   let(:mapping) { { 'BOB' => 'Bob', 'JESSICA' => 'Jessica' } }
 

--- a/spec/services/timing_logger_spec.rb
+++ b/spec/services/timing_logger_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe TimingLogger do
+  let(:logger) { described_class.new(logname) }
+  let(:logname) { Rails.root.join('log', 'timing_test.log') }
+
+  context 'disabled' do
+    describe '#log' do
+      it 'does nothing' do
+        logger.log(action: 'sending some data', start_time: Time.now)
+        expect(File).not_to be_exist(logname)
+      end
+    end
+  end
+
+  context 'enabled' do
+    before do
+      allow(ENV).to receive(:fetch).with('timing_enabled', 'false').and_return('true')
+    end
+    after do
+      FileUtils.rm(logname)
+    end
+    describe '#log' do
+      it 'does nothing' do
+        logger.log(action: 'sending some data', start_time: Time.now)
+        expect(File).to be_exist(logname)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Override CurationConcerns to not bother with empty values and cache Renderer lookup
Rename AttributeRenderer to plain Renderer since CurationConcerns looks first for a Renderer
Added TimingLogger to allow for timing log separate from rails log

refs #1233

Co-authored-by: Adam Wead <amsterdamos@gmail.com>