### PR TITLE
Change all internal files versions to external files

### DIFF
--- a/app/services/external_files_conversion.rb
+++ b/app/services/external_files_conversion.rb
@@ -1,29 +1,63 @@
 # frozen_string_literal: true
 
-class ExternalFilesConversion
-  attr_reader :work
+require 'fileutils'
 
-  def initialize(work)
-    @work = work
+class ExternalFilesConversion
+  attr_reader :work_class, :user
+
+  def initialize(work_class)
+    @work_class = work_class
+    @user = User.batch_user
   end
 
   def convert
-    @work.all.each do |work|
-      begin
-        if work.file_sets.first.original_file.nil? == false
-          IngestFileJob.perform_now(work.file_sets.first, working_file(work.file_sets.first.original_file, work.file_sets.first.id), User.batch_user, filename: work.file_sets.first.original_file.original_name)
+    @work_class.all.each do |work|
+      work.file_sets.each do |file_set|
+        file_set.files.each do |file|
+          convert_file(work, file_set, file)
         end
-      rescue OpenURI::HTTPError
-        Rails.logger.warn "Problem accessing the URI for GenericWork: #{work.id}"
-      rescue Ldp::HttpError
-        Rails.logger.warn "Problem accessing the Fedora URI for GenericWork #{work.id}"
       end
     end
   end
 
   private
 
-    def working_file(file, id)
-      CurationConcerns::WorkingDirectory.copy_repository_resource_to_working_directory(file, id)
+    def convert_file(work, file_set, file)
+      # This slug must be prefixed with auto_ so that it will not appear in versions.all
+      ActiveFedora.fedora.connection.post(file.uri + '/fcr:versions', nil, slug: 'auto_placeholder')
+      version_contents = []
+      file.versions.all.each do |version|
+        version_content = write_version_content(version.uri)
+        version_contents << version_content
+        ActiveFedora.fedora.connection.delete(version.uri)
+      end
+
+      version_contents.each do |version_content|
+        file_set.reload
+        if work.file_sets.first.original_file.nil? == false
+          IngestFileJob.perform_now(file_set, version_content, @user)
+        end
+      end
+      ActiveFedora.fedora.connection.delete(file.uri + '/fcr:versions/auto_placeholder')
+    rescue OpenURI::HTTPError
+      Rails.logger.warn "Problem accessing the URI for GenericWork: #{work.id}"
+    rescue Ldp::HttpError
+      Rails.logger.warn "Problem accessing the Fedora URI for GenericWork #{work.id}"
+    end
+
+    def write_version_content(version_uri)
+      version_file_name = filename_from_content_disposition(open(version_uri).meta['content-disposition'])
+      time_stamp = Time.now.to_i.to_s
+      FileUtils.mkdir_p(Rails.root.join('tmp', 'external_internal_conversion', time_stamp))
+
+      file = File.new(Rails.root.join('tmp', 'external_internal_conversion', time_stamp, version_file_name), 'wb+')
+      file.write open(version_uri).read
+      file_path = File.absolute_path(file.path)
+      file.close
+      file_path
+    end
+
+    def filename_from_content_disposition(content_disposition)
+      content_disposition.split(';')[1].split('filename=')[1].split('"')[1]
     end
 end

--- a/lib/tasks/scholarsphere.rake
+++ b/lib/tasks/scholarsphere.rake
@@ -221,4 +221,22 @@ namespace :scholarsphere do
     result = work.save
     puts "Work #{work_id} marked as private: #{result}"
   end
+
+  desc 'Convert files stored internally in Fedora to externally on the filesystem'
+  task 'internal_to_external_files' => :environment do
+    unless ENV['REPOSITORY_EXTERNAL_FILES'] == 'true'
+      puts 'You must set the REPOSITORY_EXTERNAL_FILES environment variable to true'
+      puts 'before running this task'
+      exit
+    end
+    puts 'This task will create a new version of all the works.'
+    puts "The process will place the content in the #{ENV['REPOSITORY_FILESTORE']} directory."
+    puts 'Are you sure you want to do this? (y/n)'
+
+    if STDIN.gets.strip == 'y'
+      ExternalFilesConversion.new(GenericWork).convert
+    else
+      puts 'You didn\'t reply with (y) so this rake task is exiting'
+    end
+  end
 end

--- a/spec/factories/works.rb
+++ b/spec/factories/works.rb
@@ -88,6 +88,16 @@ FactoryGirl.define do
       end
     end
 
+    factory :public_work_with_lots_of_versions do
+      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      after(:create) do |work, attributes|
+        FactoryHelpers.add_public_png(work, attributes)
+        FactoryHelpers.add_another_version(work, attributes)
+        FactoryHelpers.add_public_pdf(work, attributes)
+        FactoryHelpers.add_public_readme(work, attributes)
+      end
+    end
+
     # Does not call IngestFileJob directly. Because this is a mp3, ffmpeg is required for derivatives.
     # Travis does not have ffmpeg, so only add the file to the fileset and do not run characterization
     # or create any derivatives.

--- a/spec/factories/works.rb
+++ b/spec/factories/works.rb
@@ -58,21 +58,8 @@ FactoryGirl.define do
 
     factory :public_work_with_png do
       visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
-
       after(:create) do |work, attributes|
-        fs = FactoryGirl.create(:file_set,
-                                user: User.find_by_login(work.depositor),
-                                title: ['A contained PNG file'],
-                                label: 'world.png',
-                                visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)
-
-        file_path = "#{Rails.root}/spec/fixtures/world.png"
-        IngestFileJob.perform_now(fs, file_path, attributes.user)
-
-        work.ordered_members << fs
-        work.thumbnail_id = fs.id
-        work.representative_id = fs.id
-        work.update_index
+        FactoryHelpers.add_public_png(work, attributes)
       end
     end
 
@@ -80,19 +67,7 @@ FactoryGirl.define do
       visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
 
       after(:create) do |work, attributes|
-        fs = FactoryGirl.create(:file_set,
-                                user: User.find_by_login(work.depositor),
-                                title: ['A full-text pdf file'],
-                                label: 'test.pdf',
-                                visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)
-
-        file_path = "#{Rails.root}/spec/fixtures/test.pdf"
-        IngestFileJob.perform_now(fs, file_path, attributes.user)
-
-        work.ordered_members << fs
-        work.thumbnail_id = fs.id
-        work.representative_id = fs.id
-        work.update_index
+        FactoryHelpers.add_public_pdf(work, attributes)
       end
     end
 
@@ -100,19 +75,16 @@ FactoryGirl.define do
       visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
 
       after(:create) do |work, attributes|
-        fs = FactoryGirl.create(:file_set,
-                                user: User.find_by_login(work.depositor),
-                                title: ['README'],
-                                label: 'readme.md',
-                                visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)
+        FactoryHelpers.add_public_readme(work, attributes)
+      end
+    end
 
-        file_path = "#{Rails.root}/spec/fixtures/readme.md"
-        IngestFileJob.perform_now(fs, file_path, attributes.user)
-
-        work.ordered_members << fs
-        work.thumbnail_id = fs.id
-        work.representative_id = fs.id
-        work.save
+    factory :public_work_with_lots_of_files do
+      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      after(:create) do |work, attributes|
+        FactoryHelpers.add_public_png(work, attributes)
+        FactoryHelpers.add_public_pdf(work, attributes)
+        FactoryHelpers.add_public_readme(work, attributes)
       end
     end
 
@@ -123,18 +95,7 @@ FactoryGirl.define do
       visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
 
       after(:create) do |work, attributes|
-        fs = FactoryGirl.create(:file_set,
-                                user: attributes.user,
-                                title: ['A contained MP3 file'],
-                                label: 'scholarsphere_test5.mp3',
-                                visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)
-
-        filename = "#{Rails.root}/spec/fixtures/scholarsphere/scholarsphere_test5.mp3"
-        local_file = File.open(filename, 'rb')
-        Hydra::Works::AddFileToFileSet.call(fs, local_file, :original_file, versioning: false)
-        fs.save!
-        work.ordered_members << fs
-        work.thumbnail_id = fs.id
+        FactoryHelpers.add_public_mp3(work, attributes)
       end
     end
 

--- a/spec/features/create_external_versions.rb
+++ b/spec/features/create_external_versions.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# Testing versioning as a strategy for migrating from internal to externally
+# managed Fedora content
+
+require 'rails_helper'
+
+describe 'transform internal file storage into external file storage', clean: true do
+  context 'when adding a new version' do
+    let(:user) { create(:user) }
+    let(:filepath) { File.join(fixture_path, 'world.png') }
+    let(:filepath2) { File.join(fixture_path, '4-20-small.png') }
+
+    before do
+      allow(CharacterizeJob).to receive(:perform_later)
+    end
+
+    it 'can create an external version from an initially interal object' do
+      ENV['REPOSITORY_EXTERNAL_FILES'] = 'false'
+
+      # Create an initial work without external files
+      work = create(:public_work_with_lots_of_versions, depositor: user.login)
+
+      work.ordered_members.to_a.each do |file_set|
+        file_set.files.each do |file|
+          file.versions.all.each do |version|
+            # Test that the file is not a redirect
+            response = Net::HTTP.get_response(URI(version.uri.to_s))
+            expect(response.to_s).to match(/OK/)
+          end
+        end
+      end
+
+      expect(work.file_sets.first.files.first.versions.all.size).to eq(2)
+
+      ENV['REPOSITORY_EXTERNAL_FILES'] = 'true'
+
+      ExternalFilesConversion.new(GenericWork).convert
+
+      work.reload
+
+      work.ordered_members.to_a.each do |file_set|
+        file_set.files.each do |file|
+          file.versions.all.each do |version|
+            # Test that the file is not a redirect
+            response = Net::HTTP.get_response(URI(version.uri.to_s))
+            expect(response.to_s).to match(/Redirect/)
+          end
+        end
+      end
+
+      # check to see that there are two versions, and that they have the correct name
+      expect(work.ordered_members.to_a.first.files.first.versions.all.size).to eq(2)
+      expect(work.ordered_members.to_a.first.files.first.versions.all.map(&:label)).to eq(['version1', 'version2'])
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,6 +20,7 @@ require File.expand_path('../../config/environment', __FILE__)
 require 'rspec/rails'
 require 'equivalent-xml/rspec_matchers'
 require 'byebug' unless ENV['TRAVIS']
+require File.expand_path('../factory_helpers.rb', __FILE__)
 
 # For feature testing with JS
 require 'capybara/rails'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,6 @@ require File.expand_path('../../config/environment', __FILE__)
 require 'rspec/rails'
 require 'equivalent-xml/rspec_matchers'
 require 'byebug' unless ENV['TRAVIS']
-require File.expand_path('../factory_helpers.rb', __FILE__)
 
 # For feature testing with JS
 require 'capybara/rails'

--- a/spec/support/helpers/factory_helpers.rb
+++ b/spec/support/helpers/factory_helpers.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module FactoryHelpers
+  extend self
+
   def mock_file_factory(opts = {})
     mock_model('MockFile',
                mime_type:         opts.fetch(:mime_type, 'text/plain'),
@@ -18,5 +20,74 @@ module FactoryHelpers
                digest:            opts.fetch(:digest, []),
                duration:          opts.fetch(:duration, []),
                sample_rate:       opts.fetch(:sample_rate, []))
+  end
+
+  # Create a new fileset with a public PNG file and add it to the work
+  def add_public_png(work, attributes)
+    fs = FactoryGirl.create(:file_set,
+                            user: User.find_by(login: work.depositor),
+                            title: ['A contained PNG file'],
+                            label: 'world.png',
+                            visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)
+
+    file_path = "#{Rails.root}/spec/fixtures/world.png"
+    IngestFileJob.perform_now(fs, file_path, attributes.user)
+
+    work.ordered_members << fs
+    work.thumbnail_id = fs.id
+    work.representative_id = fs.id
+    work.update_index
+  end
+
+  def add_another_version(work, attributes)
+    file_path = "#{Rails.root}/spec/fixtures/world.png"
+    IngestFileJob.perform_now(work.file_sets.first, file_path, attributes.user)
+  end
+
+  def add_public_pdf(work, attributes)
+    fs = FactoryGirl.create(:file_set,
+                            user: User.find_by(login: work.depositor),
+                            title: ['A full-text pdf file'],
+                            label: 'test.pdf',
+                            visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)
+
+    file_path = "#{Rails.root}/spec/fixtures/test.pdf"
+    IngestFileJob.perform_now(fs, file_path, attributes.user)
+
+    work.ordered_members << fs
+    work.thumbnail_id = fs.id
+    work.representative_id = fs.id
+    work.update_index
+  end
+
+  def add_public_readme(work, attributes)
+    fs = FactoryGirl.create(:file_set,
+                            user: User.find_by(login: work.depositor),
+                            title: ['README'],
+                            label: 'readme.md',
+                            visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)
+
+    file_path = "#{Rails.root}/spec/fixtures/readme.md"
+    IngestFileJob.perform_now(fs, file_path, attributes.user)
+
+    work.ordered_members << fs
+    work.thumbnail_id = fs.id
+    work.representative_id = fs.id
+    work.save
+  end
+
+  def add_public_mp3
+    fs = FactoryGirl.create(:file_set,
+                            user: attributes.user,
+                            title: ['A contained MP3 file'],
+                            label: 'scholarsphere_test5.mp3',
+                            visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)
+
+    filename = "#{Rails.root}/spec/fixtures/scholarsphere/scholarsphere_test5.mp3"
+    local_file = File.open(filename, 'rb')
+    Hydra::Works::AddFileToFileSet.call(fs, local_file, :original_file, versioning: false)
+    fs.save!
+    work.ordered_members << fs
+    work.thumbnail_id = fs.id
   end
 end

--- a/spec/support/helpers/factory_helpers.rb
+++ b/spec/support/helpers/factory_helpers.rb
@@ -76,7 +76,7 @@ module FactoryHelpers
     work.save
   end
 
-  def add_public_mp3
+  def add_public_mp3(work, attributes)
     fs = FactoryGirl.create(:file_set,
                             user: attributes.user,
                             title: ['A contained MP3 file'],


### PR DESCRIPTION
This commit includes a class that takes a Work type and
converts each of the objects to use external storage.

It does this by going through each of the versions for all of the files.
It deletes the first version, while preserving the content. The
subsequent versions have the correct version names: 'version1', 'version2', etc.

There is a rake task to run this conversion that you can run:
`rake scholarsphere:internal_to_external_files`