### PR TITLE
Separate unicorn config file for test environment

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,9 +1,3 @@
 # frozen_string_literal: true
 
 worker_processes 3
-
-# By default, the Unicorn logger will write to stderr.
-# Additionally, ome applications/frameworks log to stderr or stdout,
-# so prevent them from going to /dev/null when daemonized here:
-stderr_path 'log/unicorn.stderr.log'
-stdout_path 'log/unicorn.stdout.log'

--- a/config/unicorn_test.rb
+++ b/config/unicorn_test.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+worker_processes 3
+
+# By default, the Unicorn logger will write to stderr.
+# Additionally, one applications/frameworks log to stderr or stdout,
+# so prevent them from going to /dev/null when daemonized here:
+stderr_path 'log/unicorn.stderr.log'
+stdout_path 'log/unicorn.stdout.log'


### PR DESCRIPTION
unicorn.rb was routing all requests in development mode, when typically
they showed up in terminal. Using a different file for test, keeps the
rspec output clean, and preserves the expected behavior when running
`bundle exec rails s` in your console.

@cam156 is this what you had in mind?