### PR TITLE
Updating indexing and presenters for speed

### DIFF
--- a/app/indexers/work_indexer.rb
+++ b/app/indexers/work_indexer.rb
@@ -7,8 +7,8 @@ class WorkIndexer < Sufia::WorkIndexer
     super.tap do |solr_doc|
       solr_doc[Solrizer.solr_name('file_set_ids', :symbol)] = solr_doc[Solrizer.solr_name('member_ids', :symbol)]
       solr_doc[Solrizer.solr_name('resource_type', :facetable)] = object.resource_type
-      solr_doc[Solrizer.solr_name('file_format', :stored_searchable)] = representative.file_format
-      solr_doc[Solrizer.solr_name('file_format', :facetable)] = representative.file_format
+      solr_doc[Solrizer.solr_name('file_format', :stored_searchable)] = file_format
+      solr_doc[Solrizer.solr_name('file_format', :facetable)] = file_format
       solr_doc['readme_file_ss'] = readme_file.content
       solr_doc[Solrizer.solr_name(:bytes, CurationConcerns::CollectionIndexer::STORED_LONG)] = object.bytes
       SolrDocumentGroomer.call(solr_doc)
@@ -45,6 +45,10 @@ class WorkIndexer < Sufia::WorkIndexer
 
       def content
         return unless content?
+        @content ||= retrieve_and_encode
+      end
+
+      def retrieve_and_encode
         retrieved_content = case file.original_file.content
                             when String
                               file.original_file.content
@@ -53,5 +57,9 @@ class WorkIndexer < Sufia::WorkIndexer
                             end
         EncodingService.call(retrieved_content)
       end
+    end
+
+    def file_format
+      @file_format ||= representative.file_format
     end
 end

--- a/app/models/file_set.rb
+++ b/app/models/file_set.rb
@@ -10,8 +10,26 @@ class FileSet < ActiveFedora::Base
   end
 
   # @return [String, nil]
-  # Field value is constructed at index time in CurationConcerns::FileSetIndexer
+  # Copied from file_set_indexer for efficiency
   def file_format
-    to_solr.fetch('file_format_sim', nil)
+    return unless mime_type.present? || format_label.present?
+
+    formatted = format_mime_type_and_label
+    formatted ||= format_mime_type
+    formatted ||= format_label
+
+    formatted
+  end
+
+  def format_mime_type_and_label
+    return unless mime_type.present? && format_label.present?
+
+    "#{format_mime_type} (#{format_label.join(', ')})"
+  end
+
+  def format_mime_type
+    return if mime_type.blank?
+
+    mime_type.split('/').last
   end
 end

--- a/app/presenters/work_show_presenter.rb
+++ b/app/presenters/work_show_presenter.rb
@@ -34,8 +34,9 @@ class WorkShowPresenter < Sufia::WorkShowPresenter
 
   # TODO: Remove once https://github.com/projecthydra/sufia/issues/2394 is resolved
   def member_presenters
+    return @member_presenters if @member_presenters.present?
     members = super.delete_if { |presenter| current_ability.cannot?(:read, presenter.solr_document) }
-    Kaminari.paginate_array(members).page(@file_page).per(10)
+    @member_presenters = Kaminari.paginate_array(members).page(@file_page).per(10)
   end
 
   def uploading?


### PR DESCRIPTION
refs #1233

Only paginate once and then cache member presenters for work show page
Cache File Format for two field in the index
Cache readme content in the index
Calculate Format in FileSet instead of calling to_solr, which is more expensive