### PR TITLE
Upgrade bagit version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'blacklight_advanced_search', '~> 6.0'
 gem 'mail', '= 2.6.6.rc1'
 
 # Other components
-gem 'bagit'
+gem 'bagit', '~> 0.4.2'
 gem 'bootsnap', require: false
 gem 'clamav' unless ENV['TRAVIS'] == 'true'
 gem 'coderay'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,7 +91,7 @@ GEM
       babel-source (>= 4.0, < 6)
       execjs (~> 2.0)
     backports (3.11.1)
-    bagit (0.4.1)
+    bagit (0.4.2)
       docopt (~> 0.5.0)
       validatable (~> 1.6)
     bcrypt (3.1.11)
@@ -889,7 +889,7 @@ PLATFORMS
 
 DEPENDENCIES
   active-fedora (~> 11.5)
-  bagit
+  bagit (~> 0.4.2)
   better_errors
   binding_of_caller
   blacklight_advanced_search (~> 6.0)

--- a/lib/scholarsphere/bagger.rb
+++ b/lib/scholarsphere/bagger.rb
@@ -9,7 +9,7 @@ module Scholarsphere
       @bag.add_file(working_file) do |io|
         io.puts File.open(working_file).read
       end
-      @bag.manifest!
+      @bag.manifest!(algo: 'sha256')
       Dir.chdir(current_directory)
     end
   end


### PR DESCRIPTION
This changes the bagit version to the lastest
version and changes the hasing algorithm to use sha256, which is
what is used in the Research Data Alliance examples.