### PR TITLE
Remove the Blocks with N/A from the Admin Stats

### DIFF
--- a/app/views/sufia/admin/show.html.erb
+++ b/app/views/sufia/admin/show.html.erb
@@ -1,0 +1,13 @@
+<%# Removing the columns for total, returning, and new visitors because we do not have data for them %>
+<div class="row">
+  <div class="col-md-3">
+    <div class="panel panel-default">
+      <div class="panel-heading"><div class="h3 panel-title text-center"><%= t('.registered_users') %></div></div>
+      <div class="panel-body text-center">
+        Current
+        <div class="h3"><%= @presenter.user_count %></div>
+      </div>
+    </div>
+  </div>
+</div>
+<%= render 'collections' %>


### PR DESCRIPTION
Overrides the Sufia Admin Show partial to remove the blocks without any data. Fixes #562 


![screen shot 2018-06-14 at 6 33 12 pm](https://user-images.githubusercontent.com/4163828/41441709-cc11d5c8-7001-11e8-80fe-da542c5355cf.png)
