### PR TITLE
APPINT-2371: Removed obsolete passenger code from scholarsphere codebase

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -181,30 +181,6 @@ namespace :deploy do
     end
   end
   after :roleassets, :symlink_resque_assets
-
-  # Passenger Capistrano Task
-  # The passenger install task allows Chef to install Passenger now via Yum, but it allows Capistrano to maintain the file
-  # as Ruby is updated on the system.  The PassengerDefaultRuby variable is set to system ruby by default from the Yum
-  # install.  This will not work in our environment.
-  # Passenger Install Task below defines the current ruby version
-  # Adds it to temp file
-  # then copies passenger configs to temp file.
-  # Replaces all instances of PassengerRuby with proper version in temp file.
-  # Replace passenger conf file with temp file.
-
-  namespace :passenger do
-    desc 'Passenger Version Config Update'
-    task :config_update do
-      on roles(:web) do
-        execute 'mkdir --parents /opt/heracles/deploy/passenger'
-        execute 'cd ~deploy/scholarsphere/current && echo -n "PassengerRuby " > ~deploy/passenger/passenger-ruby-version.cap   && rbenv which ruby >> ~deploy/passenger/passenger-ruby-version.cap'
-        execute 'v_passenger_ruby=$(cat ~deploy/passenger/passenger-ruby-version.cap) &&    cp --force /etc/httpd/conf.d/phusion-passenger-default-ruby.conf ~deploy/passenger/passenger-ruby-version.tmp &&    sed -i -e "s|.*PassengerRuby.*|${v_passenger_ruby}|" ~deploy/passenger/passenger-ruby-version.tmp'
-        execute 'sudo /bin/mv ~deploy/passenger/passenger-ruby-version.tmp /etc/httpd/conf.d/phusion-passenger-default-ruby.conf'
-        execute 'sudo /bin/systemctl restart httpd'
-      end
-    end
-  end
-  after :published, 'passenger:config_update'
 end
 
 # Used to keep x-1 instances of ruby on a machine.  Ex +4 leaves 3 versions on a machine.  +3 leaves 2 versions


### PR DESCRIPTION
This PR removes obsolete passenger code from the `config/deploy.rb`. @lauterman has reconfigured how passenger gets installed and configured on the servers. The new method does not require specific configuration of a particular ruby version and instead uses the system ruby for passenger related functions. This change has made the related section of the `deploy.rb` obsolete, so this code has been removed.

This change has been tested on qa and stage.