### PR TITLE
APPINT-2377 Utilize passenger commands to restart app

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -24,6 +24,7 @@ install_plugin Capistrano::SCM::Git
 require 'whenever/capistrano' # whenever
 require 'capistrano-resque' # resque
 require 'capistrano/rbenv_install' # rbenv install plugin
+require 'capistrano/passenger'
 
 # Loads custom tasks from `lib/capistrano/tasks' if you have any defined.
 # tasks included: passenger, checksum

--- a/Gemfile
+++ b/Gemfile
@@ -77,6 +77,7 @@ group :development do
   gem 'capistrano-rbenv', '~> 2.1', require: false
   gem 'capistrano-rbenv-install'
   gem 'capistrano-resque', '~> 0.2.1', require: false
+  gem 'capistrano-passenger'
   gem 'travis', require: false
   gem 'xray-rails'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -161,6 +161,8 @@ GEM
     capistrano-bundler (1.2.0)
       capistrano (~> 3.1)
       sshkit (~> 1.2)
+    capistrano-passenger (0.2.0)
+      capistrano (~> 3.0)
     capistrano-rails (1.2.0)
       capistrano (~> 3.1)
       capistrano-bundler (~> 1.1)
@@ -897,6 +899,7 @@ DEPENDENCIES
   byebug
   capistrano (~> 3.7)
   capistrano-bundler (~> 1.2)
+  capistrano-passenger
   capistrano-rails (~> 1.2)
   capistrano-rbenv (~> 2.1)
   capistrano-rbenv-install


### PR DESCRIPTION
Capistrano needs updated so that it will restart the application at the end of the deploy again. It is currently not doing that.