### PR TITLE
Updating Sprockets to 3.7.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -567,7 +567,7 @@ GEM
       faraday
       nokogiri (~> 1.6)
       rails (>= 4.2.0, < 6.0)
-    rack (1.6.9)
+    rack (1.6.10)
     rack-maintenance (2.0.1)
       rack (>= 1.0)
     rack-protection (1.5.5)
@@ -764,7 +764,7 @@ GEM
       nokogiri
       stomp
       xml-simple
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-es6 (0.9.2)
@@ -964,4 +964,4 @@ DEPENDENCIES
   yaml_db
 
 BUNDLED WITH
-   1.16.2
+   1.16.3


### PR DESCRIPTION
Addresses CVE-2018-3760