### PR TITLE
Enable editing of on_behalf_of

### DIFF
--- a/app/actors/curation_concerns/actors/generic_work_actor.rb
+++ b/app/actors/curation_concerns/actors/generic_work_actor.rb
@@ -29,9 +29,10 @@ module CurationConcerns
         # if the user is depositing on behalf of someone else.
         def apply_save_data_to_curation_concern(attributes)
           if attributes.fetch('on_behalf_of', nil).present?
-            depositor = ::User.find_by_user_key(attributes.fetch('on_behalf_of'))
-            curation_concern.apply_depositor_metadata(depositor)
-            curation_concern.edit_users += [depositor, user.user_key]
+            current_depositor = curation_concern.depositor
+            new_depositor = ::User.find_by_user_key(attributes.fetch('on_behalf_of'))
+            curation_concern.apply_depositor_metadata(new_depositor)
+            curation_concern.edit_users = update_edit_users_for_curation_concern(current_depositor, new_depositor)
           end
           super
         end
@@ -51,6 +52,14 @@ module CurationConcerns
           edit_users.delete(current_depositor)
           edit_users << new_depositor
           curation_concern.edit_users = edit_users
+        end
+
+        def update_edit_users_for_curation_concern(current_depositor, new_depositor)
+          edit_users = curation_concern.edit_users
+          edit_users.delete(current_depositor)
+          edit_users + [new_depositor, curation_concern.proxy_depositor]
+          edit_users << user.user_key unless user.administrator?
+          edit_users.uniq
         end
 
         class EncodedAttributeHash < ActiveSupport::HashWithIndifferentAccess

--- a/app/views/curation_concerns/base/_form_progress.html.erb
+++ b/app/views/curation_concerns/base/_form_progress.html.erb
@@ -55,11 +55,7 @@
         <%= f.input :on_behalf_of, label: false, collection: current_user.can_make_deposits_for.map { |proxy| [proxy.name, proxy.user_key] }, prompt: 'Yourself' %>
       </div>
     <% elsif current_user.administrator? && action_name == "edit" %>
-      <div class="list-group-item">
-        <label for="generic_work_depositor"><%= t('curation_concerns.base.form_progress.depositor') %></label>
-        <p class="bg-danger"><%= t('curation_concerns.base.form_progress.depositor_admin') %></p>
-        <%= f.input :depositor, label: false %>
-      </div>
+      <%= render 'form_progress_admin_edit', f: f, on_behalf_of: curation_concern.on_behalf_of %>
     <% end %>
   </div>
   <div class="panel-footer text-center">

--- a/app/views/curation_concerns/base/_form_progress_admin_edit.html.erb
+++ b/app/views/curation_concerns/base/_form_progress_admin_edit.html.erb
@@ -1,0 +1,13 @@
+<% if on_behalf_of.present? %>
+  <div class="list-group-item">
+    <label for="generic_work_on_behalf_of"><%= t('curation_concerns.base.form_progress.on_behalf_of') %></label>
+    <p class="bg-danger"><%= t('curation_concerns.base.form_progress.on_behalf_of_admin') %></p>
+    <%= f.input :on_behalf_of, label: false %>
+  </div>
+<% else %>
+  <div class="list-group-item">
+    <label for="generic_work_depositor"><%= t('curation_concerns.base.form_progress.depositor') %></label>
+    <p class="bg-danger"><%= t('curation_concerns.base.form_progress.depositor_admin') %></p>
+    <%= f.input :depositor, label: false %>
+  </div>
+<% end %>

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -117,6 +117,7 @@ en:
         files_required_complete: 'Required files complete'
         on_behalf_of: 'On behalf of'
         on_behalf_of_help: 'Remember to correct the creator field if you are depositing on behalf of someone else.'
+        on_behalf_of_admin: 'Warning! You are changing the proxy information.'
         depositor: 'Depositor Info'
         depositor_admin: 'Warning! You are changing the depositor information.'
       form_files:

--- a/spec/features/generic_work/edit_work_as_admin_spec.rb
+++ b/spec/features/generic_work/edit_work_as_admin_spec.rb
@@ -19,7 +19,12 @@ describe GenericWork, js: true do
 
     it 'updates the work with the new depositor' do
       visit("/concern/generic_works/#{work.id}/edit")
+
+      # Only show the depositor field, and not on_behalf_of because it is empty.
+      # We don't want to enable this field because putting a value in it would effect a transfer.
       expect(page).to have_field('generic_work[depositor]', with: user1.user_key)
+      expect(page).not_to have_field('generic_work[on_behalf_of]')
+
       fill_in 'generic_work[depositor]', with: user2.user_key
       click_button('Save')
       expect(page).to have_content('Apply changes to contents?')
@@ -30,6 +35,52 @@ describe GenericWork, js: true do
       expect(work.file_sets.first.depositor).to eq(user2.user_key)
       expect(work.edit_users).to contain_exactly(user2.user_key)
       expect(work.file_sets.first.edit_users).to contain_exactly(user2.user_key)
+    end
+  end
+
+  context 'when an administrator changes the on-behalf-of user' do
+    let(:proxy)       { create(:user, login: 'proxy1', display_name: 'Original Proxy Depositor') }
+    let(:first_user)  { create(:user, login: 'obu1', display_name: 'Original On-Behalf-Of User') }
+    let(:new_proxy)   { create(:user, login: 'proxy2', display_name: 'New Proxy Depositor') }
+    let(:second_user) { create(:user, login: 'obu2', display_name: 'New On-Behalf-Of User') }
+
+    # This is a work with the depositor creating on behalf of another user. When the work is saved,
+    # this initiates an immediate transfer so that the "on behalf of" user becomes the depositor.
+    let!(:work) do
+      create(:public_work, :with_required_metadata, :with_one_file,
+        depositor: proxy.user_key,
+        on_behalf_of: first_user.user_key,
+        admin_set: AdminSet.first)
+    end
+
+    it 'updates the work with the a new depositor' do
+      visit("/concern/generic_works/#{work.id}/edit")
+
+      # @note There is some confusion about whether or not depositor and on_behalf_of should be the
+      #   the same. We're assuming that they should be because the current code seems to reflect this.
+      # @see https://github.com/psu-stewardship/scholarsphere/issues/978
+
+      # Only on_behalf_is shown because GenericWorkActor#apply_save_data_to_curation_concern always
+      # sets the depositor to the value of the on_behalf_of user, so the field should not be shown
+      # if a value exists for on_behalf_of
+      expect(page).not_to have_field('generic_work[depositor]')
+      expect(page).to have_field('generic_work[on_behalf_of]', with: first_user.user_key)
+
+      # Verify permissions
+      # @todo the on-behalf-of user does not have edit access. This should probably be a bug
+      # expect(work.edit_users).to contain_exactly(proxy.user_key, first_user.user_key)
+
+      fill_in 'generic_work[on_behalf_of]', with: second_user.user_key
+
+      click_button('Save')
+      expect(page).to have_content('Apply changes to contents?')
+      click_button('Yes please.')
+      expect(page).to have_content(work.title.first)
+      work.reload
+      expect(work.depositor).to eq(second_user.user_key)
+      expect(work.file_sets.first.depositor).to eq(second_user.user_key)
+      expect(work.edit_users).to contain_exactly(proxy.user_key, second_user.user_key)
+      expect(work.file_sets.first.edit_users).to contain_exactly(proxy.user_key, second_user.user_key)
     end
   end
 end


### PR DESCRIPTION
Allows and administrator to change the on_behalf_of user for works that have either been transferred or uploaded by a proxy user.

Fixes #979 
