### PR TITLE
Convert a single object

### DIFF
--- a/app/services/external_files_conversion.rb
+++ b/app/services/external_files_conversion.rb
@@ -3,24 +3,40 @@
 require 'fileutils'
 
 class ExternalFilesConversion
-  attr_reader :work_class, :user
+  attr_reader :work_class, :user, :opts
 
-  def initialize(work_class)
+  def initialize(work_class, opts = {})
     @work_class = work_class
     @user = User.batch_user
+    @opts = opts
   end
 
-  def convert
-    @work_class.all.each do |work|
+  # If we receive a work ID, only convert that one item
+  # Otherwise, convert all instances of the given class
+  # @param [String] id
+  def convert(id = nil)
+    if id
+      convert_work(@work_class.find(id))
+    else
+      convert_class
+    end
+  end
+
+  private
+
+    def convert_class
+      @work_class.all.each do |work|
+        convert_work(work)
+      end
+    end
+
+    def convert_work(work)
       work.file_sets.each do |file_set|
         file_set.files.each do |file|
           convert_file(work, file_set, file)
         end
       end
     end
-  end
-
-  private
 
     def convert_file(work, file_set, file)
       # This slug must be prefixed with auto_ so that it will not appear in versions.all

--- a/spec/services/external_files_conversion_spec.rb
+++ b/spec/services/external_files_conversion_spec.rb
@@ -3,8 +3,9 @@
 require 'rails_helper'
 
 describe ExternalFilesConversion do
-  context 'when running a conversion' do
-    let(:conversion) { described_class.new(GenericWork).convert }
+  context 'running a conversion from internal to external file storage' do
+    let(:full_conversion) { described_class.new(GenericWork).convert }
+    let(:single_work_conversion) { described_class.new(GenericWork).convert(work.id) }
     let(:user) { create(:user) }
     let(:work) { create(:public_work_with_png, depositor: user.login) }
     let(:file_set) { work.file_sets.first }
@@ -14,13 +15,25 @@ describe ExternalFilesConversion do
       allow(CharacterizeJob).to receive(:perform_later)
     end
 
-    it 'converts works that use internal files to external files' do
+    it 'converts all works of a given Class' do
       ENV['REPOSITORY_EXTERNAL_FILES'] = 'false'
       file_set
       response = Net::HTTP.get_response(URI(file_set.files.first.uri.to_s))
       expect(response.to_s).to match(/OK/)
       ENV['REPOSITORY_EXTERNAL_FILES'] = 'true'
-      conversion
+      full_conversion
+      response = Net::HTTP.get_response(URI(file_set.files.first.uri.to_s))
+      expect(response['content-disposition']).to match(/world.png/)
+      expect(file_set.original_file.original_name).to eq('world.png')
+      expect(response.to_s).to match(/HTTPTemporaryRedirect/)
+    end
+    it 'converts a single work of a given Class' do
+      ENV['REPOSITORY_EXTERNAL_FILES'] = 'false'
+      file_set
+      response = Net::HTTP.get_response(URI(file_set.files.first.uri.to_s))
+      expect(response.to_s).to match(/OK/)
+      ENV['REPOSITORY_EXTERNAL_FILES'] = 'true'
+      single_work_conversion
       response = Net::HTTP.get_response(URI(file_set.files.first.uri.to_s))
       expect(response['content-disposition']).to match(/world.png/)
       expect(file_set.original_file.original_name).to eq('world.png')


### PR DESCRIPTION
If we can convert a single object from internal to
external files storage, instead of having to convert
all of the objects of a given class, it will make it
much faster to debug configuration issues.

Connected to #1338 