### PR TITLE
Replace system create date with date uploaded

### DIFF
--- a/app/prepends/prepended_services/with_date_uploaded.rb
+++ b/app/prepends/prepended_services/with_date_uploaded.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Replaces the system create date with the uploaded data in Sufia::QueryService
+# so that reports are generated based on the date a work was originally deposited
+# in the Scholarsphere. This takes into account any subsequent migrations that
+# were done to works and files after they were deposited.
+
+module PrependedServices::WithDateUploaded
+  def build_date_query(*args)
+    super(*args).gsub('system_create_dtsi', 'date_uploaded_dtsi')
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -119,6 +119,7 @@ module ScholarSphere
       CurationConcerns::MemberPresenterFactory.file_presenter_class = FileSetPresenter
       Sufia::CreateWithFilesActor.prepend PrependedActors::WithVisibilityAttributes
       Sufia::Statistics::TermQuery.prepend PrependedServices::WithNullTermQuery
+      Sufia::QueryService.prepend PrependedServices::WithDateUploaded
 
       # Prepending class methods
       if ENV['REPOSITORY_EXTERNAL_FILES'] == 'true'

--- a/spec/features/admin_stats_spec.rb
+++ b/spec/features/admin_stats_spec.rb
@@ -5,9 +5,15 @@ require 'feature_spec_helper'
 describe 'Administrative Statistics', type: :feature do
   let(:user)  { create(:user) }
   let(:admin) { create(:administrator) }
+  let(:email) { UserMailer.stats_email(8.days.ago.beginning_of_day, 1.day.ago.end_of_day) }
 
   before do
-    3.times { create(:public_work, depositor: user.login) }
+    3.times do |count|
+      create(:work, :with_one_file,
+        title: ["Admin Stat Work #{count}"],
+        date_uploaded: (Date.today - count.week),
+        depositor: user.login)
+    end
     sign_in(admin)
   end
 
@@ -16,5 +22,8 @@ describe 'Administrative Statistics', type: :feature do
     expect(page).to have_selector('h2', text: 'Statistics By Date')
     expect(page).to have_selector('h3', text: 'Work Statistics')
     expect(page).to have_selector('h4', text: 'Total Works: 3')
+    expect(email.message.parts.last.body.raw_source).to include('Admin Stat Work 1')
+    expect(email.message.parts.last.body.raw_source).not_to include('Admin Stat Work 0')
+    expect(email.message.parts.last.body.raw_source).not_to include('Admin Stat Work 2')
   end
 end

--- a/spec/models/user_mailer_spec.rb
+++ b/spec/models/user_mailer_spec.rb
@@ -23,7 +23,7 @@ describe UserMailer do
     let(:message)      { described_class.stats_email(1.day.ago, DateTime.now) }
     let(:mock_service) { double }
     let(:csv)          { "a,b,c\nd,e,f\n" }
-    let!(:generic_work) { create :work }
+    let!(:generic_work) { create :work, date_uploaded: 12.hours.ago }
 
     before do
       allow(GenericWorkListToCSVService).to receive(:new).with([generic_work]).and_return(mock_service)

--- a/spec/services/sufia/query_service_spec.rb
+++ b/spec/services/sufia/query_service_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Sufia::QueryService do
+  let(:service) { described_class.new }
+
+  describe '#build_date_query' do
+    subject { described_class.new.build_date_query(start_date, end_date) }
+
+    context 'with an end date' do
+      let(:start_date) { DateTime.iso8601('1981-04-17', Date::ENGLAND) }
+      let(:end_date) { DateTime.iso8601('1995-07-04', Date::ENGLAND) }
+
+      it { is_expected.to eq('date_uploaded_dtsi:[1981-04-17T00:00:00Z TO 1995-07-04T00:00:00Z]') }
+    end
+
+    context 'without an end date' do
+      let(:start_date) { DateTime.iso8601('1981-04-17', Date::ENGLAND) }
+      let(:end_date) { nil }
+
+      it { is_expected.to eq('date_uploaded_dtsi:[1981-04-17T00:00:00Z TO *]') }
+    end
+  end
+end


### PR DESCRIPTION
Uses the date uploaded field in Solr to query for works in the stats reports.

Fixes #933 