### PR TITLE
Displaying collection creator as a cleaned facet

### DIFF
--- a/app/presenters/collection_presenter.rb
+++ b/app/presenters/collection_presenter.rb
@@ -11,4 +11,12 @@ class CollectionPresenter < Sufia::CollectionPresenter
   def permission_badge_class
     PublicPermissionBadge
   end
+
+  def creator_facet_path(index)
+    Rails.application.routes.url_helpers.search_catalog_path(:"f[#{:creator_name_sim}][]" => cleaned_creators[index])
+  end
+
+  def cleaned_creators
+    @cleaned_creators ||= FacetValueCleaningService.call(creator, FieldConfig.new(facet_cleaners: [:creator]), solr_document)
+  end
 end

--- a/app/views/records/show_fields/_creator.html.erb
+++ b/app/views/records/show_fields/_creator.html.erb
@@ -1,6 +1,8 @@
-<% record.creator.each do |creator| %>
+<% record.creator.each_with_index do |creator, i| %>
   <span itemprop="creator" itemscope itemtype="http://schema.org/Person">
-    <span itemprop="name"><%= link_to_facet(creator, Solrizer.solr_name('creator_name', :facetable)) %></span>
+  <span itemprop="name">
+    <%= link_to(creator, @presenter.creator_facet_path(i)) %>
+  </span>
   </span>
   <br />
 <% end %>

--- a/spec/features/collection/view_and_search_spec.rb
+++ b/spec/features/collection/view_and_search_spec.rb
@@ -35,6 +35,7 @@ describe Collection, type: :feature do
         expect(page).to have_content collection.title.first
         expect(page).to have_content collection.description.first
         expect(page).to have_content collection.creator.first.display_name
+        expect(page).to have_selector("a[href='/catalog?f%5Bcreator_name_sim%5D%5B%5D=Given+Name+Sur+Name']")
         expect(page).to have_selector("a[href='https://doi.org/blah-blah']")
         expect(page).to have_content file1.title.first
         expect(page).to have_content file2.title.first


### PR DESCRIPTION
This updates the collection page to show the cleaned name.