### PR TITLE
Display admin stats page without errors

### DIFF
--- a/.solr_wrapper
+++ b/.solr_wrapper
@@ -1,5 +1,9 @@
 # .solr_wrapper
-version: 7.1.0
+# Note: If you're updating this file, it must be updated in a total of three places:
+#   - .solr_wrapper
+#   - config/solr_wrapper_test.yml
+#   - config/travis/solr_wrapper_test.yml
+version: 7.4.0
 port: 8983
 instance_dir: tmp/solr-development
 download_dir: tmp

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -710,7 +710,7 @@ GEM
       json
       multipart-post
       oauth2
-    ruby-progressbar (1.9.0)
+    ruby-progressbar (1.10.0)
     rubyzip (1.2.1)
     rufus-scheduler (3.2.2)
     safe_yaml (1.0.4)
@@ -756,8 +756,9 @@ GEM
     sitemap (0.3.3)
     slop (4.6.1)
     smart_properties (1.13.1)
-    solr_wrapper (0.19.0)
+    solr_wrapper (2.0.0)
       faraday
+      retriable
       ruby-progressbar
       rubyzip
     solrizer (3.4.1)

--- a/app/prepends/prepended_services/with_null_term_query.rb
+++ b/app/prepends/prepended_services/with_null_term_query.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Overrides Sufia::Statistics::TermQuery to correct for term queries that have no results
+
+module PrependedServices::WithNullTermQuery
+  def query
+    term = index_key
+    # Grab JSON response (looks like {"terms": {"depositor_tesim": {"mjg36": 3}}} for depositor)
+    json = solr_connection.get 'terms', params: { 'terms.fl' => term,
+                                                  'terms.sort' => 'count',
+                                                  'terms.limit' => @limit,
+                                                  wt: 'json',
+                                                  'json.nl' => 'map',
+                                                  omitHeader: 'true' }
+    if json.blank?
+      Rails.logger.error 'Unable to reach TermsComponent via Solr connection. Is it enabled in your solr config?'
+      return []
+    end
+
+    Sufia::Statistics::TermQuery::Result.build(json['terms'][term])
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -118,6 +118,7 @@ module ScholarSphere
       CurationConcerns::CollectionSearchBuilder.prepend PrependedSearchBuilders::WithMoreRows
       CurationConcerns::MemberPresenterFactory.file_presenter_class = FileSetPresenter
       Sufia::CreateWithFilesActor.prepend PrependedActors::WithVisibilityAttributes
+      Sufia::Statistics::TermQuery.prepend PrependedServices::WithNullTermQuery
 
       # Prepending class methods
       if ENV['REPOSITORY_EXTERNAL_FILES'] == 'true'

--- a/config/solr_wrapper_test.yml
+++ b/config/solr_wrapper_test.yml
@@ -1,5 +1,9 @@
 # config/solr_wrapper_test.yml
-version: 7.1.0
+# Note: If you're updating this file, it must be updated in a total of three places:
+#   - .solr_wrapper
+#   - config/solr_wrapper_test.yml
+#   - config/travis/solr_wrapper_test.yml
+version: 7.4.0
 port: 8985
 instance_dir: tmp/solr-test
 download_dir: tmp

--- a/config/travis/solr_wrapper_test.yml
+++ b/config/travis/solr_wrapper_test.yml
@@ -1,5 +1,9 @@
 # config/solr_wrapper_test.yml
-version: 5.3.1
+# Note: If you're updating this file, it must be updated in a total of three places:
+#   - .solr_wrapper
+#   - config/solr_wrapper_test.yml
+#   - config/travis/solr_wrapper_test.yml
+version: 7.4.0
 port: 8985
 instance_dir: solr-test
 download_dir: dep_cache

--- a/solr/config/solrconfig.xml
+++ b/solr/config/solrconfig.xml
@@ -144,6 +144,17 @@
 			<str name="q">{!raw f=id v=$id}</str>
 		</lst>
 	</requestHandler>
+
+  <searchComponent name="termsComponent" class="solr.TermsComponent" />
+  <requestHandler name="/terms" class="solr.SearchHandler">
+    <lst name="defaults">
+      <bool name="terms">true</bool>
+    </lst>
+    <arr name="components">
+      <str>termsComponent</str>
+    </arr>
+  </requestHandler>
+
 	<searchComponent name="spellcheck" class="solr.SpellCheckComponent">
 		<str name="queryAnalyzerFieldType">textSpell</str>
 		<lst name="spellchecker">

--- a/spec/features/admin_stats_spec.rb
+++ b/spec/features/admin_stats_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'feature_spec_helper'
+
+describe 'Administrative Statistics', type: :feature do
+  let(:user)  { create(:user) }
+  let(:admin) { create(:administrator) }
+
+  before do
+    3.times { create(:public_work, depositor: user.login) }
+    sign_in(admin)
+  end
+
+  it 'displays the administrative statistics and emails reports' do
+    visit '/admin/stats'
+    expect(page).to have_selector('h2', text: 'Statistics By Date')
+    expect(page).to have_selector('h3', text: 'Work Statistics')
+    expect(page).to have_selector('h4', text: 'Total Works: 3')
+  end
+end


### PR DESCRIPTION
Enables the admin. statistics page to render correctly if there is a term query without any results.

Additionally, updates our solr config to include a `/terms` request handler so we can respond correctly to term queries, and updates to Solr to version 7.4, matching our current version in production.

Fixes #1175 