### PR TITLE
Use EncodingService in FileSetIndexer

### DIFF
--- a/app/indexers/file_set_indexer.rb
+++ b/app/indexers/file_set_indexer.rb
@@ -8,7 +8,7 @@ class FileSetIndexer < CurationConcerns::FileSetIndexer
       solr_doc[Solrizer.solr_name(:file_size, CurationConcerns::CollectionIndexer::STORED_LONG)] = object.file_size[0]
       if solr_doc['all_text_timv'].present?
         begin
-          solr_doc['all_text_timv'].force_encoding('UTF-8')
+          solr_doc['all_text_timv'] = EncodingService.call(solr_doc['all_text_timv'])
         rescue StandardError => e
           Rails.logger.warn "could not convert File Set content to UTF8 #{object.id} #{e}"
         end

--- a/spec/indexers/file_set_indexer_spec.rb
+++ b/spec/indexers/file_set_indexer_spec.rb
@@ -42,12 +42,12 @@ describe FileSetIndexer do
         allow(file_set).to receive(:extracted_text).and_return(extracted)
       end
       it 'forces utf8' do
-        expect(text).to receive(:force_encoding).with('UTF-8').and_return('abc123')
+        expect(text).to receive(:encode).with('utf-8', invalid: :replace, undef: :replace).and_return('abc123')
         subject
       end
 
       it 'handles errors with forcing utf8' do
-        expect(text).to receive(:force_encoding).with('UTF-8').and_raise(StandardError.new('blarg'))
+        expect(text).to receive(:encode).with('utf-8', invalid: :replace, undef: :replace).and_raise(StandardError.new('blarg'))
         subject
       end
     end


### PR DESCRIPTION
This commit changes the `FileSetIndexer` to use the
`EncodingService`. This will ensure that whatever has
been stored in 'all_text_timv' is converted to UTF-8.

`force_encoding` will only treat the strings stored there
as if they were UTF-8.