### PR TITLE
Adding index of work for readme

### DIFF
--- a/app/jobs/create_derivatives_job.rb
+++ b/app/jobs/create_derivatives_job.rb
@@ -26,7 +26,7 @@ class CreateDerivativesJob < ActiveJob::Base
   # then the parent also needs to be reindexed.
   def parent_needs_reindex?(file_set)
     return false unless file_set.parent
-    file_set.parent.thumbnail_id == file_set.id
+    file_set.parent.thumbnail_id == file_set.id || file_set.label =~ /^readme/i
   end
 
   private

--- a/spec/features/generic_work/work_with_readme_spec.rb
+++ b/spec/features/generic_work/work_with_readme_spec.rb
@@ -3,12 +3,10 @@
 require 'feature_spec_helper'
 
 describe GenericWork do
-  let!(:current_user) { create(:user) }
-  let!(:work) { create(:public_work_with_readme, title: ['Work with README'], depositor: current_user.login) }
+  let(:current_user) { create(:user) }
+  let(:work) { create(:public_work_with_readme, title: ['Work with README'], depositor: current_user.login) }
 
   before do
-    described_class.all.map(&:update_index)
-    FileSet.all.map(&:update_index)
     sign_in(current_user)
   end
 

--- a/spec/support/helpers/factory_helpers.rb
+++ b/spec/support/helpers/factory_helpers.rb
@@ -61,19 +61,20 @@ module FactoryHelpers
   end
 
   def add_public_readme(work, attributes)
-    fs = FactoryGirl.create(:file_set,
-                            user: User.find_by(login: work.depositor),
-                            title: ['README'],
-                            label: 'readme.md',
-                            visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)
+    fs1 = FactoryGirl.create(:file_set)
 
+    actor = CurationConcerns::Actors::FileSetActor.new(fs1, attributes.user)
+    actor.create_metadata(work, visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)
+    file_path = "#{Rails.root}/spec/fixtures/small_file.txt"
+    local_file = File.open(file_path, 'rb')
+    actor.create_content(local_file)
+
+    fs2 = FactoryGirl.create(:file_set)
+    actor = CurationConcerns::Actors::FileSetActor.new(fs2, attributes.user)
+    actor.create_metadata(work, visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)
     file_path = "#{Rails.root}/spec/fixtures/readme.md"
-    IngestFileJob.perform_now(fs, file_path, attributes.user)
-
-    work.ordered_members << fs
-    work.thumbnail_id = fs.id
-    work.representative_id = fs.id
-    work.save
+    local_file = File.open(file_path, 'rb')
+    actor.create_content(local_file)
   end
 
   def add_public_mp3(work, attributes)


### PR DESCRIPTION
Changes:

* updated tests to include a file with the readme to make them more realistic
* updated the parent_needs_reindex? method to include reindex for readme addition
* removed additional updates to the index that were no longer needed in the test