### PR TITLE
Adding external builds to Code Climate coverage

### DIFF
--- a/travis/coverage.sh
+++ b/travis/coverage.sh
@@ -14,4 +14,4 @@ export PATH=$PATH:$(pwd)/dep_cache
 
 echo -e "\n\n\033[1;33mSending combined report to Code Climate\033[0m"
 aws s3 sync s3://psu.edu.scholarsphere-qa/coverage/$TRAVIS_BUILD_NUMBER coverage/
-cc-test-reporter sum-coverage --output - --parts 2 coverage/codeclimate.*.json | cc-test-reporter upload-coverage --input -
+cc-test-reporter sum-coverage --output - --parts 4 coverage/codeclimate.*.json | cc-test-reporter upload-coverage --input -

--- a/travis/test.sh
+++ b/travis/test.sh
@@ -59,7 +59,10 @@ bundle exec rake scholarsphere:travis:$TEST_SUITE
 RSPEC_EXIT_CODE=$?
 
 echo -e "\n\n\033[1;33mUpload coverage results to AWS\033[0m"
-cc-test-reporter format-coverage --output coverage/codeclimate.$TRAVIS_BUILD_ID.$TEST_SUITE.json
+echo "Filename: codeclimate.$TRAVIS_BUILD_ID.external-$EXTERNAL_FILES.$TEST_SUITE.json"
+cc-test-reporter format-coverage --output coverage/codeclimate.$TRAVIS_BUILD_ID.external-$EXTERNAL_FILES.$TEST_SUITE.json
+echo -n "Coverage contents:"
+ls -l coverage
 aws s3 sync coverage/ s3://psu.edu.scholarsphere-qa/coverage/$TRAVIS_BUILD_NUMBER
 
 exit $RSPEC_EXIT_CODE


### PR DESCRIPTION
Presently, Code Climate is only using the unit and feature test builds to calculate coverage, and is not taking the tests for Fedora's external binary storage into account. This corrects the issue by providing another parameter to the named build file so that we should have 4 files used to compute coverage. For example:

* codeclimate.421242764.feature.external-true.json
* codeclimate.421242764.unit.external-true.json
* codeclimate.421242764.feature.external-false.json
* codeclimate.421242764.unit.external-false.json

