### PR TITLE
Removes the Object Type Facet from My Works, Collections, and Highlights.

### DIFF
--- a/app/controllers/my/shares_controller.rb
+++ b/app/controllers/my/shares_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module My
+  class SharesController < MyController
+    field_config = FieldConfigurator.common_fields[:has_model]
+    solr_type = field_config.opts.fetch(:solr_type, :facetable)
+    blacklight_config.add_facet_field solr_name(:has_model, solr_type), label: field_config.label, limit: 5,
+                                                                        helper_method: field_config.opts[:helper_method]
+
+    def search_builder_class
+      Sufia::MySharesSearchBuilder
+    end
+
+    def index
+      super
+      @selected_tab = 'shared'
+    end
+
+    protected
+
+      def search_action_url(*args)
+        sufia.dashboard_shares_url(*args)
+      end
+
+      # The url of the "more" link for additional facet values
+      def search_facet_path(args = {})
+        sufia.dashboard_shares_facet_path(args[:id])
+      end
+  end
+end

--- a/app/controllers/my_controller.rb
+++ b/app/controllers/my_controller.rb
@@ -3,6 +3,8 @@
 class MyController < ApplicationController
   include Sufia::MyControllerBehavior
 
+  blacklight_config.facet_fields.delete 'has_model_ssim'
+
   private
 
     # Overrides Sufia::MyControllerBehavior to build a presenter for the collection to which we

--- a/spec/features/dashboard/dashboard_collections_spec.rb
+++ b/spec/features/dashboard/dashboard_collections_spec.rb
@@ -19,6 +19,7 @@ describe 'Dashboard Collections:', type: :feature do
 
   specify 'tab title and buttons' do
     expect(page).to have_content('My Collections')
+    expect(page).not_to have_content('Object Type')
     expect(page).to have_link('New Work', visible: false) # link is there (even if collapsed)
     expect(page).to have_link('New Collection', visible: false) # link is there (even if collapsed)
     expect(page).not_to have_selector(".batch-toggle input[value='Delete Selected']")
@@ -62,8 +63,6 @@ describe 'Dashboard Collections:', type: :feature do
   describe 'facets,' do
     specify 'displays the correct totals for each facet' do
       within('#facets') do
-        click_link('Object Type')
-        expect(page).to have_content('Collection (1)')
         click_link('Creator')
         expect(page).to have_content('Given Name Sur Name')
       end

--- a/spec/features/dashboard/dashboard_highlights_spec.rb
+++ b/spec/features/dashboard/dashboard_highlights_spec.rb
@@ -14,6 +14,7 @@ describe 'Dashboard Highlights', type: :feature do
 
   specify 'tab title and buttons' do
     expect(page).to have_content('My Highlights')
+    expect(page).not_to have_content('Object Type')
     expect(page).to have_content('New Work')
     expect(page).to have_content('Create Collection')
     expect(page).not_to have_selector(".batch-toggle input[value='Delete Selected']")

--- a/spec/features/dashboard/dashboard_shares_spec.rb
+++ b/spec/features/dashboard/dashboard_shares_spec.rb
@@ -24,6 +24,7 @@ describe 'Dashboard Shares', type: :feature do
 
   it 'displays only shared files' do
     expect(page).to have_content('Shared with Me')
+    expect(page).to have_content('Object Type')
     expect(page).to have_link('New Work', visible: false)
     expect(page).to have_link('New Collection', visible: false)
     expect(page).not_to have_selector(".batch-toggle input[value='Delete Selected']")

--- a/spec/features/dashboard/dashboard_works_spec.rb
+++ b/spec/features/dashboard/dashboard_works_spec.rb
@@ -36,6 +36,7 @@ describe 'Dashboard Works', type: :feature do
     specify 'interactions are wired correctly' do
       # tab title and buttons
       expect(page).to have_content('My Works')
+      expect(page).not_to have_content('Object Type')
       expect(page).to have_selector('h2.sr-only', text: 'Works listing')
       expect(page).to have_link('New Work', visible: false) # link is there (even if collapsed)
       expect(page).to have_link('New Collection', visible: false) # link is there (even if collapsed)


### PR DESCRIPTION
Removed the has_model object type from all of the My Controllers and then added it back in for the My Shares Controller.

Fixes #351 