### PR TITLE
Refactor external files migration to avoid OOM error

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,7 @@ Metrics/ClassLength:
   Exclude:
     - 'app/models/user.rb'
     - 'app/controllers/catalog_controller.rb'
+    - 'app/services/external_files_conversion.rb'
 
 Metrics/CyclomaticComplexity:
   Exclude:

--- a/app/services/external_files_conversion.rb
+++ b/app/services/external_files_conversion.rb
@@ -4,13 +4,20 @@ require 'fileutils'
 require 'logger'
 
 class ExternalFilesConversion
-  attr_reader :work_class, :user
+  NUMBER_OF_PIDS_PER_FILE = 1000
+  attr_reader :work_class, :user, :pid_lists, :error_file, :logger
 
   def initialize(work_class)
     @work_class = work_class
     @user = User.batch_user
-    @logger = Logger.new(ENV['REPOSITORY_MIGRATION_LOG'])
-    @logger.level = Logger::DEBUG
+    @logger = Logger.new(ENV['REPOSITORY_MIGRATION_LOG'] || Rails.root.join('log', "external_files_conversion_#{timestamp}.log").to_s)
+    logger.level = Logger::DEBUG
+    @pid_lists = []
+    @error_file = ENV['REPOSITORY_MIGRATION_ERROR_LOG'] || Rails.root.join('log', "external_files_conversion_errors_#{timestamp}.log").to_s
+  end
+
+  def timestamp
+    @timestamp ||= Time.now.strftime('%Y-%m-%e-%H-%M-%S')
   end
 
   # If we receive a work ID, only convert that one item
@@ -19,36 +26,62 @@ class ExternalFilesConversion
   # @param [Hash] opts optional parameters. Valid values are :id and :file
   def convert(opts = {})
     start_time = Time.now
-    @logger.info "Starting conversion process at #{start_time}"
+    logger.info "Starting conversion process at #{start_time}"
     if opts[:id]
       convert_work(opts[:id])
     elsif opts[:file]
       convert_from_file(opts[:file])
+    elsif opts[:lists]
+      create_lists
     else
       convert_class
     end
     end_time = Time.now
     elapsed_time = end_time - start_time
-    @logger.info "Finished conversion process at #{end_time}"
-    @logger.info "Elapsed time: #{elapsed_time}"
+    logger.info "Finished conversion process at #{end_time}"
+    logger.info "Elapsed time: #{elapsed_time}"
   end
 
   private
 
+    # Get a list of all of the objects of type @work_class from solr
+    # return [Array]
+    def all_objects
+      @all_objects ||= ActiveFedora::SolrService.query("has_model_ssim:#{@work_class}", fl: 'id', rows: 1000000).map(&:id)
+    end
+
+    # Create lists of PIDs for conversion, so that we can break the full export
+    # down into smaller pieces
+    # @return [Array] an array of the files that were created
+    def create_lists
+      pid_files_dir = Rails.root.join('tmp', 'external_files_conversion', timestamp)
+      FileUtils.mkdir_p pid_files_dir
+      lists_of_pids = all_objects.each_slice(NUMBER_OF_PIDS_PER_FILE).to_a
+      lists_of_pids.each_with_index do |list, index|
+        file_path = "#{pid_files_dir}/#{index}.txt"
+        File.open(file_path, 'w') { |file| file.puts(list) }
+        pid_lists << file_path
+      end
+    end
+
+    # Convert all works of a given work type
+    # Do this by first creating lists of the pids to work from, then running
+    # each of these individually, so we don't run out of memory. Pause between
+    # files.
     def convert_class
-      all_objects = ActiveFedora::SolrService.query("has_model_ssim:#{@work_class}", fl: 'id', rows: 1000000).map(&:id)
-      all_objects_count = all_objects.count
-      @logger.info "Converting #{all_objects_count} objects of type #{@work_class}"
-      all_objects.each do |work_id|
-        convert_work(work_id)
+      logger.info "Converting #{all_objects.count} objects of type #{@work_class}"
+      create_lists
+      pid_lists.each do |list|
+        convert_from_file(list)
+        sleep 10.minutes if Rails.env.production?
       end
     end
 
     def convert_from_file(file)
-      @logger.error "Unable to find file #{file}" unless File.exists?(file)
+      logger.error "Unable to find file #{file}" unless File.exists?(file)
       work_array = File.readlines(file).each(&:chomp!)
-      @logger.info "Converting contents of file #{file}"
-      @logger.info "Converting #{work_array.count} objects of type #{@work_class}"
+      logger.info "Converting contents of file #{file}"
+      logger.info "Converting #{work_array.count} objects of type #{@work_class}"
       work_array.each do |work_id|
         convert_work(work_id)
       end
@@ -56,20 +89,35 @@ class ExternalFilesConversion
 
     # param [String] work_id the id of the work to convert
     def convert_work(work_id)
-      @logger.info "Starting to convert work #{work_id}"
+      logger.info "Starting to convert work #{work_id}"
       begin
         work = ActiveFedora::Base.find(work_id)
+        if already_converted?(work)
+          logger.info "#{work_id} was previously converted"
+          return true
+        end
         work.file_sets.each do |file_set|
           file_set.files.each do |file|
             convert_file(work, file_set, file)
           end
         end
+        logger.info "Finished converting work #{work_id}"
       rescue ActiveFedora::ObjectNotFoundError => error
-        @logger.error "error finding object to migrate: #{work_id}; #{error}"
+        logger.error "error finding object to migrate: #{work_id}; #{error}"
+        File.open(@error_file, 'a') { |e| e.puts(work_id) }
       rescue StandardError => error
-        @logger.error "error migrating object: #{work_id}; #{error}"
+        logger.error "error migrating object: #{work_id}; #{error}"
+        File.open(@error_file, 'a') { |e| e.puts(work_id) }
       end
-      @logger.info "Finished converting work #{work_id}"
+    end
+
+    # Test whether a given work_id has already been converted to
+    # external file storage
+    # @param [ActiveFedora::Base] work
+    # @return [Boolean]
+    def already_converted?(work)
+      response = Net::HTTP.get_response(URI(work.file_sets.first.files.first.uri.to_s))
+      response.to_s =~ /HTTPTemporaryRedirect/
     end
 
     def convert_file(work, file_set, file)
@@ -88,7 +136,12 @@ class ExternalFilesConversion
           IngestFileJob.perform_now(file_set, version_content, @user)
         end
       end
-      ActiveFedora.fedora.connection.delete(file.uri + '/fcr:versions/auto_placeholder')
+      # Try to delete the auto_placeholder snapshot, but if it is the only version snapshot
+      # it will raise an error. Ignore these.
+      begin
+        ActiveFedora.fedora.connection.delete(file.uri + '/fcr:versions/auto_placeholder')
+      rescue StandardError
+      end
     end
 
     def write_version_content(version_uri)

--- a/lib/tasks/external_files.rake
+++ b/lib/tasks/external_files.rake
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+namespace :scholarsphere do
+  namespace :external_files do
+    # adding a logger since it got removed from our gemset
+    def logger
+      Rails.logger
+    end
+
+    desc 'Create lists of pids to convert'
+    task 'create_lists' => :environment do
+      converter = ExternalFilesConversion.new(GenericWork)
+      converter.convert(lists: true)
+      puts 'Created the following files:'
+      converter.pid_lists.each do |file|
+        puts file
+      end
+    end
+
+    desc 'Convert files stored internally in Fedora to externally on the filesystem'
+    task 'internal_to_external_files' => :environment do
+      unless ENV['REPOSITORY_EXTERNAL_FILES'] == 'true'
+        puts 'You must set the REPOSITORY_EXTERNAL_FILES environment variable to true'
+        puts 'before running this task'
+        exit
+      end
+      puts 'This task will create a new version of all the works.'
+      puts "The process will place the content in the #{ENV['REPOSITORY_FILESTORE']} directory."
+      puts 'Are you sure you want to do this? (y/n)'
+
+      if STDIN.gets.strip == 'y'
+        ExternalFilesConversion.new(GenericWork).convert
+      else
+        puts 'You didn\'t reply with (y) so this rake task is exiting'
+      end
+    end
+  end
+end

--- a/lib/tasks/scholarsphere.rake
+++ b/lib/tasks/scholarsphere.rake
@@ -221,22 +221,4 @@ namespace :scholarsphere do
     result = work.save
     puts "Work #{work_id} marked as private: #{result}"
   end
-
-  desc 'Convert files stored internally in Fedora to externally on the filesystem'
-  task 'internal_to_external_files' => :environment do
-    unless ENV['REPOSITORY_EXTERNAL_FILES'] == 'true'
-      puts 'You must set the REPOSITORY_EXTERNAL_FILES environment variable to true'
-      puts 'before running this task'
-      exit
-    end
-    puts 'This task will create a new version of all the works.'
-    puts "The process will place the content in the #{ENV['REPOSITORY_FILESTORE']} directory."
-    puts 'Are you sure you want to do this? (y/n)'
-
-    if STDIN.gets.strip == 'y'
-      ExternalFilesConversion.new(GenericWork).convert
-    else
-      puts 'You didn\'t reply with (y) so this rake task is exiting'
-    end
-  end
 end


### PR DESCRIPTION
* Use a default value for migration log
* Split list of pids into files
* Convert all works using files
* Write error PIDs to an error file

Connected to #1369 
Connected to #1340 
Connected to #1302 