### PR TITLE
refactoring tests

### DIFF
--- a/app/controllers/curation_concerns/generic_works_controller.rb
+++ b/app/controllers/curation_concerns/generic_works_controller.rb
@@ -106,4 +106,11 @@ class CurationConcerns::GenericWorksController < ApplicationController
     def doi_service
       @doi_service ||= DOIService.new
     end
+
+    def default_trail
+      if user_signed_in?
+        add_breadcrumb I18n.t('sufia.dashboard.title'), sufia.dashboard_index_path
+        add_breadcrumb I18n.t('sufia.dashboard.my.works'), sufia.dashboard_works_path
+      end
+    end
 end

--- a/spec/features/dashboard/dashboard_collections_spec.rb
+++ b/spec/features/dashboard/dashboard_collections_spec.rb
@@ -17,35 +17,38 @@ describe 'Dashboard Collections:', type: :feature do
     go_to_dashboard_collections
   end
 
-  specify 'tab title and buttons' do
+  it 'checks the page' do
+    # tab title and buttons
     expect(page).to have_content('My Collections')
     expect(page).not_to have_content('Object Type')
     expect(page).to have_link('New Work', visible: false) # link is there (even if collapsed)
     expect(page).to have_link('New Collection', visible: false) # link is there (even if collapsed)
     expect(page).not_to have_selector(".batch-toggle input[value='Delete Selected']")
-  end
 
-  specify 'collections are displayed in the Collections list' do
+    # collections are displayed in the Collections list
     expect(page).to have_content collection.title.first
     expect(page).not_to have_content jill_collection.title
-  end
 
-  specify 'toggle displays additional information' do
+    # displays the correct totals for each facet
+    within('#facets') do
+      click_link('Creator')
+      expect(page).to have_content('Given Name Sur Name')
+    end
+
+    # additional information is hidden by default
+    expect(page).not_to have_content(creator.display_name)
+    expect(page).not_to have_content(collection.depositor)
+    expect(page).not_to have_content 'Edit Access'
+    expect(page).not_to have_content(current_user)
+
+    # toggle displays additional information
     first('span.glyphicon-chevron-right').click
     expect(page).to have_content(creator.display_name)
     expect(page).to have_content(collection.depositor)
     expect(page).to have_content 'Edit Access'
     expect(page).to have_content(current_user)
-  end
 
-  specify 'additional information is hidden' do
-    expect(page).not_to have_content(creator.display_name)
-    expect(page).not_to have_content(collection.depositor)
-    expect(page).not_to have_content 'Edit Access'
-    expect(page).not_to have_content(current_user)
-  end
-
-  specify 'toggle addtitional actions' do
+    # toggle additional actions
     expect(page).not_to have_content('Edit Collection')
     expect(page).not_to have_content('Delete Collection')
     within('#documents') do
@@ -53,19 +56,9 @@ describe 'Dashboard Collections:', type: :feature do
     end
     expect(page).to have_content('Edit Collection')
     expect(page).to have_content('Delete Collection')
-  end
 
-  specify 'collections are not displayed in the Works list' do
+    # collections are not displayed in the Works list
     go_to_dashboard_works
     expect(page).not_to have_content collection.title
-  end
-
-  describe 'facets,' do
-    specify 'displays the correct totals for each facet' do
-      within('#facets') do
-        click_link('Creator')
-        expect(page).to have_content('Given Name Sur Name')
-      end
-    end
   end
 end

--- a/spec/features/generic_work/view_and_download_spec.rb
+++ b/spec/features/generic_work/view_and_download_spec.rb
@@ -11,21 +11,14 @@ describe GenericWork, type: :feature do
     before { sign_in_with_js(current_user) }
 
     context 'with a public work' do
-      let!(:work1) do
+      let(:work1) do
         create(:public_work, :with_one_file_and_size, :with_complete_metadata,
                depositor: current_user.login,
                description: ['Description http://example.org/TheDescriptionLink/'])
       end
 
-      specify 'I can see all the correct information' do
-        visit(root_path)
-
-        # Work is listed under Recently Uploaded
-        click_link('Recent Additions')
-        within('#recent_docs') do
-          expect(page).to have_link(work1.keyword.first)
-          click_link(work1.title.first)
-        end
+      it 'displays all the correct information' do
+        visit(curation_concerns_generic_work_path(work1))
 
         # View the work's show page
         expect(page).to have_content work1.title.first
@@ -70,25 +63,20 @@ describe GenericWork, type: :feature do
         within('div.show-download') do
           expect(page).to have_content('Download Work as Zip')
         end
-      end
 
-      describe 'external services' do
-        before { visit(curation_concerns_generic_work_path(work1)) }
+        # I can download an Endnote reference do
+        click_link 'EndNote'
+        expect(page.response_headers['Content-Type']).to eq('application/x-endnote-refer')
+        go_back
 
-        specify 'I can download an Endnote reference' do
-          visit(find_link('EndNote')[:href])
-          expect(page.response_headers['Content-Type']).to eq('application/x-endnote-refer')
-        end
+        # I can see the Mendeley modal
+        click_link 'Mendeley'
+        expect(page).to have_css('.modal-header')
+        go_back
 
-        specify 'I can see the Mendeley modal' do
-          click_link 'Mendeley'
-          expect(page).to have_css('.modal-header')
-        end
-
-        specify 'I can see the Zotero modal' do
-          click_link 'Zotero'
-          expect(page).to have_css('.modal-header')
-        end
+        # I can see the Zotero modal
+        click_link 'Zotero'
+        expect(page).to have_css('.modal-header')
       end
     end
 

--- a/spec/features/recent_additions_spec.rb
+++ b/spec/features/recent_additions_spec.rb
@@ -10,8 +10,8 @@ describe 'Showing recent additions', type: :feature do
     sign_in_with_js(current_user)
     visit '/'
     click_link 'Recent Additions'
-    expect(page).to have_content(gf.title.first)
+    expect(page).to have_selector('h3', gf.title.first)
     click_link(gf.keyword.first)
-    expect(page).to have_content(gf.title.first)
+    expect(page).to have_selector('h1', gf.title.first)
   end
 end


### PR DESCRIPTION
Refactoring feature tests to not use as many specify blocks
Adding My Works to the default breadcrub
Removing redundant sections of the test

Co-authored-by: Mike Tribone <mtribone@psu.edu>
Co-authored-by: Adam Wead <amsterdamos@gmail.com>
Co-authored-by: Joni Barnoff <jxb13@psu.edu>