### PR TITLE
Write external files efficiently

### DIFF
--- a/app/services/external_files_conversion.rb
+++ b/app/services/external_files_conversion.rb
@@ -150,7 +150,7 @@ class ExternalFilesConversion
       FileUtils.mkdir_p(Rails.root.join('tmp', 'external_internal_conversion', time_stamp))
 
       file = File.new(Rails.root.join('tmp', 'external_internal_conversion', time_stamp, version_file_name), 'wb+')
-      file.write open(version_uri).read
+      open(version_uri) { |f| f.each_line { |line| file.write(line) } }
       file_path = File.absolute_path(file.path)
       file.close
       file_path


### PR DESCRIPTION
This commit changes the way that files
are written to the external files repo folder
so that the writes happen line by line instead
of loading the entire file into memory.