### PR TITLE
Fix timestamp format

### DIFF
--- a/app/services/external_files_conversion.rb
+++ b/app/services/external_files_conversion.rb
@@ -17,7 +17,7 @@ class ExternalFilesConversion
   end
 
   def timestamp
-    @timestamp ||= Time.now.strftime('%Y-%m-%e-%H-%M-%S')
+    @timestamp ||= Time.now.strftime('%Y-%m-%d-%H-%M-%S')
   end
 
   # If we receive a work ID, only convert that one item


### PR DESCRIPTION
We don't want spaces in our filenames so use a timestamp
format that adds a leading zero to days.