### PR TITLE
Check that checksums remain the same during conversion

### DIFF
--- a/app/services/checksummer.rb
+++ b/app/services/checksummer.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'digest'
+
+class Checksummer
+  # This class returns an array of all the checksums for all the files
+  # (and their versions) in a work.
+  # @param work [ActiveFedora::Base]
+  def initialize(work)
+    @work = work
+  end
+
+  # @return [Array] an array of checksums from the FixityService
+  def fedora_checksums
+    checksums = []
+    @work.file_sets.each do |file_set|
+      file_set.files.each do |file|
+        file.versions.all.each do |version|
+          checksums << ActiveFedora::FixityService.new(version.uri).expected_message_digest.gsub('urn:sha1:', '')
+        end
+      end
+    end
+    checksums
+  end
+
+  # @return [Array] an array of checksums generated from the files on disk
+  def disk_checksums
+    checksums = []
+    @work.file_sets.each do |file_set|
+      file_set.files.each do |file|
+        file.versions.all.each do
+          sha1 = Digest::SHA1.new
+          open(file_set.original_file.uri,
+               http_basic_authentication: [ActiveFedora.fedora_config.credentials['user'],
+                                           ActiveFedora.fedora_config.credentials['password']],
+               allow_redirections: :all) { |f| f.each_line { |line| sha1.update line } }
+          checksums << sha1.hexdigest
+        end
+      end
+    end
+    checksums
+  end
+end

--- a/spec/services/checksummer_spec.rb
+++ b/spec/services/checksummer_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Checksummer do
+  let(:user) { create(:user) }
+  let(:work) { create(:public_work_with_pdf, depositor: user.login) }
+  let(:checksummer_with_work) { described_class.new(work) }
+  let(:fedora_sha1_without_urn) { ['ad13c5e7cc6d8198f25e003bd2965b3544e52a32'] }
+
+  before do
+    allow(CharacterizeJob).to receive(:perform_later)
+  end
+
+  it 'can return the fedora derived checksum for the work' do
+    if ENV['REPOSITORY_EXTERNAL_FILES'] = 'false'
+      expect(checksummer_with_work.fedora_checksums).to eq(fedora_sha1_without_urn)
+    end
+  end
+
+  it 'can return the checksum for works stored as external files' do
+    if ENV['REPOSITORY_EXTERNAL_FILES'] = 'true'
+      expect(checksummer_with_work.disk_checksums).to eq(fedora_sha1_without_urn)
+    end
+  end
+end


### PR DESCRIPTION
This adds a class that when given a work, returns an
array with all the checksums for all versions of the files
in that work. This is used in the conversion class
before the conversion and after the conversion.

If these checksums don't match, an error is logged.