### PR TITLE
Do not raise an error if the auto_placeholder version already exists

### DIFF
--- a/app/services/external_files_conversion.rb
+++ b/app/services/external_files_conversion.rb
@@ -122,7 +122,11 @@ class ExternalFilesConversion
 
     def convert_file(work, file_set, file)
       # This slug must be prefixed with auto_ so that it will not appear in versions.all
-      ActiveFedora.fedora.connection.post(file.uri + '/fcr:versions', nil, slug: 'auto_placeholder')
+      begin
+        ActiveFedora.fedora.connection.post(file.uri + '/fcr:versions', nil, slug: 'auto_placeholder')
+      rescue Ldp::Conflict
+        logger.warn "Work #{work.id} already had a version called 'auto_placeholder'. Perhaps it was previously converted?"
+      end
       version_contents = []
       file.versions.all.each do |version|
         version_content = write_version_content(version.uri)

--- a/spec/services/external_files_conversion_spec.rb
+++ b/spec/services/external_files_conversion_spec.rb
@@ -40,6 +40,19 @@ describe ExternalFilesConversion do
       expect(file_set.original_file.original_name).to eq('world.png')
       expect(response.to_s).to match(/HTTPTemporaryRedirect/)
     end
+    it 'will not raise an error if it already has an auto_placeholder version' do
+      ENV['REPOSITORY_EXTERNAL_FILES'] = 'false'
+      file_set
+      response = Net::HTTP.get_response(URI(file_set.files.first.uri.to_s))
+      expect(response.to_s).to match(/OK/)
+      ENV['REPOSITORY_EXTERNAL_FILES'] = 'true'
+      ActiveFedora.fedora.connection.post(file_set.files.first.uri + '/fcr:versions', nil, slug: 'auto_placeholder')
+      single_work_conversion
+      response = Net::HTTP.get_response(URI(file_set.files.first.uri.to_s))
+      expect(response['content-disposition']).to match(/world.png/)
+      expect(file_set.original_file.original_name).to eq('world.png')
+      expect(response.to_s).to match(/HTTPTemporaryRedirect/)
+    end
     context 'running from a file' do
       let(:work1) { create(:public_work_with_png, depositor: user.login) }
       let(:file_set1) { work1.file_sets.first }


### PR DESCRIPTION
It might be leftover from a previous migration attempt.
The real check for whether something has already been
migrated is whether it has externally stored files.

Fixes #1387 