### PR TITLE
Changing remote content to just access the disk instead of fedora

### DIFF
--- a/app/indexers/work_indexer.rb
+++ b/app/indexers/work_indexer.rb
@@ -52,7 +52,7 @@ class WorkIndexer < Sufia::WorkIndexer
         retrieved_content = case file.original_file.content
                             when String
                               file.original_file.content
-                            when StringIO
+                            when StringIO, File
                               file.original_file.content.read
                             end
         EncodingService.call(retrieved_content)

--- a/app/services/external_files_conversion.rb
+++ b/app/services/external_files_conversion.rb
@@ -128,7 +128,7 @@ class ExternalFilesConversion
       begin
         work = ActiveFedora::Base.find(work_id)
         if already_converted?(work)
-          puts 'converted qlready'
+          puts 'converted already'
           logger.info "#{work_id} was previously converted"
           return true
         end
@@ -144,7 +144,7 @@ class ExternalFilesConversion
         logger.error "error finding object to migrate: #{work_id}; #{error}"
         File.open(@error_file, 'a') { |e| e.puts(work_id) }
       rescue StandardError => error
-        logger.error "error migrating object: #{work_id}; #{error}"
+        logger.error "error migrating object: #{work_id}; #{error.inspect}"
         logger.error error.backtrace
 
         File.open(@error_file, 'a') { |e| e.puts(work_id) }
@@ -158,6 +158,7 @@ class ExternalFilesConversion
     def already_converted?(work)
       file_set = work.file_sets.reject { |fs| fs.original_file.blank? }.first
       return true if file_set.blank?
+
       ldp_response = ActiveFedora.fedora.connection.head(file_set.original_file.uri.to_s)
       ldp_response.response.status == 307 # Temporary Redirect
     end
@@ -281,7 +282,7 @@ class ExternalFilesConversion
           begin
             tries += 1
             file_set.reload
-            IngestFileJob.perform_now(file_set, version_content, @user)
+            IngestFileJob.perform_now(file_set, version_content, @user, skip_virus_scan: true)
             status = true
           rescue StandardError => error
             if error.message == '404 Not Found'

--- a/spec/jobs/ingest_file_job_spec.rb
+++ b/spec/jobs/ingest_file_job_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 require 'fileutils'
 
 describe IngestFileJob do
-  context 'when adding a new version', unless: external_files? do
+  context 'when adding a new version' do
     let(:user)     { create(:user) }
     let(:file_set) { create(:file_set, :with_png, depositor: user.login) }
     let(:filepath) { File.join(fixture_path, 'world.png') }
@@ -39,8 +39,11 @@ describe IngestFileJob do
     end
 
     it 'redirects to the url of the binary payload' do
-      response = Net::HTTP.get_response(URI(file_set.files.first.uri.to_s))
-      expect(response.to_s).to match(/HTTPTemporaryRedirect/)
+      uri = file_set.files.first.uri
+      Net::HTTP.start(uri.host, uri.port) { |http|
+        response = http.head(uri.path)
+        expect(response.to_s).to match(/HTTPTemporaryRedirect/)
+      }
     end
 
     it 'checks to make sure that the file_set content is a PNG' do

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -71,9 +71,7 @@ describe FileSet, type: :model do
 
   describe '#destroy' do
     let(:file) { create(:file_set, :with_original_file) }
-    let(:original_file_url) { file.original_file.file_url }
-    let(:pair_tree) { Scholarsphere::Pairtree.new(file, nil) }
-    let(:file_path) { pair_tree.storage_path(original_file_url) }
+    let(:file_path) { file.original_file.file_path }
 
     it 'deletes the external file' do
       Hydra::PCDM::File


### PR DESCRIPTION
Since we know where the data lives on disk, why ask fedora for it, just return the server copy