### PR TITLE
Convenience rake tasks for starting/stopping filestore

### DIFF
--- a/tasks/dev.rake
+++ b/tasks/dev.rake
@@ -27,6 +27,22 @@ namespace :solr do
   end
 end
 
+namespace :filestore do
+  desc 'Starts up the server for the remote file store'
+  task start: :environment do
+    system(
+      "cd #{Rails.root.join('public')} && "\
+      "python -m SimpleHTTPServer #{URI(ENV['REPOSITORY_FILESTORE_HOST']).port} &> "\
+      "../log/filestore_#{Rails.env.downcase}.log &"
+    )
+  end
+
+  desc 'Stops all instances of the remote file store'
+  task stop: :environment do
+    system("ps -ax | grep SimpleHTTPServer | awk '{print $1}' | xargs kill -s KILL &> /dev/null")
+  end
+end
+
 namespace :dev do
   desc "Cleans out everything. Everything. Don't try this at home."
   task clean: :environment do


### PR DESCRIPTION
# Description

Rake tasks that start and stop the Python HTTP server that's used for serving out remotely-stored files.

# Examples

    bundle exec rake filestore:start
    bundle exec rake filestore:stop

Writes any output to `log/filestore_development.log`. You can also start a separate server for test:

    bundle exec rake filestore:start RAILS_ENV=test

However, you don't have to, and if you specify the same port in the REPOSITORY_FILESTORE_HOST of your `application.yml`, then you'll only need one server running. Results for both development and test processes will be written to the same log file.