### PR TITLE
Do Not Merge: Updating Fedora wrappers to 4.7.5: Waiting for next sprint 

### DIFF
--- a/.fcrepo_wrapper
+++ b/.fcrepo_wrapper
@@ -2,4 +2,4 @@
 port: 8984
 enable_jms: false
 fcrepo_home_dir: tmp/fcrepo4-development-data
-version: 4.7.1
+version: 4.7.5

--- a/config/fcrepo_wrapper_test.yml
+++ b/config/fcrepo_wrapper_test.yml
@@ -2,4 +2,4 @@
 port: 8986
 enable_jms: false
 fcrepo_home_dir: tmp/fcrepo4-test-data
-version: 4.7.1
+version: 4.7.5

--- a/config/travis/fcrepo_wrapper_test.yml
+++ b/config/travis/fcrepo_wrapper_test.yml
@@ -3,3 +3,4 @@ port: 8986
 enable_jms: false
 fcrepo_home_dir: fcrepo4-test-data
 download_dir: dep_cache
+version: 4.7.5


### PR DESCRIPTION
Connected to #1269 

This updates all the instances of `fcrepo_wrapper` to use the 4.7.5 version of Fedora. Additional code changes or configuration settings required to complete this process will be added to the ticket.