### PR TITLE
Clean out filestore before the test suite

### DIFF
--- a/config/sample/application.yml
+++ b/config/sample/application.yml
@@ -18,7 +18,7 @@ development:
   backup_directory: 'backups'
   ldap_unwilling_sleep: "2"
   REPOSITORY_FILESTORE: <%= Rails.root.join('public', 'repository').to_s %>
-  REPOSITORY_FILESTORE_HOST: 'http://localhost:8000/repository'
+  REPOSITORY_FILESTORE_HOST: 'http://localhost:8000/dev_repository'
   REPOSITORY_MIGRATION_LOG: <%= Rails.root.join('log', "dev_migration.log").to_s %>
   REPOSITORY_EXTERNAL_FILES: 'true'
   timing_enabled: 'false'
@@ -34,7 +34,7 @@ test:
   backup_directory: 'backups_test'
   ldap_unwilling_sleep: "0"
   REPOSITORY_FILESTORE:  <%= Rails.root.join('public', 'repository').to_s %>
-  REPOSITORY_FILESTORE_HOST: 'http://localhost:4000/repository'
+  REPOSITORY_FILESTORE_HOST: 'http://localhost:8000/test_repository'
   REPOSITORY_MIGRATION_LOG: <%= Rails.root.join('log', "test_migration.log").to_s %>
   REPOSITORY_EXTERNAL_FILES: 'true'
   timing_enabled: 'false'

--- a/spec/support/cleanup.rb
+++ b/spec/support/cleanup.rb
@@ -14,6 +14,8 @@ RSpec.configure do |config|
   config.before :suite do
     DatabaseCleaner.clean_with(:truncation)
     ActiveFedora::Cleaner.clean!
+    FileUtils.rm_rf(ENV['REPOSITORY_FILESTORE'])
+    FileUtils.mkdir_p(ENV['REPOSITORY_FILESTORE'])
   end
 
   # Only clean Fedora and Solr unless explicitly requested
@@ -21,6 +23,8 @@ RSpec.configure do |config|
     if example.metadata.fetch(:clean, nil)
       ActiveFedora::Cleaner.clean!
       DatabaseCleaner.clean_with(:truncation)
+      FileUtils.rm_rf(ENV['REPOSITORY_FILESTORE'])
+      FileUtils.mkdir_p(ENV['REPOSITORY_FILESTORE'])
     end
   end
 

--- a/tasks/dev.rake
+++ b/tasks/dev.rake
@@ -33,7 +33,7 @@ namespace :filestore do
     system(
       "cd #{Rails.root.join('public')} && "\
       "python -m SimpleHTTPServer #{URI(ENV['REPOSITORY_FILESTORE_HOST']).port} &> "\
-      "../log/filestore_#{Rails.env.downcase}.log &"
+      '../log/filestore.log &'
     )
   end
 


### PR DESCRIPTION
To align with our other procedures in Solr and Fedora, the external file store will be cleaned out prior to running the test suite.

This also clears up some confusion with the test vs. dev. configuration of the HTTP process. We're assuming that there is one HTTP process for serving out the files for the filestore for either the test or development environment. There are different directory names for the files to be stored, but only one process is required to serve out those files and the log file will not be tied to the environment.