### PR TITLE
Updating debugging gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,7 @@ group :development, :test do
   gem 'coveralls', require: false
   gem 'faker'
   gem 'fcrepo_wrapper'
+  gem 'launchy'
   gem 'niftany'
   gem 'pry'
   gem 'pry-byebug'
@@ -67,7 +68,7 @@ group :development, :test do
 end
 
 group :development do
-  gem 'better_errors'
+  gem 'better_errors', '~> 2.4.0'
   gem 'binding_of_caller'
 
   # Use Capistrano for deployment
@@ -92,9 +93,4 @@ group :test do
   gem 'selenium-webdriver'
   gem 'vcr'
   gem 'webmock'
-end
-
-group :debug do
-  gem 'byebug', require: false
-  gem 'launchy'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,9 +95,9 @@ GEM
       docopt (~> 0.5.0)
       validatable (~> 1.6)
     bcrypt (3.1.11)
-    better_errors (2.1.1)
+    better_errors (2.4.0)
       coderay (>= 1.0.0)
-      erubis (>= 2.6.6)
+      erubi (>= 1.0.0)
       rack (>= 0.9.0)
     better_html (1.0.11)
       actionview (>= 4.0)
@@ -107,7 +107,7 @@ GEM
       html_tokenizer (~> 0.0.6)
       parser (>= 2.4)
       smart_properties
-    binding_of_caller (0.7.2)
+    binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
     blacklight (6.9.0)
       bootstrap-sass (~> 3.2)
@@ -151,7 +151,7 @@ GEM
       sass-rails
       signet
     builder (3.2.3)
-    byebug (9.0.6)
+    byebug (10.0.2)
     cancancan (1.17.0)
     capistrano (3.8.0)
       airbrussh (>= 1.0.0)
@@ -196,7 +196,7 @@ GEM
     clamav (0.4.1)
     clipboard-rails (1.7.1)
     cliver (0.3.2)
-    coderay (1.1.1)
+    coderay (1.1.2)
     coffee-rails (4.2.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.2.x)
@@ -246,7 +246,7 @@ GEM
       sprockets-es6
     daemons (1.2.6)
     database_cleaner (1.5.3)
-    debug_inspector (0.0.2)
+    debug_inspector (0.0.3)
     declarative (0.0.10)
     declarative-option (0.1.0)
     deprecation (1.0.0)
@@ -487,7 +487,7 @@ GEM
       carrierwave (>= 0.5.8)
       rails (>= 4.2.0)
     memoist (0.16.0)
-    method_source (0.9.0)
+    method_source (0.9.1)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
@@ -548,11 +548,11 @@ GEM
     posix-spawn (0.3.13)
     power_converter (0.1.2)
     powerpack (0.1.2)
-    pry (0.11.3)
+    pry (0.12.0)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    pry-byebug (3.4.3)
-      byebug (>= 9.0, < 9.1)
+    pry-byebug (3.6.0)
+      byebug (~> 10.0)
       pry (~> 0.10)
     psu_dir (0.2.0)
       hydra-ldap
@@ -569,7 +569,7 @@ GEM
       faraday
       nokogiri (~> 1.6)
       rails (>= 4.2.0, < 6.0)
-    rack (1.6.10)
+    rack (1.6.11)
     rack-maintenance (2.0.1)
       rack (>= 1.0)
     rack-protection (1.5.5)
@@ -893,11 +893,10 @@ PLATFORMS
 DEPENDENCIES
   active-fedora (~> 11.5)
   bagit (~> 0.4.2)
-  better_errors
+  better_errors (~> 2.4.0)
   binding_of_caller
   blacklight_advanced_search (~> 6.0)
   bootsnap
-  byebug
   capistrano (~> 3.7)
   capistrano-bundler (~> 1.2)
   capistrano-passenger


### PR DESCRIPTION
Updates pry, pry-byebug, better errors, and binding of caller, which are used when debugging work in development and test modes.