### PR TITLE
Analyze and report on line-by-line test coverage

### DIFF
--- a/spec/support/line_usage.rb
+++ b/spec/support/line_usage.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# @note Prints to a log, and optionally STDOUT, when a particular line is hit during a test.
+#
+# @example To register a line, add:
+#   LineUsage.register(name: self, caller: __method__)
+#
+# @exmaple To write STDOUT as well as the log:
+#   LineUsage.register(name: self, caller: __method__, write_out: true)
+class LineUsage
+  cattr_accessor :current_test
+
+  class << self
+    def register(name:, caller:, write_out: false)
+      usage_log.info("#{current_test} #{name.class}##{caller}")
+      puts "#{current_test} #{name.class}##{caller}" if write_out
+    end
+
+    private
+
+      def usage_log
+        @usage_log ||= Logger.new(File.open(Rails.root.join('log', 'line_usage.log'), 'w'))
+      end
+  end
+end
+
+RSpec.configure do |config|
+  config.before(:suite) do
+    FileUtils.rm_rf(Rails.root.join('log', 'line_usage.log'))
+  end
+
+  config.before do
+    LineUsage.current_test = self.class.to_s
+  end
+end

--- a/tasks/dev.rake
+++ b/tasks/dev.rake
@@ -69,3 +69,23 @@ namespace :dev do
     Logger.new(STDOUT).warn "WARNING -- Redis might be down: #{e}"
   end
 end
+
+namespace :coveralls do
+  desc 'Report line count statistics from Coveralls'
+  task line_report: :environment do
+    report = Rails.root.join('coverage/.resultset.json')
+    unless report.exist?
+      raise ArgumentError, 'No coveralls report found. Run `bundle exec coveralls report` to generate'
+    end
+
+    results = JSON.parse(File.read(report))
+
+    CSV.open(Rails.root.join('coverage/line_report.csv'), 'w') do |csv|
+      csv << ['Test', 'Max', 'Average']
+      results['spec']['coverage'].each do |key, values|
+        values.compact!
+        csv << [Pathname.new(key).basename, values.max, (values.sum / values.length)]
+      end
+    end
+  end
+end


### PR DESCRIPTION
This was some analysis code I wrote to determine which files had the most hits per line. It requires you to run the test suite locally using Coveralls to generate the report. The information can also be found in the build for Coveralls, but sometimes that data is misleading because of our split builds.

The rake task produces a CSV report detailing average and maximum hits per line for each RSpec test file.

Additionally, the is a `LineUsage` class for logging when a particular line it "hit" during a test, and noting which RSpec test is running and which method it is accessing. This is useful for determining which RSpec test might be over-testing a particular line.

I'm not sure how useful any of this is, so comments and questions are welcome.

Connected to #1444 