### PR TITLE
Refactor collection feature tests

### DIFF
--- a/spec/features/collection/edit_spec.rb
+++ b/spec/features/collection/edit_spec.rb
@@ -9,103 +9,125 @@ describe Collection, type: :feature, js: true do
   let(:work1)        { create(:work, depositor: current_user.login, title: ['world.png']) }
   let(:work2)        { create(:work, depositor: current_user.login, title: ['little_file.txt']) }
 
-  context 'when the collection has files' do
-    let!(:collection) { create(:collection, depositor: current_user.login, members: [work1, work2], description: ['my description']) }
-    let!(:work3)      { create(:work, title: ['scholarsphere_test5.txt'], depositor: current_user.login) }
+  context 'when removing works' do
+    let!(:collection) do
+      create(:collection,
+        depositor: current_user.login,
+        members: [work1, work2],
+        description: ['my description'])
+    end
 
     before { login_as(current_user) }
 
-    describe 'adding an additional file' do
-      specify do
-        visit '/dashboard/works'
-        db_file_checkbox(work3).click
-        click_button 'Add to Collection'
-        db_collection_radio_button(collection).click
-        within('#collection-list-container .modal-footer') do
-          click_button 'Add to Collection'
-        end
-        expect(page).to have_content 'Collection was successfully updated.'
-        expect(page).to have_content work3.title.first
-      end
+    it 'removes a single work' do
+      visit '/dashboard/collections'
+      db_item_actions_toggle(collection).click
+      click_link 'Edit Collection'
+      expect(page).to have_content work1.title.first
+      expect(page).to have_content work2.title.first
+      db_item_actions_toggle(work1).click
+      click_button 'Remove from Collection'
+      expect(page).to have_content collection.title.first
+      expect(page).to have_content collection.description.first
+      expect(page).not_to have_content work1.title.first
+      expect(page).to have_content work2.title.first
     end
-    describe 'removing a work' do
-      specify do
-        visit '/dashboard/collections'
-        db_item_actions_toggle(collection).click
-        click_link 'Edit Collection'
-        expect(page).to have_content work1.title.first
-        expect(page).to have_content work2.title.first
-        db_item_actions_toggle(work1).click
-        click_button 'Remove from Collection'
-        expect(page).to have_content collection.title.first
-        expect(page).to have_content collection.description.first
-        expect(page).not_to have_content work1.title.first
-        expect(page).to have_content work2.title.first
-      end
-    end
-    describe 'removing all works' do
-      specify do
-        visit '/dashboard/collections'
-        db_item_actions_toggle(collection).click
-        click_link 'Edit Collection'
-        expect(page).to have_content "Edit Collection: #{collection.title.first}"
-        expect(page).to have_content work1.title.first
-        expect(page).to have_content work2.title.first
-        check 'check_all'
-        click_button 'Remove From Collection'
-        expect(page).to have_content collection.title.first
-        expect(page).to have_content collection.description.first
-        expect(page).not_to have_content work1.title.first
-        expect(page).not_to have_content work2.title.first
-      end
+
+    it 'removes all the works' do
+      visit '/dashboard/collections'
+      db_item_actions_toggle(collection).click
+      click_link 'Edit Collection'
+      expect(page).to have_content "Edit Collection: #{collection.title.first}"
+      expect(page).to have_content work1.title.first
+      expect(page).to have_content work2.title.first
+      check 'check_all'
+      click_button 'Remove From Collection'
+      expect(page).to have_content collection.title.first
+      expect(page).to have_content collection.description.first
+      expect(page).not_to have_content work1.title.first
+      expect(page).not_to have_content work2.title.first
     end
   end
 
-  describe "editing a collection's edit groups" do
-    let!(:collection)           { create(:collection, depositor: current_user.login, subtitle: 'Vimana', description: ['original description']) }
-    let!(:original_title)       { collection.title }
-    let!(:original_subtitle)    { collection.subtitle }
-    let!(:original_description) { collection.description }
-
-    let(:updated_title)         { 'Updated Title' }
-    let(:updated_subtitle)      { 'Updated Vimana2' }
-    let(:updated_description)   { 'Updated description text.' }
+  context 'when adding existing works' do
+    let!(:collection) { create(:collection, depositor: current_user.login) }
+    let!(:work3) { create(:work, title: ['scholarsphere_test5.txt'], depositor: current_user.login) }
 
     before { login_as(current_user) }
-    specify do
-      visit "/collections/#{collection.id}/edit"
+
+    it 'adds a work from the dashboard' do
+      visit '/dashboard/works'
+      db_file_checkbox(work3).click
+      click_button 'Add to Collection'
+      db_collection_radio_button(collection).click
+      within('#collection-list-container .modal-footer') do
+        click_button 'Add to Collection'
+      end
+      expect(page).to have_content 'Collection was successfully updated.'
+      expect(page).to have_content work3.title.first
+    end
+
+    it 'adds a work from the edit page' do
+      visit '/dashboard/collections'
+      db_item_actions_toggle(collection).click
+      click_link 'Edit Collection'
+      click_link('Add existing works')
+      check 'check_all'
+      expect(page).to have_button("Add to #{collection.title.first}")
+    end
+  end
+
+  context 'when adding new works' do
+    let!(:collection) { create(:collection, depositor: current_user.login) }
+
+    before { login_as(current_user) }
+
+    it 'adds multiple new works' do
+      visit '/dashboard/collections'
+      db_item_actions_toggle(collection).click
+      click_link 'Edit Collection'
+      click_link('Add new works')
+      expect(page).to have_content('Add Multiple New Works')
+      within('ul.nav-tabs') { click_link('Collections') }
+      expect(page).to have_select('batch_upload_item_collection_ids', selected: collection.title.first)
+    end
+  end
+
+  describe 'when editing' do
+    let!(:collection) do
+      create(:collection,
+        depositor: current_user.login,
+        subtitle: 'Vimana',
+        keyword: ['edit', 'collection'],
+        description: ['original description'])
+    end
+
+    let(:original_title)       { collection.title }
+    let(:original_subtitle)    { collection.subtitle }
+    let(:original_description) { collection.description }
+    let(:updated_title)        { 'Updated Title' }
+    let(:updated_subtitle)     { 'Updated Vimana2' }
+    let(:updated_description)  { 'Updated description text.' }
+
+    before { login_as(current_user) }
+
+    it 'updates groups and metadata' do
+      visit '/dashboard/collections'
+      db_item_actions_toggle(collection).click
+      click_link 'Edit Collection'
+
       expect(page).to have_field 'collection_title', with: original_title.first
       expect(page).to have_field 'collection_subtitle', with: original_subtitle
       expect(page).to have_field 'collection_description', with: original_description.first
+
       within('div#share') do
         select 'umg/up.dlt.scholarsphere-users', from: 'new_group_name_skel'
         select 'Edit', from: 'new_group_permission_skel'
         page.find('#add_new_group_skel').click
         expect(page).to have_selector("input[value='umg/up.dlt.scholarsphere-users']", visible: false)
       end
-    end
-  end
 
-  describe "editing a collection's metadata" do
-    let!(:collection)           { create(:collection, depositor: current_user.login, subtitle: 'Vimana', description: ['original description']) }
-    let!(:original_title)       { collection.title }
-    let!(:original_subtitle)    { collection.subtitle }
-    let!(:original_description) { collection.description }
-
-    let(:updated_title)         { 'Updated Title' }
-    let(:updated_subtitle)      { 'Updated Vimana2' }
-    let(:updated_description)   { 'Updated description text.' }
-
-    before { sign_in(current_user) }
-
-    specify do
-      visit '/dashboard/collections'
-      db_item_actions_toggle(collection).click
-      click_link 'Edit Collection'
       click_link 'Additional Fields'
-      expect(page).to have_field 'collection_title', with: original_title.first
-      expect(page).to have_field 'collection_subtitle', with: original_subtitle
-      expect(page).to have_field 'collection_description', with: original_description.first
       within('div.collection_date_created') do
         expect(page).to have_content('Published Date')
       end
@@ -114,8 +136,8 @@ describe Collection, type: :feature, js: true do
       fill_in 'Title', with: updated_title
       fill_in 'Subtitle', with: updated_subtitle
       fill_in 'Description', with: updated_description
-      expect(find('.creator-first-name')['readonly']).to eq('readonly')
-      expect(find('.creator-last-name')['readonly']).to eq('readonly')
+      expect(find('.creator-first-name')['readonly']).to eq('true')
+      expect(find('.creator-last-name')['readonly']).to eq('true')
       fill_in 'collection[creators][0][display_name]', with: 'Mdme. Dorje Trollo'
       click_button 'Update Collection'
       expect(page).not_to have_content original_title.first
@@ -124,34 +146,7 @@ describe Collection, type: :feature, js: true do
       expect(page).to have_content updated_subtitle
       expect(page).to have_content updated_description
       expect(page).to have_content 'Mdme. Dorje Trollo'
-    end
-  end
-
-  context 'when adding works' do
-    let(:collection) { create(:collection, depositor: current_user.login, title: ['Special collection']) }
-
-    before do
-      login_as(current_user)
-      visit("/collections/#{collection.id}/edit")
-    end
-
-    describe 'adding existing works' do
-      let!(:work4) { create(:work, depositor: current_user.login, title: ['Work to add']) }
-
-      specify do
-        click_link('Add existing works')
-        check 'check_all'
-        expect(page).to have_button("Add to #{collection.title.first}")
-      end
-    end
-
-    describe 'adding new works' do
-      specify do
-        click_link('Add new works')
-        expect(page).to have_content('Add Multiple New Works')
-        within('ul.nav-tabs') { click_link('Collections') }
-        expect(page).to have_select('batch_upload_item_collection_ids', selected: collection.title.first)
-      end
+      expect(collection.reload.edit_groups).to contain_exactly('umg/up.dlt.scholarsphere-users')
     end
   end
 end

--- a/spec/features/collection/view_and_search_spec.rb
+++ b/spec/features/collection/view_and_search_spec.rb
@@ -8,21 +8,23 @@ include Selectors::Dashboard
 describe Collection, type: :feature, js: true do
   let(:creator) { create(:alias, :with_agent) }
 
-  let!(:collection)  { create(:public_collection, :with_complete_metadata,
-                              creators: [creator],
-                              depositor: current_user.login,
-                              identifier: ['doi:blah-blah'],
-                              members: [file1, file2]) }
+  let!(:collection) do
+    create(:public_collection, :with_complete_metadata,
+      creators: [creator],
+      depositor: current_user.login,
+      identifier: ['doi:blah-blah'],
+      members: [file1, file2])
+  end
 
   let(:current_user) { create(:user) }
 
-  let(:file1)        { create(:public_file, :with_one_file_and_size,
-                              title: ['world.png'],
-                              depositor: current_user.login) }
+  let(:file1) do
+    create(:public_file, :with_one_file_and_size, title: ['world.png'], depositor: current_user.login)
+  end
 
-  let(:file2)        { create(:private_file, :with_one_file_and_size,
-                              title: ['little_file.txt'],
-                              depositor: current_user.login) }
+  let(:file2) do
+    create(:private_file, :with_one_file_and_size, title: ['little_file.txt'], depositor: current_user.login)
+  end
 
   context 'with a logged in user' do
     before do
@@ -30,67 +32,36 @@ describe Collection, type: :feature, js: true do
       visit("/collections/#{collection.id}")
     end
 
-    describe 'viewing a collection and its files' do
-      specify do
-        expect(page).to have_content collection.title.first
-        expect(page).to have_content collection.description.first
-        expect(page).to have_content collection.creator.first.display_name
-        expect(page).to have_selector("a[href='/catalog?f%5Bcreator_name_sim%5D%5B%5D=Given+Name+Sur+Name']")
-        expect(page).to have_selector("a[href='https://doi.org/blah-blah']")
-        expect(page).to have_content file1.title.first
-        expect(page).to have_content file2.title.first
-        expect(page).to have_content 'Total Items 2'
-        expect(page).to have_content 'Size 2 Bytes'
+    it 'shows the collection and searches within it' do
+      expect(page).to have_content collection.title.first
+      expect(page).to have_content collection.description.first
+      expect(page).to have_content collection.creator.first.display_name
+      expect(page).to have_selector("a[href='/catalog?f%5Bcreator_name_sim%5D%5B%5D=Given+Name+Sur+Name']")
+      expect(page).to have_selector("a[href='https://doi.org/blah-blah']")
+      expect(page).to have_content file1.title.first
+      expect(page).to have_content file2.title.first
+      expect(page).to have_content 'Total Items 2'
+      expect(page).to have_content 'Size 2 Bytes'
 
-        within('div.actions-controls-collections') do
-          expect(page).to have_content('Download Collection as Zip')
-        end
-
-        within('dl.metadata-collections') do
-          expect(page).to have_content('Published Date')
-        end
-        go_to_dashboard_works
-
-        # TODO: Re-add this test once ticket https://github.com/psu-stewardship/scholarsphere/issues/294
-        # has been completed. Or totally remove the commented test if the ticket is closed.
-        # expect(page).to have_content "Is part of: #{collection.title}"
-
-        expect(page).to have_link('My Works')
-        expect(page).to have_link('My Collections')
+      within('div.actions-controls-collections') do
+        expect(page).to have_content('Download Collection as Zip')
       end
-    end
 
-    describe 'searching within a collection' do
-      specify do
-        fill_in 'collection_search', with: file1.title.first
-        click_button 'collection_submit'
-        expect(page).to have_content collection.title.first
-        expect(page).to have_content collection.description.first
-
-        # Should have search results / contents listing
-        expect(page).to have_content file1.title.first
-        expect(page).not_to have_content file2.title.first
-
-        # Should not have Collection Descriptive metadata table
-        expect(page).not_to have_content collection.creator.first.display_name
+      within('dl.metadata-collections') do
+        expect(page).to have_content('Published Date')
       end
-    end
 
-    describe 'adding existing works' do
-      specify do
-        click_link('Add existing works')
-        check 'check_all'
-        expect(page).to have_button("Add to #{collection.title.first}")
-      end
-    end
+      fill_in 'collection_search', with: file1.title.first
+      click_button 'collection_submit'
+      expect(page).to have_content collection.title.first
+      expect(page).to have_content collection.description.first
 
-    describe 'adding new works' do
-      specify do
-        click_link('Add new works')
-        expect(page).to have_content('Add Multiple New Works')
-        within('ul.nav-tabs') { click_link('Collections') }
-        expect(page).to have_select('batch_upload_item_collection_ids', selected: collection.title.first)
-      end
+      # Should have search results / contents listing
+      expect(page).to have_content file1.title.first
+      expect(page).not_to have_content file2.title.first
+
+      # Should not have Collection Descriptive metadata table
+      expect(page).not_to have_content collection.creator.first.display_name
     end
   end
 


### PR DESCRIPTION
Combines and reorganizes our collection feature tests for better efficiency. This saves about 13 seconds off the total time for all the collection tests.

Connected to #1437 