### PR TITLE
Removing migration of collection creator in the controller

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -5,8 +5,6 @@ class CollectionsController < ApplicationController
   include Sufia::CollectionsControllerBehavior
   prepend_before_action :remove_and_store_permissions, only: :create
 
-  before_action :migrate_creator, only: :edit
-
   self.presenter_class = ::CollectionPresenter
   self.form_class = ::CollectionForm
 
@@ -93,10 +91,6 @@ class CollectionsController < ApplicationController
       else
         collection_path(@collection)
       end
-    end
-
-    def migrate_creator
-      Migration::SolrListMigrator.update(@collection, {})
     end
 
     def doi_service

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -32,18 +32,6 @@ describe CollectionsController, type: :controller do
     it { is_expected.to be_success }
   end
 
-  context 'when editing an existing collection' do
-    let(:work1)       { create(:public_work, depositor: user.login) }
-    let(:work2)       { create(:public_work, depositor: user.login) }
-    let!(:collection) { create(:public_collection, members: [work1, work2], depositor: user.login) }
-
-    it 'runs the migration' do
-      expect(Migration::SolrListMigrator).to receive(:update).and_call_original
-      get :edit, id: collection.id
-      expect(response).to be_success
-    end
-  end
-
   describe '::form_class' do
     subject { described_class }
 


### PR DESCRIPTION
Did a query on Production and all creators have been successfully migrated

```
resp = ActiveFedora::SolrService.query('*:*', fq: 'has_model_ssim:Collection',fl:'id', rows: 1000)
ids = resp.map{|resp| resp['id']}
ids.reject{|id| collection = Collection.find(id); collection.creator[0].is_a?(Alias) || collection.creator[0].nil?}
```

Above code returned empty array