### PR TITLE
Added an agent to the creator form when no creator was set.

### DIFF
--- a/app/forms/concerns/with_creator.rb
+++ b/app/forms/concerns/with_creator.rb
@@ -5,10 +5,9 @@ module WithCreator
 
   # @return [Array<CreatorForm>]
   # If there are no creators, a new CreatorForm is built using the logged-in user
-  # @todo add Solr search here or in CreatorForm to user existing Alias record for the user
   def creators
     if model.creators.empty?
-      Array.wrap(CreatorForm.new(Alias.new(display_name: current_display_name)))
+      [CreatorForm.new(Alias.new(display_name: current_display_name, agent: current_agent))]
     else
       model.creators.map { |c| CreatorForm.new(c) }
     end
@@ -25,13 +24,30 @@ module WithCreator
   private
 
     # @return [String]
+    def current_display_name
+      current_user.display_name
+    end
+
+    # @return [User]
     # Sometimes current_ability is really a user
     # @todo See https://github.com/psu-stewardship/scholarsphere/issues/1038
-    def current_display_name
+    def current_user
       if current_ability.is_a?(User)
-        current_ability.display_name
+        current_ability
       else
-        current_ability.current_user.display_name
+        current_ability.current_user
       end
+    end
+
+    # @return [Agent]
+    # Finds the existing agent for the current user or builds an agent if it doesn't exist
+    def current_agent
+      Agent.where(psu_id: current_user.login).first || create_agent
+    end
+
+    def create_agent
+      parsed_name = Namae::Name.parse(current_user.display_name)
+      Agent.new(psu_id: current_user.login, email: current_user.email, sur_name: parsed_name.family,
+                given_name: parsed_name.given, orcid_id: current_user.orcid)
     end
 end

--- a/app/forms/creator_form.rb
+++ b/app/forms/creator_form.rb
@@ -4,45 +4,17 @@ class CreatorForm
   attr_reader :agent_alias
 
   delegate :id, :display_name, to: :agent_alias
+  delegate :sur_name, :given_name, :psu_id, :email, :orcid_id, to: :@agent
 
   # @param [Alias]
   def initialize(agent_alias)
     @agent_alias = agent_alias
+    @agent_alias.agent = Agent.new(sur_name: parsed_name.family, given_name: parsed_name.given) if @agent_alias.agent.blank?
+    @agent = @agent_alias.agent
   end
 
   def read_only?
-    agent_alias.agent.present?
-  end
-
-  def sur_name
-    if read_only?
-      agent_alias.agent.sur_name
-    else
-      parsed_name.family
-    end
-  end
-
-  def given_name
-    if read_only?
-      agent_alias.agent.given_name
-    else
-      parsed_name.given
-    end
-  end
-
-  def psu_id
-    return unless read_only?
-    agent_alias.agent.psu_id
-  end
-
-  def email
-    return unless read_only?
-    agent_alias.agent.email
-  end
-
-  def orcid_id
-    return unless read_only?
-    agent_alias.agent.orcid_id
+    agent_alias.agent.present? && agent_alias.agent.id.present?
   end
 
   private

--- a/app/views/records/edit_fields/_creator.html.erb
+++ b/app/views/records/edit_fields/_creator.html.erb
@@ -30,7 +30,7 @@
       <fieldset>
         <legend class="sr-only">Creator Information</legend>
         <% given_name_id = "#{id_base}[given_name]" %>
-        <%= label_tag given_name_id, 'Given Name' %>
+        <%= label_tag given_name_id, t('scholarsphere.creators.given_name') %>
         <%= text_field_tag given_name_id, creator_form.given_name,
               required: false,
               readonly: creator_form.read_only?,
@@ -38,7 +38,7 @@
               class: 'form-control string creator-first-name creator' %>
 
         <% sur_name_id = "#{id_base}[sur_name]" %>
-        <%= label_tag sur_name_id, 'Last Name' %>
+        <%= label_tag sur_name_id, t('scholarsphere.creators.sur_name') %>
         <%= text_field_tag sur_name_id, creator_form.sur_name,
               required: false,
               readonly: creator_form.read_only?,
@@ -55,7 +55,7 @@
               class: 'form-control string required creator-display-name creator' %>
 
         <% email_id = "#{id_base}[email]" %>
-        <%= label_tag email_id, 'Email' %>
+        <%= label_tag email_id, t('scholarsphere.creators.email') %>
         <%= text_field_tag email_id, creator_form.email,
               required: false,
               readonly: creator_form.read_only?,
@@ -63,7 +63,7 @@
               class: 'form-control string creator-email creator' %>
 
         <% psu_id_id = "#{id_base}[psu_id]" %>
-        <%= label_tag psu_id_id, 'PSU ID' %>
+        <%= label_tag psu_id_id, t('scholarsphere.creators.psu_id') %>
         <%= text_field_tag psu_id_id, creator_form.psu_id,
               required: false,
               readonly: creator_form.read_only?,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -62,7 +62,11 @@ en:
 
   scholarsphere:
     creators:
-      search_text: 'You can search for creators by Penn State User ID (abc123 or abc1234) or first name or last name.'
+      search_text: 'You can search for creators by Access Account ID (abc123 or abc1234) or first name or last name.'
+      given_name: 'Given Name'
+      sur_name: 'Last Name'
+      email: 'Email'
+      psu_id: 'Access Account ID (xyz1234)'
     model_display_name:
       generic_work: 'work'
       file_set: 'file'

--- a/spec/forms/creator_form_spec.rb
+++ b/spec/forms/creator_form_spec.rb
@@ -9,7 +9,7 @@ describe CreatorForm do
 
   context 'when the alias exists with an agent' do
     let(:agent_alias) { build(:alias, display_name: 'Joe Bob',
-                                      agent: build(:agent, :with_complete_metadata)) }
+                                      agent: build(:agent, :with_complete_metadata, id: 'abc123')) }
 
     it { is_expected.to be_read_only }
     its(:display_name) { is_expected.to eq('Joe Bob') }
@@ -32,5 +32,19 @@ describe CreatorForm do
     its(:psu_id) { is_expected.to be_nil }
     its(:email) { is_expected.to be_nil }
     its(:orcid_id) { is_expected.to be_nil }
+  end
+
+  context 'agent that is unsaved' do
+    let(:agent_alias) { build(:alias, display_name: 'Joe Bob',
+                                      agent: build(:agent, :with_complete_metadata)) }
+
+    it { is_expected.not_to be_read_only }
+    its(:display_name) { is_expected.to eq('Joe Bob') }
+    its(:id) { is_expected.to eq(agent_alias.id) }
+    its(:given_name) { is_expected.to eq('Johnny C.') }
+    its(:sur_name) { is_expected.to eq('Lately') }
+    its(:psu_id) { is_expected.to eq('jcl81') }
+    its(:email) { is_expected.to eq('newkid@example.com') }
+    its(:orcid_id) { is_expected.to eq('00123445') }
   end
 end

--- a/spec/forms/generic_work_form_spec.rb
+++ b/spec/forms/generic_work_form_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe CurationConcerns::GenericWorkForm do
-  let(:user)    { create(:user, display_name: 'Test A User') }
+  let(:user)    { create(:user, display_name: 'Test A User', email: 'abc123', login: 'psu_id') }
   let(:ability) { Ability.new(user) }
   let(:work)    { build(:work) }
   let(:form)    { described_class.new(work, ability) }
@@ -15,6 +15,9 @@ describe CurationConcerns::GenericWorkForm do
       its(:display_name) { is_expected.to eq('Test A User') }
       its(:given_name) { is_expected.to eq('Test A') }
       its(:sur_name) { is_expected.to eq('User') }
+      its(:email) { is_expected.to eq('abc123') }
+      its(:psu_id) { is_expected.to eq('psu_id') }
+      its(:read_only?) { is_expected.to be_falsey }
     end
 
     context 'without a display name' do
@@ -34,6 +37,17 @@ describe CurationConcerns::GenericWorkForm do
       its(:display_name) { is_expected.to eq(creator.display_name) }
       its(:given_name) { is_expected.to eq(creator.agent.given_name) }
       its(:sur_name) { is_expected.to eq(creator.agent.sur_name) }
+    end
+
+    context 'with existing agent' do
+      let!(:agent) { create(:agent, psu_id: 'psu_id', email: 'abc123', sur_name: 'User', given_name: 'Test A') }
+
+      its(:display_name) { is_expected.to eq('Test A User') }
+      its(:given_name) { is_expected.to eq('Test A') }
+      its(:sur_name) { is_expected.to eq('User') }
+      its(:email) { is_expected.to eq('abc123') }
+      its(:psu_id) { is_expected.to eq('psu_id') }
+      its(:read_only?) { is_expected.to be_truthy }
     end
   end
 


### PR DESCRIPTION
This allows us to set the email, orcid, psu id on the work and collection creation form
Looks for an existing agent and uses the existing agent if found.

refs #1453 