### PR TITLE
Fixes up the creator form when creator is added from search

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -114,7 +114,7 @@ RSpec/MessageSpies:
 # Offense count: 281
 # Configuration parameters: AggregateFailuresByDefault.
 RSpec/MultipleExpectations:
-  Max: 53
+  Max: 58
 
 # Offense count: 135
 # Configuration parameters: IgnoreSharedExamples.

--- a/app/assets/javascripts/scholarsphere/creator/creator_autocomplete.js
+++ b/app/assets/javascripts/scholarsphere/creator/creator_autocomplete.js
@@ -1,3 +1,5 @@
+//= require scholarsphere/creator/creator_behavior
+
 ScholarSphere.creatorAutocomplete = {
   /**
    * Object for setting up Typeahead and Bloodhound
@@ -48,6 +50,7 @@ ScholarSphere.creatorAutocomplete = {
       var template = $('#creator_template').html()
       var render = Mustache.render(template, creator)
       $('.creator_container').append(render)
+      ScholarSphere.creatorBehavior.showHideCreatorRemove()
     })
   },
   typeaheadClose: function () {

--- a/app/assets/javascripts/scholarsphere/creator/creator_behavior.js
+++ b/app/assets/javascripts/scholarsphere/creator/creator_behavior.js
@@ -14,20 +14,21 @@ ScholarSphere.creatorBehavior = {
       $('.creator_container').append(render)
       ScholarSphere.creatorBehavior.activateRemoveButton()
       $('.creator_container').trigger("managed_field:add")
-        if ($('.remove-creator').length == 1)
-            $('.remove-creator').hide()
-        else
-            $('.remove-creator').show()
+      ScholarSphere.creatorBehavior.showHideCreatorRemove()
     })
   },
   activateRemoveButton: function () {
     $('.creator_container').on('click', '.remove-creator', function () {
         $(this).parent().remove()
-        if ($('.remove-creator').length == 1)
-            $('.remove-creator').hide()
-        else
-            $('.remove-creator').show()
+        ScholarSphere.creatorBehavior.showHideCreatorRemove()
     })
+  },
+
+  showHideCreatorRemove: function () {
+      if ($('.remove-creator').length == 1)
+          $('.remove-creator').hide()
+      else
+          $('.remove-creator').show()
   }
 }
 

--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -51,7 +51,7 @@ class AgentsController < ApplicationController
           'id' => nil,
           'given_name' => ldap_entry[:given_name],
           'sur_name' => ldap_entry[:surname],
-          'email' => ldap_entry[:mail],
+          'email' => ldap_entry[:email],
           'psu_id' => ldap_entry[:id],
           'orcid_id' => nil,
           'display_name' => ldap_entry[:displayname]

--- a/spec/controllers/agents_controller_spec.rb
+++ b/spec/controllers/agents_controller_spec.rb
@@ -13,37 +13,41 @@ RSpec.describe AgentsController do
     let(:ldap_attrs) { %i[uid givenname sn mail eduPersonPrimaryAffiliation displayname] }
 
     let(:jamie_l_franks_ldap_entry) do
-      build(:ldap_entry,
-            uid: 'qjf1',
-            displayname: 'JAMIE L FRANKS',
-            givenname: 'JAMIE L',
-            sn: 'FRANKS',
-            mail: 'qjf1@psu.edu')
+      {
+        id: 'qjf1',
+        displayname: 'JAMIE L FRANKS',
+        given_name: 'JAMIE L',
+        surname: 'FRANKS',
+        email: 'qjf1@psu.edu'
+      }
     end
     let(:jamie_test_gmail_ldap_entry) do
-      build(:ldap_entry,
-            uid: 'jat1',
-            displayname: 'JAMIE TEST',
-            givenname: 'Jamie',
-            sn: 'Test',
-            mail: 'james@gmail.com')
+      {
+        id: 'jat1',
+        displayname: 'JAMIE TEST',
+        given_name: 'Jamie',
+        surname: 'Test',
+        email: 'james@gmail.com'
+      }
     end
     let(:jamie_test_psu_ldap_entry) do
-      build(:ldap_entry,
-            uid: 'jat1',
-            displayname: 'JAMIE TEST',
-            givenname: 'Jamie',
-            sn: 'Test',
-            mail: 'jat1@psu.edu')
+      {
+        id: 'jat1',
+        displayname: 'JAMIE TEST',
+        given_name: 'Jamie',
+        surname: 'Test',
+        email: 'jat1@psu.edu'
+      }
     end
 
     let(:janet_mouse_ldap_entry) do
-      build(:ldap_entry,
-            uid: 'jam',
-            displayname: 'JANET A MOUSE',
-            givenname: 'JANET A',
-            sn: 'MOUSE',
-            mail: 'jam@psu.edu')
+      {
+        id: 'jam',
+        displayname: 'JANET A MOUSE',
+        given_name: 'JANET A',
+        surname: 'MOUSE',
+        email: 'jam@psu.edu'
+      }
     end
 
     let(:name_results) { [jamie_l_franks_ldap_entry,
@@ -74,10 +78,10 @@ RSpec.describe AgentsController do
         results = JSON.parse(response.body)
         expect(results.count).to eq(6)
         expect(results.map { |x| x['display_name'] }.flatten).to contain_exactly('Dr. James T. Test', 'JAMIE L FRANKS', 'JAMIE TEST', 'JANET A MOUSE', 'Jamie Test', 'Sally James')
-        expect(results.map { |x| x['given_name'] }.flatten).to contain_exactly('Jamie', 'Jamie', 'Sally')
-        expect(results.map { |x| x['sur_name'] }.flatten).to contain_exactly('Test', 'Test', 'James')
+        expect(results.map { |x| x['given_name'] }.flatten).to contain_exactly('JAMIE L', 'Jamie', 'Jamie', 'Jamie', 'JANET A', 'Sally')
+        expect(results.map { |x| x['sur_name'] }.flatten).to contain_exactly('Test', 'Test', 'James', 'FRANKS', 'MOUSE', 'Test')
         expect(results.map { |x| x['email'] }.flatten).to contain_exactly(nil, 'jam@psu.edu', 'jat1@psu.edu', 'james@gmail.com', 'qjf1@psu.edu', 'james@gmail.com')
-        expect(results.map { |x| x['psu_id'] }.flatten).to contain_exactly('jtt01', 'jtt01', nil)
+        expect(results.map { |x| x['psu_id'] }.flatten).to contain_exactly('jtt01', 'jtt01', 'jam', 'jat1', 'qjf1', nil)
         expect(results.map { |x| x['orcid_id'] }.flatten).to contain_exactly(nil, nil, '1234', nil, nil, '1234')
       end
       it 'returns JSON results when queried with spaces' do
@@ -87,10 +91,10 @@ RSpec.describe AgentsController do
         results = JSON.parse(response.body)
         expect(results.count).to eq(2)
         expect(results.map { |x| x['display_name'] }.flatten).to contain_exactly('JAMIE TEST', 'Jamie Test')
-        expect(results.map { |x| x['given_name'] }.flatten).to contain_exactly('Jamie')
-        expect(results.map { |x| x['sur_name'] }.flatten).to contain_exactly('Test')
+        expect(results.map { |x| x['given_name'] }.flatten).to contain_exactly('Jamie', 'Jamie')
+        expect(results.map { |x| x['sur_name'] }.flatten).to contain_exactly('Test', 'Test')
         expect(results.map { |x| x['email'] }.flatten).to contain_exactly('james@gmail.com', 'jat1@psu.edu')
-        expect(results.map { |x| x['psu_id'] }.flatten).to contain_exactly('jtt01')
+        expect(results.map { |x| x['psu_id'] }.flatten).to contain_exactly('jtt01', 'jat1')
         expect(results.map { |x| x['orcid_id'] }.flatten).to contain_exactly(nil, '1234')
       end
     end

--- a/spec/features/generic_work/upload_and_delete_spec.rb
+++ b/spec/features/generic_work/upload_and_delete_spec.rb
@@ -177,6 +177,7 @@ describe 'Generic File uploading and deletion:', type: :feature do
 
         # Add creator field from autocomplete results
         expect(page).to have_selector('.creator_inputs', count: 5)
+        expect(page).to have_selector('.remove-creator', count: 5)
         expect(page).to have_field('generic_work[creators][2][given_name]', readonly: true)
         expect(page).to have_field('generic_work[creators][2][sur_name]', readonly: true)
         expect(page).to have_field('generic_work[creators][2][email]', readonly: true)
@@ -185,6 +186,10 @@ describe 'Generic File uploading and deletion:', type: :feature do
         expect(page).to have_selector("input[value='TESTING TRANSFR UNIV']")
         expect(page).to have_selector("input[value='TESTING 1 CHRIS']")
         expect(page).to have_selector("input[value='Jeffrey L Tate']")
+        expect(page).to have_selector("input[value='Jeffrey L']")
+        expect(page).to have_selector("input[value='Tate']")
+        expect(page).to have_selector("input[value='jlt37@psu.edu']")
+        expect(page).to have_selector("input[value='jlt37']")
 
         # Remove the autocompleted creator field
         execute_script("$('.remove-creator')[2].click()")


### PR DESCRIPTION
Updates the JS to ensure that we have a remove button when a creator is added from the search function and updates the tests for the use of email versus mail and the presence of the remove functionality.

refs #1453 