### PR TITLE
Fixes the broken queries for depositor works and collections from the dashboard.

### DIFF
--- a/app/views/users/_vitals.html.erb
+++ b/app/views/users/_vitals.html.erb
@@ -1,0 +1,18 @@
+<%# Overrides the partial from Sufia to fix the depositor %>
+<div class="list-group-item">
+  <span class="glyphicon glyphicon-time"></span> Joined on <%= user.created_at.to_date.strftime('%b %d, %Y') %>
+</div>
+
+<div class="list-group-item">
+  <span class="badge"><%= number_of_collections(user) %></span>
+  <span class="glyphicon glyphicon-folder-open"></span> <%= link_to_field('depositor_ssim', user.to_s, t('sufia.dashboard.stats.collections'), generic_type: 'Collection') %>
+</div>
+
+<div class="list-group-item">
+  <span class="badge"><%= number_of_works(user) %></span>
+  <span class="glyphicon glyphicon-upload"></span> <%= link_to_field('depositor_ssim', user.to_s, t('sufia.dashboard.stats.works'), generic_type: 'Work') %>
+  <ul class="views-downloads-dashboard list-unstyled">
+    <li><span class="badge badge-optional"><%= user.total_file_views %></span> <%= t('sufia.dashboard.stats.file_views').pluralize(user.total_file_views) %></li>
+    <li><span class="badge badge-optional"><%= user.total_file_downloads %></span> <%= t('sufia.dashboard.stats.file_downloads').pluralize(user.total_file_downloads) %></li>
+  </ul>
+</div>


### PR DESCRIPTION
Grabs the _vitals partial from Sufia and overrides depositor field for depositor_ssim, so that the queries from the dashboard return works and collections made by the depositor.

<img width="1186" alt="screen shot 2019-02-19 at 8 00 40 pm" src="https://user-images.githubusercontent.com/4163828/53058492-38ce9900-3481-11e9-8057-7d9f2d6176a4.png">





<img width="1188" alt="screen shot 2019-02-19 at 8 01 11 pm" src="https://user-images.githubusercontent.com/4163828/53058493-39672f80-3481-11e9-9a4a-2451fc122aab.png">
