### PR TITLE
Overriding blacklight to allow for blank values in the resource type

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,6 +7,11 @@ module ApplicationHelper
     c.title
   end
 
+  # Put a clickable value when the facet value is empty
+  def resource_type_helper_method(value)
+    value.presence || I18n.t('scholarsphere.missing_facet')
+  end
+
   # TODO: Needed? this is in curation_concerns-0.14.0.pre1/app/inputs/select_with_modal_help_input.rb
   def link_to_help(subject)
     link_to '#', id: "#{subject}_help", rel: 'popover',

--- a/app/helpers/render_constraints_helper.rb
+++ b/app/helpers/render_constraints_helper.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module RenderConstraintsHelper
+  include Blacklight::RenderConstraintsHelperBehavior
+
+  ##
+  # Override Blacklight to allow for blank values in facets.
+  #    This is required for out blank resource types
+  #
+  # Render a single facet's constraint
+  # @param [String] facet field
+  # @param [Array<String>] values selected facet values
+  # @param [Blacklight::SearchState] path query parameters
+  # @return [String]
+  def render_filter_element(facet, values, path)
+    facet_config = facet_configuration_for_field(facet)
+
+    safe_join(Array(values).map do |val|
+      render_constraint_element(facet_field_label(facet_config.key),
+                                facet_display_value(facet, val),
+                                remove: search_action_path(path.remove_facet_params(facet, val)),
+                                classes: ['filter', 'filter-' + facet.parameterize])
+    end, "\n")
+  end
+end

--- a/app/search_builders/search_builder.rb
+++ b/app/search_builders/search_builder.rb
@@ -9,6 +9,27 @@ class SearchBuilder < Sufia::CatalogSearchBuilder
     :show_works_or_works_that_contain_files
   ]
 
+  # Override Blacklight to allow for blank values in facets.
+  #   This is required for out blank resource types
+  #
+  def add_facet_fq_to_solr(solr_parameters)
+    # convert a String value into an Array
+    if solr_parameters[:fq].is_a? String
+      solr_parameters[:fq] = [solr_parameters[:fq]]
+    end
+
+    # :fq, map from :f.
+    if blacklight_params[:f]
+      f_request_params = blacklight_params[:f]
+
+      f_request_params.each_pair do |facet_field, value_list|
+        Array(value_list).each do |value|
+          solr_parameters.append_filter_query facet_value_to_fq_string(facet_field, value)
+        end
+      end
+    end
+  end
+
   # @note Overrides Sufia with a later Hyrax version to correct full-text searching.
   # show both works that match the query and works that contain files that match the query
   def show_works_or_works_that_contain_files(solr_parameters)

--- a/app/services/field_configurator.rb
+++ b/app/services/field_configurator.rb
@@ -39,7 +39,7 @@ class FieldConfigurator
   # Common fields between all lists
   def self.common_fields
     {
-      resource_type: FieldConfig.new('Resource Type'),
+      resource_type: FieldConfig.new(label: 'Resource Type', helper_method: :resource_type_helper_method),
       creator_name: FieldConfig.new(label: 'Creator', facet_cleaners: [:creator]),
       keyword: FieldConfig.new(label: 'Keyword', facet_cleaners: [:downcase]),
       subject: FieldConfig.new('Subject'),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -98,6 +98,7 @@ en:
       representative_media: 'If this is or becomes your representative media, this may impact the display of your work in search results.'
     encoding:
       error: 'Error encoding readme as UTF-8'
+    missing_facet: 'unspecified'
 
   statistic:
     report:

--- a/spec/features/catalog_search_spec.rb
+++ b/spec/features/catalog_search_spec.rb
@@ -10,20 +10,23 @@ describe 'catalog searching', type: :feature do
                                      title: ['title 1'],
                                      description: ['first work'],
                                      date_created: ['just now'],
-                                     keyword: ['tag1', 'tag2']) }
+                                     keyword: ['tag1', 'tag2'],
+                                     resource_type: ['Audio']) }
 
   let!(:work2) { build(:public_work, id: 'pw2',
                                      depositor: user.login,
                                      title: ['title 2'],
                                      description: ['second work'],
                                      date_created: ['just now'],
-                                     keyword: ['tag2', 'tag3']) }
+                                     keyword: ['tag2', 'tag3'],
+                                     resource_type: ['']) }
 
   let!(:work3) { build(:public_work, id: 'pw3',
                                      depositor: user.login,
                                      title: ['title 3'],
                                      date_created: ['just now'],
-                                     keyword: ['tag3', 'tag4']) }
+                                     keyword: ['tag3', 'tag4'],
+                                     resource_type: ['']) }
 
   let!(:collection) { build(:collection, id: 'coll1', depositor: user.login, keyword: ['tag3', 'tag4']) }
 
@@ -33,17 +36,15 @@ describe 'catalog searching', type: :feature do
     visit '/'
   end
 
-  it 'shows the facets' do
-    within('#search-form-header') do
-      click_button('Go')
-    end
-    expect(page).to have_css 'div#facets'
-  end
-
   it 'finds multiple files' do
     within('#search-form-header') do
       fill_in('search-field-header', with: 'tag2')
       click_button('Go')
+    end
+
+    within('div#facets') do
+      expect(page).to have_link('unspecified')
+      expect(page).to have_link('Audio')
     end
 
     # All fields are displayed in the list view
@@ -75,6 +76,11 @@ describe 'catalog searching', type: :feature do
 
     expect(page).not_to have_selector('a.view-type-masonry')
     expect(page).not_to have_selector('a.view-type-slideshow')
+
+    click_link('unspecified')
+    expect(page).to have_content('You searched for: tag2 Remove constraint tag2 Resource Type unspecified Remove constraint Resource Type: unspecified')
+    expect(page).not_to have_link(work1.title.first)
+    expect(page).to have_link(work2.title.first)
   end
 
   it 'finds files and collections' do


### PR DESCRIPTION
Added a view helper, a search builder override and a render helper

ref #1396

Before with blank:
<img width="793" alt="screen shot 2019-02-26 at 9 57 32 am" src="https://user-images.githubusercontent.com/1599081/53430849-4a51fc80-39bd-11e9-8254-ce8d4dec2de2.png">

After with 'unspecified'
<img width="721" alt="screen shot 2019-02-26 at 11 54 14 am" src="https://user-images.githubusercontent.com/1599081/53430852-4de58380-39bd-11e9-997b-9512df14dab3.png">

Unspecified selected as a filter
<img width="1009" alt="screen shot 2019-02-26 at 11 55 47 am" src="https://user-images.githubusercontent.com/1599081/53430948-8c7b3e00-39bd-11e9-935f-8f3c57cc2411.png">
