### PR TITLE
Changing work zip service to utilize the local file system

### DIFF
--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -23,10 +23,9 @@ class DownloadsController < ApplicationController
       if params['file'] == 'thumbnail'
         super
       elsif asset.is_a?(FileSet)
-        pcdm_file = asset.association(:original_file).find_target
-        path = Scholarsphere::Pairtree.new(asset, nil).storage_path(disk_file_url(pcdm_file))
-        if File.exist?(path)
-          path
+        location = FileSetDiskLocation.new(asset)
+        if File.exist?(location.path)
+          location.path
         else
           super
         end
@@ -55,8 +54,4 @@ class DownloadsController < ApplicationController
     end
 
     class ZipServiceError < StandardError; end
-
-    def disk_file_url(file)
-      @disk_file_url ||= ActiveFedora.fedora.connection.head(file.uri).response.headers['content-type'].split('"')[1]
-    end
 end

--- a/app/services/file_set_disk_location.rb
+++ b/app/services/file_set_disk_location.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# returns the location of the FileSet original file on disk
+#
+class FileSetDiskLocation
+  attr_reader :path
+
+  def initialize(file_set)
+    pcdm_file = file_set.association(:original_file).find_target
+    disk_file_url = ActiveFedora.fedora.connection.head(pcdm_file.uri).response.headers['content-type'].split('"')[1]
+    @path = Scholarsphere::Pairtree.new(file_set, nil).storage_path(disk_file_url)
+  end
+end

--- a/app/services/work_zip_service.rb
+++ b/app/services/work_zip_service.rb
@@ -48,7 +48,8 @@ class WorkZipService
       return unless add_to_zip?(file_set)
 
       zipfile.get_output_stream(file_set.title.first) do |outfile|
-        file_set.original_file.stream.each { |buffer| outfile.write(buffer) }
+        location = FileSetDiskLocation.new(file_set)
+        File.open(location.path).each { |buffer| outfile.write(buffer) }
       end
     end
 

--- a/spec/factories/works.rb
+++ b/spec/factories/works.rb
@@ -113,6 +113,7 @@ FactoryGirl.define do
       visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
 
       after(:create) do |work, attributes|
+        allow(CreateDerivativesJob).to receive(:perform_later)
         FactoryHelpers.add_public_mp3(work, attributes)
       end
     end

--- a/spec/support/helpers/factory_helpers.rb
+++ b/spec/support/helpers/factory_helpers.rb
@@ -97,9 +97,7 @@ module FactoryHelpers
                             visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)
 
     filename = "#{Rails.root}/spec/fixtures/scholarsphere/scholarsphere_test5.mp3"
-    local_file = File.open(filename, 'rb')
-    Hydra::Works::AddFileToFileSet.call(fs, local_file, :original_file, versioning: false)
-    fs.save!
+    IngestFileJob.perform_now(fs, filename, attributes.user)
     work.ordered_members << fs
     work.thumbnail_id = fs.id
     work.save


### PR DESCRIPTION
Added a service to return the path, which could be used in the downloads controller and the zip service
Changed the Downloads controller to utilize the extracted code
changed the zip service to use the new code
Changed the test to create an external file instead of an internal file