### PR TITLE
Limit video's width to its container

### DIFF
--- a/app/assets/stylesheets/scholarsphere/work_show.scss
+++ b/app/assets/stylesheets/scholarsphere/work_show.scss
@@ -42,3 +42,6 @@ dd.attribute + dd.attribute::before { // Keeping the dd here so that we don't ne
 .readme h4 { font-size: 1.5rem; }
 
 .breadcrumb > .active { color: $gray-bread-aaa; }
+
+// Fit video to its containing element
+video { width: 100%; }


### PR DESCRIPTION
Prevents the video from taking up the entire page.

Fixes #1519