### PR TITLE
Default to application/octet-stream for unknown mime types

### DIFF
--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -54,4 +54,11 @@ class DownloadsController < ApplicationController
     end
 
     class ZipServiceError < StandardError; end
+
+    def mime_type_for(file)
+      types = MIME::Types.type_for(File.extname(file))
+      return 'application/octet-stream' if types.empty?
+
+      types.first.content_type
+    end
 end

--- a/spec/controllers/downloads_controller_spec.rb
+++ b/spec/controllers/downloads_controller_spec.rb
@@ -170,5 +170,21 @@ describe DownloadsController do
         expect { subject }.to raise_error(DownloadsController::ZipServiceError, 'BogusClass cannot be downloaded as a zip file')
       end
     end
+
+    context 'with an unknown file type' do
+      let(:file) { File.open(File.join(fixture_path, 'special-mime-type.R')) }
+
+      before do
+        allow(response).to receive(:"status=")
+        controller.params[:id] = my_file.id
+      end
+
+      it 'sends content' do
+        expect(WorkZipService).not_to receive(:new)
+        expect(controller).to receive(:send_file)
+          .with(/.*#{my_file.id}.*special-mime-type.R/, type: 'application/octet-stream', disposition: 'inline')
+        subject
+      end
+    end
   end
 end

--- a/spec/fixtures/special-mime-type.R
+++ b/spec/fixtures/special-mime-type.R
@@ -1,0 +1,1 @@
+File with special mime-type


### PR DESCRIPTION
Fixes issue reported in #1580. This was originally reported by a user trying to download https://scholarsphere.psu.edu/concern/generic_works/zg64tm07w