### PR TITLE
Enabling headless testing in features

### DIFF
--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -42,12 +42,11 @@ describe 'Visting the home page:', type: :feature, js: true do
     let(:current_user) { create(:user) }
 
     before do
-      sign_in_with_named_js(:small_chrome, current_user, height: '400', width: '500')
+      sign_in_with_named_js(:small_chrome, current_user, window_size: 'window-size=400,500')
       visit '/'
     end
 
     it do
-      pending 'Unable to resize existing session with webdriver'
       expect(page).not_to have_content(current_user.display_name)
     end
   end

--- a/spec/features/support/feature_sessions.rb
+++ b/spec/features/support/feature_sessions.rb
@@ -17,10 +17,10 @@ module Features
       unless Capybara.drivers.include?(name)
         Capybara.register_driver name do |app|
           window_size = opts[:window_size] || 'window-size=1024,768'
-          capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(chromeOptions: { args: ['no-sandbox', 'headless', 'disable-gpu', window_size, 'single-process'] })
-          Capybara::Selenium::Driver.new(app,
-                                           browser: :chrome,
-                                           desired_capabilities: capabilities)
+          options = Selenium::WebDriver::Chrome::Options.new(
+            args: ['no-sandbox', 'headless', 'disable-gpu', window_size, 'single-process']
+          )
+          Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
         end
       end
       Capybara.current_driver = name

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -20,4 +20,10 @@ RSpec.configure do |config|
   # Alias for shared examples
   config.alias_it_should_behave_like_to :we_can, 'We can'
   config.infer_spec_type_from_file_location!
+
+  config.before do |test|
+    if test.metadata.fetch(:js, false)
+      Capybara.current_driver = :selenium_chrome_headless
+    end
+  end
 end


### PR DESCRIPTION
Makes changes to our local js-based login methods, and the methods included with Warden so that headless versions of chrome are used when running tests.

With thanks to @whereismyjetpack @mtribone @banukutlu @AndrewGearhart @cdmo 