### PR TITLE
Create zip files for large works and collections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,5 @@ migration_report
 user_emails.txt
 public/uploads
 config/application.yml
+public/zip-development
+public/zip-test

--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -29,6 +29,8 @@ class DownloadsController < ApplicationController
         else
           super
         end
+      elsif asset.public?
+        ScholarSphere::Application.config.public_zipfile_directory.join("#{asset.id}.zip").to_s
       else
         zip_service.call
       end

--- a/app/jobs/zip_job.rb
+++ b/app/jobs/zip_job.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class ZipJob < ApplicationJob
+  class Error < StandardError; end
+
+  attr_reader :object
+
+  def perform(id)
+    @object = ActiveFedora::Base.find(id)
+    file = ZipFile.new(ScholarSphere::Application.config.public_zipfile_directory.join("#{@object.id}.zip"))
+
+    zip_service.new(@object, public_ability, file.parent, file.basename.to_s).call if file.stale?
+  end
+
+  def zip_service
+    return WorkZipService if object.is_a?(GenericWork)
+    return CollectionZipService if object.is_a?(Collection)
+
+    raise Error, "#{object.class} is not exportable as a zip"
+  end
+
+  # @return [Ability]
+  # Creates a type of ability that only allows access to public resources
+  def public_ability
+    Ability.new(nil)
+  end
+end

--- a/app/models/zip_file.rb
+++ b/app/models/zip_file.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class ZipFile
+  attr_reader :file, :resource
+
+  delegate :exist?, :parent, :basename, to: :file
+
+  # @param [File, Pathname] file to be treated as a zip file
+  def initialize(file)
+    @file = Pathname.new(file)
+    @resource = resource_from_zip(@file)
+  end
+
+  # @note This won't raise any hubbub if the file doesn't exist
+  def delete
+    FileUtils.rm_f(file)
+  end
+
+  def exceeds_threshold?
+    return false unless resource
+
+    resource.fetch('bytes_lts', 0) > ScholarSphere::Application.config.zipfile_size_threshold
+  end
+
+  def stale?
+    return true unless resource && exist?
+
+    DateTime.parse(resource.fetch('system_modified_dtsi')) > file.mtime
+  end
+
+  private
+
+    def resource_from_zip(file)
+      SolrDocument.find(file.basename('.*').to_s)
+    rescue Blacklight::Exceptions::RecordNotFound
+      nil
+    end
+end

--- a/app/presenters/collection_presenter.rb
+++ b/app/presenters/collection_presenter.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class CollectionPresenter < Sufia::CollectionPresenter
-  delegate :subtitle, to: :solr_document
+  delegate :subtitle, :bytes, to: :solr_document
 
   def self.terms
     [:creator, :keyword, :rights, :resource_type, :contributor, :publisher, :date_created, :date_uploaded,
@@ -18,5 +18,12 @@ class CollectionPresenter < Sufia::CollectionPresenter
 
   def cleaned_creators
     @cleaned_creators ||= FacetValueCleaningService.call(creator, FieldConfig.new(facet_cleaners: [:creator]), solr_document)
+  end
+
+  def zip_available?
+    return false if total_items.zero?
+    return true if bytes < ScholarSphere::Application.config.zipfile_size_threshold
+
+    ScholarSphere::Application.config.public_zipfile_directory.join("#{id}.zip").exist?
   end
 end

--- a/app/presenters/work_show_presenter.rb
+++ b/app/presenters/work_show_presenter.rb
@@ -85,6 +85,13 @@ class WorkShowPresenter < Sufia::WorkShowPresenter
     super
   end
 
+  def zip_available?
+    return false if uploading?
+    return true if bytes < ScholarSphere::Application.config.zipfile_size_threshold
+
+    ScholarSphere::Application.config.public_zipfile_directory.join("#{id}.zip").exist?
+  end
+
   private
 
     # Override to add rows parameter

--- a/app/services/collection_zip_service.rb
+++ b/app/services/collection_zip_service.rb
@@ -10,7 +10,7 @@ class CollectionZipService < WorkZipService
     def add_files_to_zip(zipfile, work)
       return unless ability.can? :read, work.id
 
-      zipfile.add("#{work.title.first}.zip", WorkZipService.new(work, ability, zip_directory).call) do
+      zipfile.add("#{work.title.first}.zip", WorkZipService.new(work, ability, ENV['TMPDIR']).call) do
         true
       end
     end

--- a/app/views/collections/_show_actions.html.erb
+++ b/app/views/collections/_show_actions.html.erb
@@ -26,7 +26,7 @@
                         method: :delete } %>
   <% end %>
 
-  <% if member_docs.present? %>
+  <% if presenter.zip_available? %>
     <%= link_to t('sufia.collection.actions.collection_zip_link'),
                 main_app.download_path(presenter),
                 target: :_blank,

--- a/app/views/curation_concerns/base/_download_work.html.erb
+++ b/app/views/curation_concerns/base/_download_work.html.erb
@@ -1,5 +1,5 @@
 <div class="show-download">
-  <% unless presenter.uploading? %>
+  <% if presenter.zip_available? %>
     <%= link_to main_app.download_path(presenter),
                 target: :_blank,
                 data: { turbolinks: false },

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,6 +37,8 @@ module ScholarSphere
     config.upload_limit = ENV.fetch('upload_limit', 10.gigabyte.to_s)
     config.admin_group = ENV.fetch('admin_group', 'umg/up.ss.admin')
     config.network_ingest_directory = Pathname.new(ENV.fetch('network_ingest_directory', 'tmp/ingest-development'))
+    config.zipfile_size_threshold = ENV.fetch('zipfile_size_threshold', 500_000_000).to_i
+    config.public_zipfile_directory = Pathname.new(ENV.fetch('public_zipfile_directory', 'public/zip-development'))
 
     # DOI Handle used with either EZID or DateCite EZ API
     config.doi_handle = ENV.fetch('doi_handle', 'doi:10.33532')

--- a/config/sample/application.yml
+++ b/config/sample/application.yml
@@ -26,6 +26,8 @@ development:
   REPOSITORY_EXTERNAL_FILES: 'true'
   timing_enabled: 'false'
   network_ingest_directory: 'tmp/ingest-development'
+  zipfile_size_threshold: 500_000_000
+  public_zipfile_directory: 'public/zip-development'
 test:
   ffmpeg_path: "ffmpeg-test"
   service_instance: "example-test"
@@ -44,6 +46,8 @@ test:
   REPOSITORY_EXTERNAL_FILES: 'true'
   timing_enabled: 'false'
   network_ingest_directory: 'tmp/ingest-test'
+  zipfile_size_threshold: 500_000_000
+  public_zipfile_directory: 'public/zip-test'
 production:
   TMPDIR: "/tmp"
   ffmpeg_path: "ffmpeg-test"
@@ -67,3 +71,5 @@ production:
   REPOSITORY_EXTERNAL_FILES: 'true'
   timing_enabled: 'false'
   network_ingest_directory: 'tmp/ingest-development'
+  zipfile_size_threshold: 500_000_000
+  public_zipfile_directory: 'public/zip-development'

--- a/config/travis/application_test.yml
+++ b/config/travis/application_test.yml
@@ -5,6 +5,7 @@
 # Scholarsphere::Config::REQUIREMENTS otherwise, the cap deploy will fail.
 #
 development:
+  TMPDIR: "/tmp"
   ffmpeg_path: "ffmpeg"
   service_instance: "localhost"
   virtual_host: "http://localhost:3000/"
@@ -26,7 +27,10 @@ development:
   timing_enabled: 'false'
   admin_group: 'umg/admin'
   network_ingest_directory: 'tmp/ingest-test'
+  zipfile_size_threshold: 500_000_000
+  public_zipfile_directory: 'public/zip-test'
 test:
+  TMPDIR: "/tmp"
   ffmpeg_path: "ffmpeg-test"
   service_instance: "example-test"
   virtual_host: "http://test.com/"
@@ -44,6 +48,8 @@ test:
   timing_enabled: 'false'
   admin_group: 'umg/admin'
   network_ingest_directory: 'tmp/ingest-test'
+  zipfile_size_threshold: 500_000_000
+  public_zipfile_directory: 'public/zip-test'
 production:
   TMPDIR: "/tmp"
   ffmpeg_path: "ffmpeg-test"
@@ -67,3 +73,5 @@ production:
   timing_enabled: 'false'
   admin_group: 'umg/admin'
   network_ingest_directory: 'tmp/ingest-test'
+  zipfile_size_threshold: 500_000_000
+  public_zipfile_directory: 'public/zip-test'

--- a/lib/scholarsphere/config.rb
+++ b/lib/scholarsphere/config.rb
@@ -27,7 +27,8 @@ class Scholarsphere::Config
         'RECAPTCHA_SITE_KEY',
         'RECAPTCHA_SECRET_KEY',
         'admin_group',
-        'network_ingest_directory'
+        'network_ingest_directory',
+        'public_zipfile_directory'
       ]
     }.freeze
 

--- a/spec/config/application_spec.rb
+++ b/spec/config/application_spec.rb
@@ -52,4 +52,16 @@ describe 'Application configuration' do
 
     it { is_expected.to eq(Pathname.new('tmp/ingest-test')) }
   end
+
+  describe 'Zip file size threshold' do
+    subject { config.zipfile_size_threshold }
+
+    it { is_expected.to eq(500_000_000) }
+  end
+
+  describe 'Public zip file directory' do
+    subject { config.public_zipfile_directory }
+
+    it { is_expected.to eq(Pathname.new('public/zip-test')) }
+  end
 end

--- a/spec/controllers/downloads_controller_spec.rb
+++ b/spec/controllers/downloads_controller_spec.rb
@@ -86,7 +86,7 @@ describe DownloadsController do
   end
 
   describe '#show' do
-    subject { controller.send(:show) }
+    subject(:path) { controller.send(:show) }
 
     let(:response) { instance_double ActionDispatch::Response, headers: {} }
 
@@ -109,8 +109,8 @@ describe DownloadsController do
       end
     end
 
-    context 'with a GenericWork' do
-      let(:my_work) { create :public_work, depositor: user.login }
+    context 'with a non-public work' do
+      let(:my_work) { create :registered_work, depositor: user.login }
       let(:response) { instance_double ActionDispatch::Response, headers: {} }
 
       before do
@@ -133,8 +133,25 @@ describe DownloadsController do
       end
     end
 
-    context 'with a Collection' do
-      let(:my_collection) { create :public_collection, depositor: user.login }
+    context 'with a public work' do
+      let(:my_work) { create :public_work, depositor: user.login }
+      let(:zip_file) { ScholarSphere::Application.config.public_zipfile_directory.join("#{my_work.id}.zip") }
+
+      before do
+        FileUtils.touch(zip_file)
+        controller.params[:id] = my_work.id
+      end
+
+      it 'downloads the public zip' do
+        expect(WorkZipService).not_to receive(:new)
+        expect(controller).to receive(:send_file)
+          .with(zip_file.to_s, type: 'application/zip', disposition: 'inline')
+        subject
+      end
+    end
+
+    context 'with a non-public collection' do
+      let(:my_collection) { create :registered_collection, depositor: user.login }
       let(:response) { instance_double ActionDispatch::Response, headers: {} }
 
       before do
@@ -157,7 +174,12 @@ describe DownloadsController do
       let(:response) { instance_double ActionDispatch::Response, headers: {} }
 
       before do
-        class BogusClass < ActiveFedora::Base; end
+        class BogusClass < ActiveFedora::Base
+          def public?
+            false
+          end
+        end
+
         controller.params[:id] = unsupported_class.id
         allow(controller).to receive(:response).and_return(response)
       end

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -25,6 +25,10 @@ FactoryGirl.define do
       description { 'My incredibly detailed description of the collection' }
     end
 
+    factory :registered_collection do
+      visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED }
+    end
+
     trait :with_complete_metadata do
       resource_type { ['Dissertation aaa'] }
       publisher { ['publisher bbb'] }

--- a/spec/jobs/zip_job_spec.rb
+++ b/spec/jobs/zip_job_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ZipJob do
+  let(:job) { described_class }
+  let(:mock_work_service) { instance_double(WorkZipService) }
+  let(:mock_collection_service) { instance_double(CollectionZipService) }
+  let(:path) { ScholarSphere::Application.config.public_zipfile_directory }
+  let(:file) { "#{document.id}.zip" }
+
+  context 'with a work' do
+    let(:document) { create(:public_work) }
+
+    it 'calls WorkZipService' do
+      expect(WorkZipService).to receive(:new)
+        .with(document, kind_of(Ability), path, "#{document.id}.zip")
+        .and_return(mock_work_service)
+      expect(mock_work_service).to receive(:call)
+      job.perform_now(document.id)
+    end
+  end
+
+  context 'with a collection' do
+    let(:document) { create(:public_collection) }
+
+    it 'calls CollectionZipService' do
+      expect(CollectionZipService).to receive(:new)
+        .with(document, kind_of(Ability), path, file)
+        .and_return(mock_collection_service)
+      expect(mock_collection_service).to receive(:call)
+      job.perform_now(document.id)
+    end
+  end
+
+  context 'when the zip file is not stale' do
+    let(:document) { create(:public_work) }
+    let(:mock_file) { instance_double(ZipFile) }
+
+    before do
+      allow(ZipFile).to receive(:new).and_return(mock_file)
+      allow(mock_file).to receive(:stale?).and_return(false)
+    end
+
+    it 'does not call the WorkZipService' do
+      expect(WorkZipService).not_to receive(:new)
+      job.perform_now(document.id)
+    end
+  end
+
+  context 'when specifying an unknown id' do
+    specify do
+      expect { job.perform_now('idontexist') }.to raise_error(ActiveFedora::ObjectNotFoundError)
+    end
+  end
+
+  context 'with a non-exportable object' do
+    let(:document) { create(:agent) }
+
+    specify do
+      expect { job.perform_now(document.id) }.to raise_error(ZipJob::Error)
+    end
+  end
+end

--- a/spec/models/zip_file_spec.rb
+++ b/spec/models/zip_file_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ZipFile do
+  subject { described_class.new(file) }
+
+  let(:id) { SecureRandom.uuid }
+  let(:file) { ScholarSphere::Application.config.public_zipfile_directory.join("#{id}.zip") }
+
+  describe '#delete' do
+    before { FileUtils.touch(file) }
+
+    it 'removes the file' do
+      expect(file).to be_exist
+      described_class.new(file).delete
+      expect(file).not_to be_exist
+    end
+  end
+
+  describe '#exist?' do
+    before { FileUtils.touch(file) }
+
+    it { is_expected.to be_exist }
+  end
+
+  describe '#parent' do
+    before { FileUtils.touch(file) }
+
+    its(:parent) { is_expected.to eq(ScholarSphere::Application.config.public_zipfile_directory) }
+  end
+
+  describe '#basename' do
+    before { FileUtils.touch(file) }
+
+    its(:basename) { is_expected.to eq(Pathname.new("#{id}.zip")) }
+  end
+
+  describe '#exceeds_threshold?' do
+    context "when the resource's size still exceeds the threshold" do
+      before do
+        index_document(build(:public_work, id: id).to_solr.merge!(bytes_lts: 600_000_000))
+      end
+
+      it { is_expected.to be_exceeds_threshold }
+    end
+
+    context "when the resource's size no longer exceeds the threshold" do
+      before do
+        index_document(build(:public_work, id: id).to_solr.merge!(bytes_lts: 600_000))
+      end
+
+      it { is_expected.not_to be_exceeds_threshold }
+    end
+
+    context 'when the resource does not exist' do
+      it { is_expected.not_to be_exceeds_threshold }
+    end
+  end
+
+  describe '#stale?' do
+    context 'when the resource is newer than the file' do
+      before do
+        FileUtils.touch(file, mtime: (DateTime.now - 2.days).to_i)
+        index_document(build(:public_work, id: id).to_solr)
+      end
+
+      it { is_expected.to be_stale }
+    end
+
+    context 'when the resource is older than the file' do
+      before do
+        FileUtils.touch(file, mtime: (DateTime.now + 2.days).to_i)
+        index_document(build(:public_work, id: id).to_solr)
+      end
+
+      it { is_expected.not_to be_stale }
+    end
+
+    context 'when the resource does not exist' do
+      it { is_expected.to be_stale }
+    end
+  end
+end

--- a/spec/presenters/collection_presenter_spec.rb
+++ b/spec/presenters/collection_presenter_spec.rb
@@ -21,4 +21,50 @@ describe CollectionPresenter do
 
     its(:size) { is_expected.to eq('40 Bytes') }
   end
+
+  describe '#zip_available?' do
+    subject(:presenter) { described_class.new(doc, nil) }
+
+    let(:collection) { build(:public_collection) }
+
+    let(:doc) do
+      SolrDocument.new(collection.to_solr.merge!(
+                         bytes_lts: bytes,
+                         member_ids_ssim: member_ids,
+                         id: '1234'
+                       ))
+    end
+
+    context 'when there are no member docs present' do
+      let(:bytes) { 0 }
+      let(:member_ids) { [] }
+
+      it { is_expected.not_to be_zip_available }
+    end
+
+    context 'when the collection is smaller than the zip file size threshold' do
+      let(:bytes) { 10 }
+      let(:member_ids) { ['1', '2'] }
+
+      it { is_expected.to be_zip_available }
+    end
+
+    context 'when the collection is larger than the zip file size threshold and the file is present' do
+      let(:bytes) { ScholarSphere::Application.config.zipfile_size_threshold + 100 }
+      let(:member_ids) { ['1', '2'] }
+
+      before { FileUtils.touch(ScholarSphere::Application.config.public_zipfile_directory.join("#{doc.id}.zip")) }
+
+      after { FileUtils.rm_f(ScholarSphere::Application.config.public_zipfile_directory.join("#{doc.id}.zip")) }
+
+      it { is_expected.to be_zip_available }
+    end
+
+    context 'when the collection is larger than the zip file size threshold and the file is not present' do
+      let(:bytes) { ScholarSphere::Application.config.zipfile_size_threshold + 100 }
+      let(:member_ids) { ['1', '2'] }
+
+      it { is_expected.not_to be_zip_available }
+    end
+  end
 end

--- a/spec/presenters/work_show_presenter_spec.rb
+++ b/spec/presenters/work_show_presenter_spec.rb
@@ -165,4 +165,38 @@ describe WorkShowPresenter do
   end
 
   its(:event_class) { is_expected.to eq(GenericWork) }
+
+  describe '#zip_available?' do
+    before { allow(presenter).to receive(:bytes).and_return(bytes) }
+
+    context 'when the files are still being uploaded' do
+      let(:bytes) { 0 }
+
+      before { allow(presenter).to receive(:uploading?).and_return(true) }
+
+      it { is_expected.not_to be_zip_available }
+    end
+
+    context 'when the work is smaller than the zip file size threshold' do
+      let(:bytes) { 10 }
+
+      it { is_expected.to be_zip_available }
+    end
+
+    context 'when the work is larger than the zip file size threshold and the file is present' do
+      let(:bytes) { ScholarSphere::Application.config.zipfile_size_threshold + 100 }
+
+      before { FileUtils.touch(ScholarSphere::Application.config.public_zipfile_directory.join("#{work.id}.zip")) }
+
+      after { FileUtils.rm_f(ScholarSphere::Application.config.public_zipfile_directory.join("#{work.id}.zip")) }
+
+      it { is_expected.to be_zip_available }
+    end
+
+    context 'when the work is larger than the zip file size threshold and the file is not present' do
+      let(:bytes) { ScholarSphere::Application.config.zipfile_size_threshold + 100 }
+
+      it { is_expected.not_to be_zip_available }
+    end
+  end
 end

--- a/spec/services/work_zip_service_spec.rb
+++ b/spec/services/work_zip_service_spec.rb
@@ -27,12 +27,22 @@ describe WorkZipService do
       end
     end
 
-    context 'An different location' do
+    context 'A different location' do
       let(:service) { described_class.new(work, user, '/tmp') }
       let(:work) { build :work, title: ['My Work Is empty'], depositor: user.login }
 
       it 'creates a zip' do
         expect(subject).to eq('/tmp/my_work_is_empty.zip')
+        expect(zip_file.entries.count).to eq(0)
+      end
+    end
+
+    context 'A different zip file title' do
+      let(:service) { described_class.new(work, user, '/tmp', "#{work.id}.zip") }
+      let(:work) { build :work, title: ['Custom zip name'], depositor: user.login, id: SecureRandom.uuid }
+
+      it 'creates a zip' do
+        expect(subject).to eq("/tmp/#{work.id}.zip")
         expect(zip_file.entries.count).to eq(0)
       end
     end
@@ -56,6 +66,26 @@ describe WorkZipService do
         expect(subject).to eq('tmp/my_work_is_great.zip')
         expect(zip_file.entries.map(&:name)).to contain_exactly(mp3_file.title.first, my_file.title.first)
         expect(zip_file.entries.map(&:size)).to contain_exactly(mp3_file.original_file.size, my_file.original_file.size)
+      end
+    end
+
+    context 'A newer zip file already exists' do
+      let(:public_zip_file) { ScholarSphere::Application.config.public_zipfile_directory.join("#{work.id}.zip") }
+      let(:work) { create :work, title: ['Pre-existing zip file'], depositor: user.login, id: SecureRandom.uuid }
+
+      let(:service) do
+        described_class.new(
+          work,
+          user,
+          ScholarSphere::Application.config.public_zipfile_directory,
+          "#{work.id}.zip"
+        )
+      end
+
+      before { FileUtils.touch(public_zip_file, mtime: (DateTime.now + 2.days).to_i) }
+
+      it 'does not re-create the zip file' do
+        expect(Zip::File).not_to receive(:open)
       end
     end
   end

--- a/spec/support/cleanup.rb
+++ b/spec/support/cleanup.rb
@@ -8,6 +8,8 @@ class Cleanup
     FileUtils.mkdir_p(ENV['REPOSITORY_FILESTORE'])
     FileUtils.rm_rf(ScholarSphere::Application.config.network_ingest_directory)
     FileUtils.mkdir_p(ScholarSphere::Application.config.network_ingest_directory)
+    FileUtils.rm_rf(ScholarSphere::Application.config.public_zipfile_directory)
+    FileUtils.mkdir_p(ScholarSphere::Application.config.public_zipfile_directory)
   end
 end
 

--- a/spec/views/collections/_show_actions.html.erb_spec.rb
+++ b/spec/views/collections/_show_actions.html.erb_spec.rb
@@ -8,20 +8,22 @@ describe 'collections/_show_actions.html.erb' do
   let(:collection) { build(:collection, id: '1') }
   let(:presenter) { CollectionPresenter.new(SolrDocument.new(collection.to_solr), Ability.new(nil)) }
 
-  before do
-    render 'collections/show_actions.html.erb', presenter: presenter, member_docs: member_docs
-  end
-
-  context 'when there are no members of the collection available to display' do
-    let(:member_docs) { [] }
+  context 'when a zip file is not available' do
+    before do
+      allow(presenter).to receive(:zip_available?).and_return(false)
+      render 'collections/show_actions.html.erb', presenter: presenter
+    end
 
     it 'does not show the zip download link' do
       expect(rendered).not_to include('Download Collection as Zip')
     end
   end
 
-  context 'with collection members present' do
-    let(:member_docs) { ['doc'] }
+  context 'when a zip file is available' do
+    before do
+      allow(presenter).to receive(:zip_available?).and_return(true)
+      render 'collections/show_actions.html.erb', presenter: presenter
+    end
 
     it 'shows the zip download link' do
       expect(rendered).to include('Download Collection as Zip')

--- a/tasks/dev.rake
+++ b/tasks/dev.rake
@@ -62,6 +62,8 @@ namespace :dev do
     FileUtils.rm_rf(ENV['REPOSITORY_FILESTORE'])
     FileUtils.mkdir_p(ENV['REPOSITORY_FILESTORE'])
     FileUtils.mkdir_p(ScholarSphere::Application.config.network_ingest_directory)
+    FileUtils.rm_rf(ScholarSphere::Application.config.public_zipfile_directory)
+    FileUtils.mkdir_p(ScholarSphere::Application.config.public_zipfile_directory)
   end
 
   def cleanout_redis


### PR DESCRIPTION
## Description

Defines a rake task that creates zips of public collections and works that exceed a given size. second rake task will delete zip files that no longer fit the criteria for the export.

The option to download works or collections in the UI will be presented if the resource is below the certain threshold size, or if the pre-made zip is available. If the resource exceeds the specified size and a zip file has not been created yet, then no zip download option will be present.

## Changes

* adds a new ZipJob and ZipFile classes
* modifies UI to display zip download links only if valid zip files exist or can be created
* if an up-to-date zip file exists, the service will not recreate the file