### PR TITLE
Adding configuration for contact email

### DIFF
--- a/app/models/user_mailer.rb
+++ b/app/models/user_mailer.rb
@@ -5,6 +5,8 @@ class UserMailer < ActionMailer::Base
   default from: Rails.application.config.action_mailer.default_options.fetch(:from)
 
   def acknowledgment_email(params)
+    return if params[:sufia_contact_form][:email].split('@').last == 'psu.edu'
+
     mail(to: params[:sufia_contact_form][:email],
          subject: "ScholarSphere Contact Form - #{params[:sufia_contact_form][:subject]}")
   end
@@ -13,7 +15,6 @@ class UserMailer < ActionMailer::Base
     @presenter = StatsPresenter.new(start_datetime, end_datetime)
     attachments[stats_report_name] = stats_report
     mail(to: ScholarSphere::Application.config.stats_email,
-         from: ScholarSphere::Application.config.stats_from_email,
          subject: ::I18n.t('statistic.report.subject'))
   end
 
@@ -22,7 +23,6 @@ class UserMailer < ActionMailer::Base
     return if @presenter.file_downloads.zero?
 
     mail(to: user.email,
-         from: ScholarSphere::Application.config.no_reply_email,
          subject: ::I18n.t('statistic.user_stats.subject'))
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,7 +32,8 @@ module ScholarSphere
     config.virtual_host = ENV.fetch('virtual_host', "https://#{Socket.gethostname}")
     config.google_analytics_id = ENV.fetch('google_analytics_id', nil)
     config.stats_email = ENV.fetch('stats_email', 'ScholarSphere Stats <umg-up.its.sas.scholarsphere-email@groups.ucs.psu.edu>')
-    config.no_reply_email = ENV.fetch('no_reply_email', 'no_reply@scholarsphere.psu.edu')
+    config.contact_email = ENV.fetch('contact_email', 'ssphere-support@psu.edu')
+    config.subject_prefix = ENV.fetch('subject_prefix', 'ScholarSphere Contact Form - ')
     config.backup_directory = Rails.root.join(ENV.fetch('backup_directory', 'backups'))
     config.upload_limit = ENV.fetch('upload_limit', 10.gigabyte.to_s)
     config.admin_group = ENV.fetch('admin_group', 'umg/up.ss.admin')
@@ -93,8 +94,6 @@ module ScholarSphere
     # Configure sensitive parameters which will be filtered from the log file.
     config.filter_parameters += [:password]
 
-    config.stats_from_email = 'umg-up.its.sas.scholarsphere-email@groups.ucs.psu.edu'
-
     config.max_upload_file_size = 20 * 1024 * 1024 * 1024 # 20GB
 
     # html maintenance response
@@ -107,7 +106,7 @@ module ScholarSphere
     # allow errors to be raised in callbacks
     ActiveSupport.halt_callback_chains_on_return_false = false
 
-    config.action_mailer.default_options = { from: 'umg-up.its.sas.scholarsphere-email@groups.ucs.psu.edu' }
+    config.action_mailer.default_options = { from: ENV.fetch('no_reply_email', 'no_reply@scholarsphere.psu.edu') }
     config.action_mailer.default_url_options = { host: config.service_instance, protocol: 'https' }
 
     # Inject new behaviors into existing classes without having to override the entire class itself.

--- a/config/initializers/sufia.rb
+++ b/config/initializers/sufia.rb
@@ -5,8 +5,8 @@ Sufia.config do |config|
 
   config.register_curation_concern :generic_work
 
-  config.contact_email = 'scholarsphere@servicedesk.css.psu.edu, umg-up.its.scholarsphere-support@groups.ucs.psu.edu'
-  config.subject_prefix = 'ScholarSphere Contact Form - '
+  config.contact_email = Rails.application.config.contact_email
+  config.subject_prefix = Rails.application.config.subject_prefix
 
   config.fits_path = 'fits.sh'
   config.max_days_between_audits = 7

--- a/spec/config/application_spec.rb
+++ b/spec/config/application_spec.rb
@@ -29,6 +29,18 @@ describe 'Application configuration' do
     it { is_expected.to eq('Test email') }
   end
 
+  describe 'contact_email' do
+    subject { config.contact_email }
+
+    it { is_expected.to eq('ssphere-support@psu.edu') }
+  end
+
+  describe 'subject_prefix' do
+    subject { config.subject_prefix }
+
+    it { is_expected.to eq('ScholarSphere Contact Form - ') }
+  end
+
   describe 'derivatives path' do
     subject { config.derivatives_path }
 

--- a/spec/features/contact_form_spec.rb
+++ b/spec/features/contact_form_spec.rb
@@ -3,48 +3,66 @@
 require 'feature_spec_helper'
 
 describe 'Contact form:', type: :feature do
-  let(:email)         { 'archivist1@example.com' }
   let(:email_subject) { 'My Subject is Cool' }
   let(:user)          { create(:user, email: email) }
   let(:sent_messages) { ActionMailer::Base.deliveries }
-  let(:admin_message) {
+
+  let(:contact_email) {
     sent_messages.find do |message|
-      message.to == ['scholarsphere@servicedesk.css.psu.edu', 'umg-up.its.scholarsphere-support@groups.ucs.psu.edu']
+      message.to == [Rails.application.config.contact_email]
     end
   }
-  let(:thank_you_message) {
+
+  let(:user_email) {
     sent_messages.find do |message|
       message.to == [email]
     end
   }
-  let(:plaintext_message) {
-    admin_message.body.parts.find do |p|
-      p.content_type.match(/plain/)
-    end
-  }
-  let(:html_message) {
-    admin_message.body.parts.find do |p|
-      p.content_type.match(/html/)
-    end
-  }
 
-  before { sign_in(user) }
+  context 'when the user is outside of Penn State' do
+    let(:email) { 'archivist1@example.com' }
 
-  it 'sends emails to the service desk and confirmations to the user' do
-    visit '/'
-    click_link 'Contact'
-    expect(page).to have_content 'Contact Form'
-    expect(find_field('sufia_contact_form_name').value).to eq(user.name)
-    expect(find_field('sufia_contact_form_email').value).to eq(email)
-    fill_in 'sufia_contact_form_message', with: 'I am contacting you regarding ScholarSphere.'
-    fill_in 'sufia_contact_form_subject', with: email_subject
-    select 'Depositing content', from: 'sufia_contact_form_category'
-    expect(page).to have_content('ReCaptcha')
-    expect(page).to have_selector('div.g-recaptcha')
-    click_button 'Send'
-    expect(page).to have_content('Thank you for your message!')
-    expect(admin_message.subject).to eq("ScholarSphere Contact Form - #{email_subject}")
-    expect(thank_you_message.to).to contain_exactly(email)
-    expect(thank_you_message.subject).to eq("ScholarSphere Contact Form - #{email_subject}")
+    before { sign_in(user) }
+
+    it 'sends emails to the contact email and confirmations to the user' do
+      visit '/'
+      click_link 'Contact'
+      expect(page).to have_content 'Contact Form'
+      expect(find_field('sufia_contact_form_name').value).to eq(user.name)
+      expect(find_field('sufia_contact_form_email').value).to eq(email)
+      fill_in 'sufia_contact_form_message', with: 'I am contacting you regarding ScholarSphere.'
+      fill_in 'sufia_contact_form_subject', with: email_subject
+      select 'Depositing content', from: 'sufia_contact_form_category'
+      expect(page).to have_content('ReCaptcha')
+      expect(page).to have_selector('div.g-recaptcha')
+      click_button 'Send'
+      expect(page).to have_content('Thank you for your message!')
+      expect(contact_email.subject).to eq("ScholarSphere Contact Form - #{email_subject}")
+      expect(user_email.to).to contain_exactly(email)
+      expect(user_email.subject).to eq("ScholarSphere Contact Form - #{email_subject}")
+    end
+  end
+
+  context 'when the user is from Penn State' do
+    let(:email) { 'archivist1@psu.edu' }
+
+    before { sign_in(user) }
+
+    it 'sends email only to the contact email' do
+      visit '/'
+      click_link 'Contact'
+      expect(page).to have_content 'Contact Form'
+      expect(find_field('sufia_contact_form_name').value).to eq(user.name)
+      expect(find_field('sufia_contact_form_email').value).to eq(email)
+      fill_in 'sufia_contact_form_message', with: 'I am contacting you regarding ScholarSphere.'
+      fill_in 'sufia_contact_form_subject', with: email_subject
+      select 'Depositing content', from: 'sufia_contact_form_category'
+      expect(page).to have_content('ReCaptcha')
+      expect(page).to have_selector('div.g-recaptcha')
+      click_button 'Send'
+      expect(page).to have_content('Thank you for your message!')
+      expect(contact_email.subject).to eq("ScholarSphere Contact Form - #{email_subject}")
+      expect(user_email).to be_nil
+    end
   end
 end


### PR DESCRIPTION
## Description

Integrates our contact form with ServiceNow so that incidents are created when requests are made through the form.

Fixes #1572 

## Changes

* adds a contact email configuration option so that we can specify which
  email to send requests for help.
* updates the contact form to only sent confirmation emails if the user
  is outside Penn State.
* sets the "no reply" to the be the default from email for all mailers
