### PR TITLE
Send stats emails only on production jobs servers

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -36,7 +36,7 @@ set :rails_env, 'production'
 
 # Settings for whenever gem that updates the crontab file on the server
 # See schedule.rb for details
-set :whenever_roles, [:app, :job]
+set :whenever_roles, [:app, :job, :prod_job]
 
 set :log_level, :debug
 set :pty, true

--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -19,7 +19,7 @@ ENV['NEW_RELIC_APP_NAME'] = 'ss-prod-ruby'
 # used to set extended properties on the server.
 server 'ssweb1prod-new.vmhost.psu.edu:1855', user: 'deploy', roles: %w(web app db), primary: true
 server 'ssweb2prod-new.vmhost.psu.edu:1855', user: 'deploy', roles: %w(web app db)
-server 'scholarsphere-jobs-prod.libraries.psu.edu:1855', user: 'deploy', roles: %w(app job)
+server 'scholarsphere-jobs-prod.libraries.psu.edu:1855', user: 'deploy', roles: %w(app job prod_job)
 # server 'example.com', user: 'deploy', roles: %w{web app}, my_property: :my_value
 
 # Custom SSH Options

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -28,7 +28,7 @@ every :day, at: '7:00am', roles: [:job] do
 end
 
 # Stats email sent to users on the 2nd of every month at 9 am
-every '0 9 2 * *' do
+every '0 9 2 * *', roles: [:prod_job] do
   rake 'scholarsphere:stats:notify'
 end
 


### PR DESCRIPTION
Adds an additional environment key for "service name" such as qa, production, stage, etc. which we can use to set the cron job for emailing monthly stats emails. This way, only the jobs server for the designated "production" service will send the emails.

Fixes #1614 