### PR TITLE
Add Hydra::Derivatives config option

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -61,6 +61,7 @@ set :linked_files, fetch(:linked_files, []).push(
   'config/initializers/arkivo_constraint.rb',
   'config/initializers/qa.rb',
   'config/initializers/sufia6.rb',
+  'config/initializers/hydra_derivatives_config.rb ',
   'config/newrelic.yml',
   'config/redis.yml',
   'config/secrets.yml',


### PR DESCRIPTION
Moves the initializer for configuring Hydra::Derivatives to a linked file so that we can change on the server to meet our needs. When ingesting large video files, the jobs will often timeout after 10 minutes, and we need them to be able to run longer.