### PR TITLE
Switching Travis build to Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ before_install:
   - gem update --system
   - gem install bundler
 language: ruby
-dist: trusty
+dist: xenial
 addons:
   chrome: stable
 cache:
@@ -10,11 +10,8 @@ cache:
   directories:
     - "dep_cache"
 bundler_args: --without development debug
-sudo: false
 rvm:
   - 2.4.6
-jdk:
-  - oraclejdk8
 env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
@@ -25,7 +22,8 @@ env:
     - secure: "G2snfK/GK8rk8emiy3a0wqe+rLJkM0abaPIktgjv0P3SDreQzeDNLyy5GsVG4LhM/QCur3qznlDl5c8/fXQpSrzZb9lsJmu/HX4yjiF+5FtAgPlAnfw0H6Dy1N14E4KhBktHS/EZzv7NLhyzn/ADFSiETHiDHWMQuQvWs8w8iJI="
     - secure: "jLLPH2btu/jQog37DK4TbU/x7wrE/bYpY14fhxuysHousEemJ2hAFl2uK86v3K4ZdpgPBMBznubvgKihXT5JOEm+PGfmi6kKTPZFCp0+M88F/42eruna9Zl15rl1TwgarGdSadCB8ZAq4iCGXVxiIgvQEq7X1rUlpOpj32jBPUk="
 services:
-  - redis-server
+  - redis
+  - mysql
 stages:
   - niftany
   - test
@@ -43,5 +41,3 @@ jobs:
       script: ./travis/coverage.sh
     - stage: niftany
       script: bundle exec niftany
-  after_failure:
-    - cat log/test.log

--- a/spec/services/network_ingest_service_spec.rb
+++ b/spec/services/network_ingest_service_spec.rb
@@ -13,7 +13,7 @@ describe NetworkIngestService do
       before do
         FileUtils.mkdir(path)
         FileUtils.cp(Pathname.new(fixture_path).join('readme.md'), path)
-        FileUtils.cp(Pathname.new(fixture_path).join('image.jp2'), path)
+        FileUtils.cp(Pathname.new(fixture_path).join('world.png'), path)
       end
 
       it 'ingests each file in the directory' do
@@ -23,7 +23,7 @@ describe NetworkIngestService do
         described_class.call(path)
         work.reload
         expect(work.file_sets.count).to eq(2)
-        expect(work.file_sets.map(&:title)).to include(['readme.md'], ['image.jp2'])
+        expect(work.file_sets.map(&:title)).to include(['readme.md'], ['world.png'])
         work.file_sets.each do |file_set|
           expect(file_set.edit_users).to eq(edit_users)
           expect(file_set.read_users).to eq(read_users)
@@ -37,7 +37,7 @@ describe NetworkIngestService do
       before do
         FileUtils.mkdir(path)
         FileUtils.cp(Pathname.new(fixture_path).join('readme.md'), path)
-        FileUtils.cp(Pathname.new(fixture_path).join('image.jp2'), path)
+        FileUtils.cp(Pathname.new(fixture_path).join('world.png'), path)
       end
 
       it 'raises an error' do

--- a/travis/test.sh
+++ b/travis/test.sh
@@ -2,6 +2,12 @@
 
 echo -e "\n\n\033[0;32mTravis test.sh script\033[0m"
 
+echo -e "\n\n\033[0;32mInfo\033[0m"
+echo "Google Chrome version:"
+google-chrome --version
+echo "Java version:"
+java -version
+
 echo -e "\n\n\033[1;33mMaking dependency cache directory\033[0m"
 mkdir -p dep_cache
 echo "Listing directory contents:"
@@ -48,8 +54,9 @@ cc-test-reporter before-build
 bundle exec rake scholarsphere:travis:$TEST_SUITE
 RSPEC_EXIT_CODE=$?
 
-echo -e "\n\n\033[1;33mUpload coverage results to AWS\033[0m"
+echo -e "\n\n\033[1;33mUpload coverage results and logs to AWS\033[0m"
 cc-test-reporter format-coverage --output coverage/codeclimate.$TRAVIS_BUILD_ID.$TEST_SUITE.json
 aws s3 sync coverage/ s3://psu.edu.scholarsphere-qa/coverage/$TRAVIS_BUILD_NUMBER
+aws s3 sync log/ s3://psu.edu.scholarsphere-qa/build-logs/$TRAVIS_BUILD_NUMBER
 
 exit $RSPEC_EXIT_CODE


### PR DESCRIPTION
The trusty build was using an outdated version of Chrome; however, the Xenial build doesn't have jp2 support outright. Instead of trying to get jp2 support installed with minimagick, we'll just use plain jpegs in our test.