### PR TITLE
Update rack to 2.2.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -585,7 +585,7 @@ GEM
       nokogiri (~> 1.6)
       rails (>= 4.2.0, < 6.0)
     raabro (1.1.6)
-    rack (2.1.2)
+    rack (2.2.3)
     rack-maintenance (2.1.0)
       rack (>= 1.0)
     rack-protection (2.0.5)


### PR DESCRIPTION
Addresses CVE-2020-8184