### PR TITLE
Mapping multiple rights to only one

### DIFF
--- a/lib/scholarsphere/migration.rb
+++ b/lib/scholarsphere/migration.rb
@@ -16,6 +16,7 @@ module Scholarsphere
     require 'job'
     require 'permissions'
     require 'resource'
+    require 'rights'
     require 'statistics'
     require 'work'
     require 'work_type_mapper'

--- a/lib/scholarsphere/migration/rights.rb
+++ b/lib/scholarsphere/migration/rights.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module Scholarsphere
+  module Migration
+    class Rights
+      def self.call(rights)
+        result = nil
+        [
+          [
+            ['http://creativecommons.org/licenses/by-nc-sa/3.0/us/', 'http://creativecommons.org/licenses/by-nc-nd/3.0/us/'],
+            'http://creativecommons.org/licenses/by-nc-sa/3.0/us/'
+          ],
+          [
+            ['http://creativecommons.org/licenses/by-nc-sa/3.0/us/', 'http://creativecommons.org/licenses/by/3.0/us/'],
+            'http://creativecommons.org/licenses/by/3.0/us/'
+          ],
+          [
+            ['http://creativecommons.org/licenses/by-nc/3.0/us/', 'http://creativecommons.org/licenses/by-nc-nd/3.0/us/'],
+            'http://creativecommons.org/licenses/by-nc/3.0/us/'
+          ],
+          [
+            ['http://creativecommons.org/licenses/by-nc/3.0/us/', 'http://creativecommons.org/licenses/by-sa/3.0/us/', 'http://creativecommons.org/licenses/by-nc-nd/3.0/us/'],
+            'https://creativecommons.org/licenses/by-nc/3.0/us/'
+          ],
+          [
+            ['http://creativecommons.org/licenses/by-nd/3.0/us/', 'http://creativecommons.org/licenses/by-nc-nd/3.0/us/'],
+            'http://creativecommons.org/licenses/by-nd/3.0/us/'
+          ],
+          [
+            ['http://creativecommons.org/licenses/by-sa/3.0/us/', 'http://creativecommons.org/licenses/by-nc-nd/3.0/us/'],
+            'http://creativecommons.org/licenses/by-sa/3.0/us/'
+          ],
+          [
+            ['http://creativecommons.org/licenses/by/3.0/us/', 'http://creativecommons.org/licenses/by-nc-nd/3.0/us/'],
+            'http://creativecommons.org/licenses/by/3.0/us/'
+          ],
+          [
+            ['http://creativecommons.org/publicdomain/mark/1.0/', 'http://creativecommons.org/licenses/by-nc-nd/3.0/us/'],
+            'http://creativecommons.org/publicdomain/mark/1.0/'
+          ],
+          [
+            ['http://creativecommons.org/publicdomain/zero/1.0/', 'http://creativecommons.org/licenses/by-nc-nd/3.0/us/'],
+            'http://creativecommons.org/publicdomain/zero/1.0/'
+          ],
+          [
+            ['http://www.europeana.eu/portal/rights/rr-r.html', 'http://creativecommons.org/licenses/by-nc-nd/3.0/us/'],
+            'http://creativecommons.org/licenses/by-nc-nd/3.0/us/'
+          ],
+          [
+            ['https://creativecommons.org/licenses/by/4.0/', 'http://www.europeana.eu/portal/rights/rr-r.html'],
+            'https://creativecommons.org/licenses/by/4.0/'
+          ]
+        ].each do |tuple|
+          if tuple.first.sort == rights.sort
+            result = tuple.second
+          end
+        end
+
+        return rights.first if result.nil?
+
+        result
+      end
+    end
+  end
+end

--- a/lib/scholarsphere/migration/work.rb
+++ b/lib/scholarsphere/migration/work.rb
@@ -24,7 +24,8 @@ module Scholarsphere
             published_date: work.date_created.join(', '),
             description: work.description.join(' '),
             identifier: identifier.other,
-            doi: identifier.doi
+            doi: identifier.doi,
+            rights: Rights.call(work_attributes[:rights])
           )
       end
 

--- a/spec/lib/scholarsphere/migration/rights_spec.rb
+++ b/spec/lib/scholarsphere/migration/rights_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Scholarsphere::Migration::Rights do
+  subject { described_class.call(rights) }
+
+  context 'with one value for rights' do
+    let(:rights) { ['value'] }
+
+    it { is_expected.to eq('value') }
+  end
+
+  context 'with different combinations of mutliple rights' do
+    [
+      [
+        ['http://creativecommons.org/licenses/by-nc-sa/3.0/us/', 'http://creativecommons.org/licenses/by-nc-nd/3.0/us/'],
+        'http://creativecommons.org/licenses/by-nc-sa/3.0/us/'
+      ],
+      [
+        ['http://creativecommons.org/licenses/by-nc-sa/3.0/us/', 'http://creativecommons.org/licenses/by/3.0/us/'],
+        'http://creativecommons.org/licenses/by/3.0/us/'
+      ],
+      [
+        ['http://creativecommons.org/licenses/by-nc/3.0/us/', 'http://creativecommons.org/licenses/by-nc-nd/3.0/us/'],
+        'http://creativecommons.org/licenses/by-nc/3.0/us/'
+      ],
+      [
+        ['http://creativecommons.org/licenses/by-nc/3.0/us/', 'http://creativecommons.org/licenses/by-sa/3.0/us/', 'http://creativecommons.org/licenses/by-nc-nd/3.0/us/'],
+        'https://creativecommons.org/licenses/by-nc/3.0/us/'
+      ],
+      [
+        ['http://creativecommons.org/licenses/by-nd/3.0/us/', 'http://creativecommons.org/licenses/by-nc-nd/3.0/us/'],
+        'http://creativecommons.org/licenses/by-nd/3.0/us/'
+      ],
+      [
+        ['http://creativecommons.org/licenses/by-sa/3.0/us/', 'http://creativecommons.org/licenses/by-nc-nd/3.0/us/'],
+        'http://creativecommons.org/licenses/by-sa/3.0/us/'
+      ],
+      [
+        ['http://creativecommons.org/licenses/by/3.0/us/', 'http://creativecommons.org/licenses/by-nc-nd/3.0/us/'],
+        'http://creativecommons.org/licenses/by/3.0/us/'
+      ],
+      [
+        ['http://creativecommons.org/publicdomain/mark/1.0/', 'http://creativecommons.org/licenses/by-nc-nd/3.0/us/'],
+        'http://creativecommons.org/publicdomain/mark/1.0/'
+      ],
+      [
+        ['http://creativecommons.org/publicdomain/zero/1.0/', 'http://creativecommons.org/licenses/by-nc-nd/3.0/us/'],
+        'http://creativecommons.org/publicdomain/zero/1.0/'
+      ],
+      [
+        ['http://www.europeana.eu/portal/rights/rr-r.html', 'http://creativecommons.org/licenses/by-nc-nd/3.0/us/'],
+        'http://creativecommons.org/licenses/by-nc-nd/3.0/us/'
+      ],
+      [
+        ['https://creativecommons.org/licenses/by/4.0/', 'http://www.europeana.eu/portal/rights/rr-r.html'],
+        'https://creativecommons.org/licenses/by/4.0/'
+      ]
+    ].each do |tuple|
+
+      it { expect(described_class.call(tuple.first)).to eq(tuple.second) }
+    end
+  end
+end

--- a/spec/lib/scholarsphere/migration/work_spec.rb
+++ b/spec/lib/scholarsphere/migration/work_spec.rb
@@ -102,6 +102,25 @@ RSpec.describe Scholarsphere::Migration::Work, type: :model do
 
       its(:metadata) { is_expected.to include(identifier: ['asdf'], doi: doi) }
     end
+
+    context 'with a single rights statement' do
+      let(:work) { build(:public_work, :with_complete_metadata) }
+
+      its(:metadata) { is_expected.to include(rights: work.rights.first) }
+    end
+
+    context 'with multiple rights statements' do
+      let(:rights) do
+        [
+          'http://creativecommons.org/licenses/by-nc-nd/3.0/us/',
+          'http://creativecommons.org/publicdomain/mark/1.0/'
+        ]
+      end
+
+      let(:work) { build(:public_work, rights: rights) }
+
+      its(:metadata) { is_expected.to include(rights: 'http://creativecommons.org/publicdomain/mark/1.0/') }
+    end
   end
 
   describe '#depositor' do


### PR DESCRIPTION
For works that have multiple rights selected, we map them to a single rights statement based on the types of rights that are selected.